### PR TITLE
Define StateReader API

### DIFF
--- a/blockifier/Cargo.toml
+++ b/blockifier/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.66"
-# This is how they instructed to use their package.
-cairo-rs =  { git = "https://github.com/lambdaclass/cairo-rs.git" }
+cairo-rs =  { git = "https://github.com/lambdaclass/cairo-rs.git" } # This is how they instructed to use their package.
 num-bigint = "0.4"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0.81" , features = ["arbitrary_precision"]}

--- a/blockifier/src/cached_state.rs
+++ b/blockifier/src/cached_state.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use starknet_api::{ClassHash, ContractAddress, Nonce, StarkFelt, StorageKey};
+
+/// A read-only API for accessing StarkNet global state.
+pub trait StateReader {
+    /// Returns the storage value under the given key in the given contract instance (represented by
+    /// its address).
+    fn get_storage_at(
+        &self,
+        _contract_address: ContractAddress,
+        _key: StorageKey,
+    ) -> Result<StarkFelt> {
+        unimplemented!();
+    }
+
+    /// Returns the nonce of the given contract instance.
+    fn get_nonce_at(&self, _contract_address: ContractAddress) -> Result<Nonce> {
+        unimplemented!();
+    }
+
+    /// Returns the class hash of the contract class at the given contract instance;
+    /// uninitialized class hash, if the address is unassigned.
+    fn get_class_hash_at(&self, _contract_address: ContractAddress) -> Result<ClassHash> {
+        unimplemented!();
+    }
+}

--- a/blockifier/src/lib.rs
+++ b/blockifier/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod cached_state;
 pub mod execution;


### PR DESCRIPTION
Currently using the same logic as in Python, except for `get_contract_class` and `_get_raw_contract_class`, which will soon be removed from it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/28)
<!-- Reviewable:end -->
