### PR TITLE
Ban `unwrap()` in non-test code

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Dwarnings", "-Dfuture-incompatible", "-Dnonstandard-style", "-Drust-2018-idioms", "-Dunused", "-Dclippy::unwrap_used"]

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,4 @@ jobs:
           components: clippy
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
-      - run: >
-          cargo clippy --all-targets --all-features -- -D warnings -D future-incompatible
-          -D nonstandard-style -D rust-2018-idioms -D unused
+      - run: cargo clippy --all-targets --all-features


### PR DESCRIPTION
Unfortunately it isn't possible to define all of the `clippy` flags in that toml file, just config variables for configurable lints (https://github.com/starkware-libs/blockifier/pull/10/files)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/10)
<!-- Reviewable:end -->
