### PR TITLE
Add CachedState

### DIFF
--- a/blockifier/src/cached_state.rs
+++ b/blockifier/src/cached_state.rs
@@ -1,5 +1,23 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use starknet_api::{ClassHash, ContractAddress, Nonce, StarkFelt, StorageKey};
+
+/// Caches read and write requests.
+///
+/// Writer functionality is built-in, whereas Reader functionality is injected through
+/// initialization.
+pub struct CachedState<SR: StateReader> {
+    pub state_reader: SR,
+    // Invariant: the cache should remain private.
+    _cache: StateCache,
+}
+
+impl<SR: StateReader> CachedState<SR> {
+    pub fn new(state_reader: SR) -> Self {
+        Self { state_reader, _cache: StateCache::default() }
+    }
+}
 
 /// A read-only API for accessing StarkNet global state.
 pub trait StateReader {
@@ -23,4 +41,22 @@ pub trait StateReader {
     fn get_class_hash_at(&self, _contract_address: ContractAddress) -> Result<ClassHash> {
         unimplemented!();
     }
+}
+
+// Used internally by `StateCache`.
+type ContractStorageKey = (ContractAddress, StorageKey);
+
+/// Caches read and write requests.
+// Invariant: cannot delete keys from fields.
+#[derive(Default)]
+struct StateCache {
+    // Reader's cached information; initial values, read before any write operation (per cell).
+    _nonce_initial_values: HashMap<ContractAddress, Nonce>,
+    _class_hash_initial_values: HashMap<ContractAddress, ClassHash>,
+    _storage_initial_values: HashMap<ContractStorageKey, StarkFelt>,
+
+    // Writer's cached information.
+    _nonce_writes: HashMap<ContractAddress, Nonce>,
+    _class_hash_writes: HashMap<ContractAddress, ClassHash>,
+    _storage_writes: HashMap<ContractStorageKey, StarkFelt>,
 }


### PR DESCRIPTION
and a cache struct, to save accessing the reader and to record writes for generating a `StateDiff`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/23)
<!-- Reviewable:end -->
