### PR TITLE
Reallow using `unwrap`s

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [build]
-rustflags = ["-Dwarnings", "-Dfuture-incompatible", "-Dnonstandard-style", "-Drust-2018-idioms", "-Dunused" , "-Dclippy::unwrap_used"]
+# Configuration for these lints should be placed in `.clippy.toml` at the crate root.
+rustflags = ["-Dwarnings", "-Dfuture-incompatible", "-Dnonstandard-style", "-Drust-2018-idioms", "-Dunused"]

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,3 @@
-allow-unwrap-in-tests = true
+# Place configuration for clippy lints here, when applicable (lints that can be configured
+# state so in clippy's documentation).
+# Note: only lint configurations can be placed here, lints must be placed in `.cargo/config.toml`.


### PR DESCRIPTION
We technically allow `unwrap`s, but this will be heavily scrutinized in PRs, and should not replace proper error handling or `except` when applicable (which is almost always).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/34)
<!-- Reviewable:end -->
