### PR TITLE
Add account contract without (some) syscalls.

### DIFF
--- a/blockifier/feature_contracts/account_without_some_syscalls.cairo
+++ b/blockifier/feature_contracts/account_without_some_syscalls.cairo
@@ -5,7 +5,6 @@
 from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import (
-    call_contract,
     deploy,
     get_caller_address,
     get_contract_address,

--- a/blockifier/feature_contracts/compiled/account_without_some_syscalls_compiled.json
+++ b/blockifier/feature_contracts/compiled/account_without_some_syscalls_compiled.json
@@ -121,27 +121,27 @@
         "CONSTRUCTOR": [],
         "EXTERNAL": [
             {
-                "offset": "0x7e",
+                "offset": "0x72",
                 "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
             },
             {
-                "offset": "0x5e",
+                "offset": "0x52",
                 "selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775"
             },
             {
-                "offset": "0xa8",
+                "offset": "0x9c",
                 "selector": "0x2730079d734ee55315f4f141eaed376bddd8c2133523d223a344c5604e0f7f8"
             },
             {
-                "offset": "0x3d",
+                "offset": "0x31",
                 "selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3"
             },
             {
-                "offset": "0x2f",
+                "offset": "0x23",
                 "selector": "0x2de154d8a89be65c1724e962dc4c65637c05532a6c2825d0a7b7d774169dbba"
             },
             {
-                "offset": "0x4d",
+                "offset": "0x41",
                 "selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895"
             }
         ],
@@ -155,18 +155,6 @@
         ],
         "compiler_version": "0.10.2",
         "data": [
-            "0x480680017fff8000",
-            "0x43616c6c436f6e7472616374",
-            "0x400280007ff97fff",
-            "0x400380017ff97ffa",
-            "0x400380027ff97ffb",
-            "0x400380037ff97ffc",
-            "0x400380047ff97ffd",
-            "0x482680017ff98000",
-            "0x7",
-            "0x480280057ff98000",
-            "0x480280067ff98000",
-            "0x208b7fff7fff7ffe",
             "0x480680017fff8000",
             "0x4465706c6f79",
             "0x400280007ff87fff",
@@ -401,213 +389,6 @@
                 "0": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.call_contract"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 40,
-                        "end_line": 47,
-                        "input_file": {
-                            "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 18,
-                        "start_line": 47
-                    }
-                },
-                "2": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.call_contract"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 28,
-                        "end_line": 51,
-                        "input_file": {
-                            "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 46
-                    }
-                },
-                "3": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.call_contract"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 28,
-                        "end_line": 51,
-                        "input_file": {
-                            "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 46
-                    }
-                },
-                "4": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.call_contract"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 28,
-                        "end_line": 51,
-                        "input_file": {
-                            "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 46
-                    }
-                },
-                "5": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.call_contract"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 28,
-                        "end_line": 51,
-                        "input_file": {
-                            "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 46
-                    }
-                },
-                "6": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.call_contract"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 28,
-                        "end_line": 51,
-                        "input_file": {
-                            "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 46
-                    }
-                },
-                "7": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.call_contract"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [
-                        {
-                            "location": {
-                                "end_col": 88,
-                                "end_line": 52,
-                                "input_file": {
-                                    "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                                },
-                                "start_col": 5,
-                                "start_line": 52
-                            },
-                            "n_prefix_newlines": 0
-                        }
-                    ],
-                    "inst": {
-                        "end_col": 54,
-                        "end_line": 55,
-                        "input_file": {
-                            "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "parent_location": [
-                            {
-                                "end_col": 38,
-                                "end_line": 42,
-                                "input_file": {
-                                    "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                                },
-                                "parent_location": [
-                                    {
-                                        "end_col": 75,
-                                        "end_line": 56,
-                                        "input_file": {
-                                            "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                                        },
-                                        "start_col": 5,
-                                        "start_line": 56
-                                    },
-                                    "While trying to retrieve the implicit argument 'syscall_ptr' in:"
-                                ],
-                                "start_col": 20,
-                                "start_line": 42
-                            },
-                            "While expanding the reference 'syscall_ptr' in:"
-                        ],
-                        "start_col": 23,
-                        "start_line": 55
-                    }
-                },
-                "9": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.call_contract"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 47,
-                        "end_line": 56,
-                        "input_file": {
-                            "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 26,
-                        "start_line": 56
-                    }
-                },
-                "10": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.call_contract"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 73,
-                        "end_line": 56,
-                        "input_file": {
-                            "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 57,
-                        "start_line": 56
-                    }
-                },
-                "11": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.call_contract"
-                    ],
-                    "flow_tracking_data": null,
-                    "hints": [],
-                    "inst": {
-                        "end_col": 75,
-                        "end_line": 56,
-                        "input_file": {
-                            "filename": "/home/adi/.local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
-                        },
-                        "start_col": 5,
-                        "start_line": 56
-                    }
-                },
-                "12": {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.deploy"
                     ],
                     "flow_tracking_data": null,
@@ -622,7 +403,7 @@
                         "start_line": 163
                     }
                 },
-                "14": {
+                "2": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.deploy"
@@ -639,7 +420,7 @@
                         "start_line": 162
                     }
                 },
-                "15": {
+                "3": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.deploy"
@@ -656,7 +437,7 @@
                         "start_line": 162
                     }
                 },
-                "16": {
+                "4": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.deploy"
@@ -673,7 +454,7 @@
                         "start_line": 162
                     }
                 },
-                "17": {
+                "5": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.deploy"
@@ -690,7 +471,7 @@
                         "start_line": 162
                     }
                 },
-                "18": {
+                "6": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.deploy"
@@ -707,7 +488,7 @@
                         "start_line": 162
                     }
                 },
-                "19": {
+                "7": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.deploy"
@@ -724,7 +505,7 @@
                         "start_line": 162
                     }
                 },
-                "20": {
+                "8": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.deploy"
@@ -778,7 +559,7 @@
                         "start_line": 172
                     }
                 },
-                "22": {
+                "10": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.deploy"
@@ -795,7 +576,7 @@
                         "start_line": 174
                     }
                 },
-                "23": {
+                "11": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.deploy"
@@ -812,7 +593,7 @@
                         "start_line": 174
                     }
                 },
-                "24": {
+                "12": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.get_caller_address"
@@ -829,7 +610,7 @@
                         "start_line": 198
                     }
                 },
-                "26": {
+                "14": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.get_caller_address"
@@ -846,7 +627,7 @@
                         "start_line": 198
                     }
                 },
-                "27": {
+                "15": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.get_caller_address"
@@ -900,7 +681,7 @@
                         "start_line": 200
                     }
                 },
-                "29": {
+                "17": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.get_caller_address"
@@ -917,7 +698,7 @@
                         "start_line": 201
                     }
                 },
-                "30": {
+                "18": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.get_caller_address"
@@ -934,7 +715,7 @@
                         "start_line": 201
                     }
                 },
-                "31": {
+                "19": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.get_contract_address"
@@ -951,7 +732,7 @@
                         "start_line": 272
                     }
                 },
-                "33": {
+                "21": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.get_contract_address"
@@ -968,7 +749,7 @@
                         "start_line": 272
                     }
                 },
-                "34": {
+                "22": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.get_contract_address"
@@ -1022,7 +803,7 @@
                         "start_line": 274
                     }
                 },
-                "36": {
+                "24": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.get_contract_address"
@@ -1039,7 +820,7 @@
                         "start_line": 275
                     }
                 },
-                "37": {
+                "25": {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
                         "starkware.starknet.common.syscalls.get_contract_address"
@@ -1056,7 +837,7 @@
                         "start_line": 275
                     }
                 },
-                "38": {
+                "26": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1066,9 +847,9 @@
                     "hints": [],
                     "inst": {
                         "end_col": 41,
-                        "end_line": 15,
+                        "end_line": 14,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "parent_location": [
                             {
@@ -1080,12 +861,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 40,
-                                        "end_line": 16,
+                                        "end_line": 15,
                                         "input_file": {
-                                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                         },
                                         "start_col": 18,
-                                        "start_line": 16
+                                        "start_line": 15
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
@@ -1095,10 +876,10 @@
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 23,
-                        "start_line": 15
+                        "start_line": 14
                     }
                 },
-                "39": {
+                "27": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1108,15 +889,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 40,
-                        "end_line": 16,
+                        "end_line": 15,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 18,
-                        "start_line": 16
+                        "start_line": 15
                     }
                 },
-                "41": {
+                "29": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1133,9 +914,9 @@
                         "parent_location": [
                             {
                                 "end_col": 40,
-                                "end_line": 16,
+                                "end_line": 15,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -1147,12 +928,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 40,
-                                                "end_line": 17,
+                                                "end_line": 16,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 20,
-                                                "start_line": 17
+                                                "start_line": 16
                                             },
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
@@ -1162,7 +943,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 18,
-                                "start_line": 16
+                                "start_line": 15
                             },
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
@@ -1170,7 +951,7 @@
                         "start_line": 270
                     }
                 },
-                "42": {
+                "30": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1180,15 +961,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 40,
-                        "end_line": 17,
+                        "end_line": 16,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 20,
-                        "start_line": 17
+                        "start_line": 16
                     }
                 },
-                "44": {
+                "32": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1198,15 +979,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 26,
-                        "end_line": 18,
+                        "end_line": 17,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 18
+                        "start_line": 17
                     }
                 },
-                "45": {
+                "33": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1223,36 +1004,36 @@
                         "parent_location": [
                             {
                                 "end_col": 40,
-                                "end_line": 17,
+                                "end_line": 16,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 41,
-                                        "end_line": 15,
+                                        "end_line": 14,
                                         "input_file": {
-                                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 19,
+                                                "end_line": 18,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 5,
-                                                "start_line": 19
+                                                "start_line": 18
                                             },
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 23,
-                                        "start_line": 15
+                                        "start_line": 14
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 17
+                                "start_line": 16
                             },
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
@@ -1260,7 +1041,7 @@
                         "start_line": 196
                     }
                 },
-                "46": {
+                "34": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1270,15 +1051,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 15,
-                        "end_line": 19,
+                        "end_line": 18,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 19
+                        "start_line": 18
                     }
                 },
-                "47": {
+                "35": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1296,12 +1077,12 @@
                         "parent_location": [
                             {
                                 "end_col": 22,
-                                "end_line": 15,
+                                "end_line": 14,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 15
+                                "start_line": 14
                             },
                             "While handling calldata of"
                         ],
@@ -1309,7 +1090,7 @@
                         "start_line": 1
                     }
                 },
-                "48": {
+                "36": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1327,9 +1108,9 @@
                         "parent_location": [
                             {
                                 "end_col": 41,
-                                "end_line": 15,
+                                "end_line": 14,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -1341,12 +1122,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 22,
-                                                "end_line": 15,
+                                                "end_line": 14,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 15
+                                                "start_line": 14
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -1356,7 +1137,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 23,
-                                "start_line": 15
+                                "start_line": 14
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -1364,7 +1145,7 @@
                         "start_line": 1
                     }
                 },
-                "49": {
+                "37": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1375,15 +1156,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 22,
-                        "end_line": 15,
+                        "end_line": 14,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 6,
-                        "start_line": 15
+                        "start_line": 14
                     }
                 },
-                "51": {
+                "39": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1402,12 +1183,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 22,
-                                        "end_line": 15,
+                                        "end_line": 14,
                                         "input_file": {
-                                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                         },
                                         "start_col": 6,
-                                        "start_line": 15
+                                        "start_line": 14
                                     },
                                     "While constructing the external wrapper for:"
                                 ],
@@ -1426,12 +1207,12 @@
                         "parent_location": [
                             {
                                 "end_col": 22,
-                                "end_line": 15,
+                                "end_line": 14,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 15
+                                "start_line": 14
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -1439,7 +1220,7 @@
                         "start_line": 3
                     }
                 },
-                "53": {
+                "41": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1457,9 +1238,9 @@
                         "parent_location": [
                             {
                                 "end_col": 22,
-                                "end_line": 15,
+                                "end_line": 14,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -1471,12 +1252,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 22,
-                                                "end_line": 15,
+                                                "end_line": 14,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 15
+                                                "start_line": 14
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -1486,7 +1267,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 15
+                                "start_line": 14
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -1494,7 +1275,7 @@
                         "start_line": 1
                     }
                 },
-                "54": {
+                "42": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1512,9 +1293,9 @@
                         "parent_location": [
                             {
                                 "end_col": 22,
-                                "end_line": 15,
+                                "end_line": 14,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -1526,12 +1307,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 22,
-                                                "end_line": 15,
+                                                "end_line": 14,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 15
+                                                "start_line": 14
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -1541,7 +1322,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 15
+                                "start_line": 14
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -1549,7 +1330,7 @@
                         "start_line": 1
                     }
                 },
-                "55": {
+                "43": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1567,9 +1348,9 @@
                         "parent_location": [
                             {
                                 "end_col": 22,
-                                "end_line": 15,
+                                "end_line": 14,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -1581,12 +1362,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 22,
-                                                "end_line": 15,
+                                                "end_line": 14,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 15
+                                                "start_line": 14
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -1596,7 +1377,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 15
+                                "start_line": 14
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -1604,7 +1385,7 @@
                         "start_line": 1
                     }
                 },
-                "56": {
+                "44": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1622,9 +1403,9 @@
                         "parent_location": [
                             {
                                 "end_col": 22,
-                                "end_line": 15,
+                                "end_line": 14,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -1636,12 +1417,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 22,
-                                                "end_line": 15,
+                                                "end_line": 14,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 15
+                                                "start_line": 14
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -1651,7 +1432,7 @@
                                     "While expanding the reference 'retdata_size' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 15
+                                "start_line": 14
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -1659,7 +1440,7 @@
                         "start_line": 4
                     }
                 },
-                "58": {
+                "46": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1677,9 +1458,9 @@
                         "parent_location": [
                             {
                                 "end_col": 22,
-                                "end_line": 15,
+                                "end_line": 14,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -1691,12 +1472,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 22,
-                                                "end_line": 15,
+                                                "end_line": 14,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 15
+                                                "start_line": 14
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -1706,7 +1487,7 @@
                                     "While expanding the reference 'retdata' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 15
+                                "start_line": 14
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -1714,7 +1495,7 @@
                         "start_line": 3
                     }
                 },
-                "59": {
+                "47": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1732,12 +1513,12 @@
                         "parent_location": [
                             {
                                 "end_col": 22,
-                                "end_line": 15,
+                                "end_line": 14,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 15
+                                "start_line": 14
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -1745,7 +1526,7 @@
                         "start_line": 1
                     }
                 },
-                "60": {
+                "48": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1755,15 +1536,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 15,
-                        "end_line": 24,
+                        "end_line": 23,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 24
+                        "start_line": 23
                     }
                 },
-                "61": {
+                "49": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1781,9 +1562,9 @@
                         "parent_location": [
                             {
                                 "end_col": 43,
-                                "end_line": 23,
+                                "end_line": 22,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -1795,9 +1576,9 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 26,
-                                                "end_line": 23,
+                                                "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
@@ -1809,12 +1590,12 @@
                                                         "parent_location": [
                                                             {
                                                                 "end_col": 26,
-                                                                "end_line": 23,
+                                                                "end_line": 22,
                                                                 "input_file": {
-                                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                                 },
                                                                 "start_col": 6,
-                                                                "start_line": 23
+                                                                "start_line": 22
                                                             },
                                                             "While handling calldata of"
                                                         ],
@@ -1824,7 +1605,7 @@
                                                     "While expanding the reference '__calldata_actual_size' in:"
                                                 ],
                                                 "start_col": 6,
-                                                "start_line": 23
+                                                "start_line": 22
                                             },
                                             "While handling calldata of"
                                         ],
@@ -1834,7 +1615,7 @@
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
                                 "start_col": 27,
-                                "start_line": 23
+                                "start_line": 22
                             },
                             "While handling calldata argument 'class_hash'"
                         ],
@@ -1842,7 +1623,7 @@
                         "start_line": 2
                     }
                 },
-                "63": {
+                "51": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1860,12 +1641,12 @@
                         "parent_location": [
                             {
                                 "end_col": 26,
-                                "end_line": 23,
+                                "end_line": 22,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 23
+                                "start_line": 22
                             },
                             "While handling calldata of"
                         ],
@@ -1873,7 +1654,7 @@
                         "start_line": 1
                     }
                 },
-                "64": {
+                "52": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1891,9 +1672,9 @@
                         "parent_location": [
                             {
                                 "end_col": 43,
-                                "end_line": 23,
+                                "end_line": 22,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -1905,12 +1686,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 26,
-                                                "end_line": 23,
+                                                "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 23
+                                                "start_line": 22
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -1920,7 +1701,7 @@
                                     "While expanding the reference '__calldata_arg_class_hash' in:"
                                 ],
                                 "start_col": 27,
-                                "start_line": 23
+                                "start_line": 22
                             },
                             "While handling calldata argument 'class_hash'"
                         ],
@@ -1928,7 +1709,7 @@
                         "start_line": 1
                     }
                 },
-                "65": {
+                "53": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1939,15 +1720,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 26,
-                        "end_line": 23,
+                        "end_line": 22,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 6,
-                        "start_line": 23
+                        "start_line": 22
                     }
                 },
-                "67": {
+                "55": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -1966,12 +1747,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 26,
-                                        "end_line": 23,
+                                        "end_line": 22,
                                         "input_file": {
-                                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                         },
                                         "start_col": 6,
-                                        "start_line": 23
+                                        "start_line": 22
                                     },
                                     "While constructing the external wrapper for:"
                                 ],
@@ -1990,12 +1771,12 @@
                         "parent_location": [
                             {
                                 "end_col": 26,
-                                "end_line": 23,
+                                "end_line": 22,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 23
+                                "start_line": 22
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2003,7 +1784,7 @@
                         "start_line": 3
                     }
                 },
-                "69": {
+                "57": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2021,9 +1802,9 @@
                         "parent_location": [
                             {
                                 "end_col": 26,
-                                "end_line": 23,
+                                "end_line": 22,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2035,12 +1816,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 26,
-                                                "end_line": 23,
+                                                "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 23
+                                                "start_line": 22
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -2050,7 +1831,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 23
+                                "start_line": 22
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2058,7 +1839,7 @@
                         "start_line": 1
                     }
                 },
-                "70": {
+                "58": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2076,9 +1857,9 @@
                         "parent_location": [
                             {
                                 "end_col": 26,
-                                "end_line": 23,
+                                "end_line": 22,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2090,12 +1871,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 26,
-                                                "end_line": 23,
+                                                "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 23
+                                                "start_line": 22
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -2105,7 +1886,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 23
+                                "start_line": 22
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2113,7 +1894,7 @@
                         "start_line": 1
                     }
                 },
-                "71": {
+                "59": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2131,9 +1912,9 @@
                         "parent_location": [
                             {
                                 "end_col": 26,
-                                "end_line": 23,
+                                "end_line": 22,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2145,12 +1926,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 26,
-                                                "end_line": 23,
+                                                "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 23
+                                                "start_line": 22
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -2160,7 +1941,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 23
+                                "start_line": 22
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2168,7 +1949,7 @@
                         "start_line": 1
                     }
                 },
-                "72": {
+                "60": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2186,9 +1967,9 @@
                         "parent_location": [
                             {
                                 "end_col": 26,
-                                "end_line": 23,
+                                "end_line": 22,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2200,12 +1981,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 26,
-                                                "end_line": 23,
+                                                "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 23
+                                                "start_line": 22
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -2215,7 +1996,7 @@
                                     "While expanding the reference 'retdata_size' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 23
+                                "start_line": 22
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2223,7 +2004,7 @@
                         "start_line": 4
                     }
                 },
-                "74": {
+                "62": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2241,9 +2022,9 @@
                         "parent_location": [
                             {
                                 "end_col": 26,
-                                "end_line": 23,
+                                "end_line": 22,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2255,12 +2036,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 26,
-                                                "end_line": 23,
+                                                "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 23
+                                                "start_line": 22
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -2270,7 +2051,7 @@
                                     "While expanding the reference 'retdata' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 23
+                                "start_line": 22
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2278,7 +2059,7 @@
                         "start_line": 3
                     }
                 },
-                "75": {
+                "63": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2296,12 +2077,12 @@
                         "parent_location": [
                             {
                                 "end_col": 26,
-                                "end_line": 23,
+                                "end_line": 22,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 23
+                                "start_line": 22
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2309,7 +2090,7 @@
                         "start_line": 1
                     }
                 },
-                "76": {
+                "64": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2319,15 +2100,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 15,
-                        "end_line": 29,
+                        "end_line": 28,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 29
+                        "start_line": 28
                     }
                 },
-                "77": {
+                "65": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2345,9 +2126,9 @@
                         "parent_location": [
                             {
                                 "end_col": 71,
-                                "end_line": 28,
+                                "end_line": 27,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2359,9 +2140,9 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 25,
-                                                "end_line": 28,
+                                                "end_line": 27,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
@@ -2373,12 +2154,12 @@
                                                         "parent_location": [
                                                             {
                                                                 "end_col": 25,
-                                                                "end_line": 28,
+                                                                "end_line": 27,
                                                                 "input_file": {
-                                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                                 },
                                                                 "start_col": 6,
-                                                                "start_line": 28
+                                                                "start_line": 27
                                                             },
                                                             "While handling calldata of"
                                                         ],
@@ -2388,7 +2169,7 @@
                                                     "While expanding the reference '__calldata_actual_size' in:"
                                                 ],
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 27
                                             },
                                             "While handling calldata of"
                                         ],
@@ -2398,7 +2179,7 @@
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
                                 "start_col": 44,
-                                "start_line": 28
+                                "start_line": 27
                             },
                             "While handling calldata argument 'contract_address_salt'"
                         ],
@@ -2406,7 +2187,7 @@
                         "start_line": 2
                     }
                 },
-                "79": {
+                "67": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2424,12 +2205,12 @@
                         "parent_location": [
                             {
                                 "end_col": 25,
-                                "end_line": 28,
+                                "end_line": 27,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 27
                             },
                             "While handling calldata of"
                         ],
@@ -2437,7 +2218,7 @@
                         "start_line": 1
                     }
                 },
-                "80": {
+                "68": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2455,9 +2236,9 @@
                         "parent_location": [
                             {
                                 "end_col": 42,
-                                "end_line": 28,
+                                "end_line": 27,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2469,12 +2250,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 25,
-                                                "end_line": 28,
+                                                "end_line": 27,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 27
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -2484,7 +2265,7 @@
                                     "While expanding the reference '__calldata_arg_class_hash' in:"
                                 ],
                                 "start_col": 26,
-                                "start_line": 28
+                                "start_line": 27
                             },
                             "While handling calldata argument 'class_hash'"
                         ],
@@ -2492,7 +2273,7 @@
                         "start_line": 1
                     }
                 },
-                "81": {
+                "69": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2510,9 +2291,9 @@
                         "parent_location": [
                             {
                                 "end_col": 71,
-                                "end_line": 28,
+                                "end_line": 27,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2524,12 +2305,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 25,
-                                                "end_line": 28,
+                                                "end_line": 27,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 27
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -2539,7 +2320,7 @@
                                     "While expanding the reference '__calldata_arg_contract_address_salt' in:"
                                 ],
                                 "start_col": 44,
-                                "start_line": 28
+                                "start_line": 27
                             },
                             "While handling calldata argument 'contract_address_salt'"
                         ],
@@ -2547,7 +2328,7 @@
                         "start_line": 1
                     }
                 },
-                "82": {
+                "70": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2558,15 +2339,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 25,
-                        "end_line": 28,
+                        "end_line": 27,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 6,
-                        "start_line": 28
+                        "start_line": 27
                     }
                 },
-                "84": {
+                "72": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2585,12 +2366,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 25,
-                                        "end_line": 28,
+                                        "end_line": 27,
                                         "input_file": {
-                                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                         },
                                         "start_col": 6,
-                                        "start_line": 28
+                                        "start_line": 27
                                     },
                                     "While constructing the external wrapper for:"
                                 ],
@@ -2609,12 +2390,12 @@
                         "parent_location": [
                             {
                                 "end_col": 25,
-                                "end_line": 28,
+                                "end_line": 27,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 27
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2622,7 +2403,7 @@
                         "start_line": 3
                     }
                 },
-                "86": {
+                "74": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2640,9 +2421,9 @@
                         "parent_location": [
                             {
                                 "end_col": 25,
-                                "end_line": 28,
+                                "end_line": 27,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2654,12 +2435,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 25,
-                                                "end_line": 28,
+                                                "end_line": 27,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 27
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -2669,7 +2450,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 27
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2677,7 +2458,7 @@
                         "start_line": 1
                     }
                 },
-                "87": {
+                "75": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2695,9 +2476,9 @@
                         "parent_location": [
                             {
                                 "end_col": 25,
-                                "end_line": 28,
+                                "end_line": 27,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2709,12 +2490,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 25,
-                                                "end_line": 28,
+                                                "end_line": 27,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 27
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -2724,7 +2505,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 27
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2732,7 +2513,7 @@
                         "start_line": 1
                     }
                 },
-                "88": {
+                "76": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2750,9 +2531,9 @@
                         "parent_location": [
                             {
                                 "end_col": 25,
-                                "end_line": 28,
+                                "end_line": 27,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2764,12 +2545,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 25,
-                                                "end_line": 28,
+                                                "end_line": 27,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 27
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -2779,7 +2560,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 27
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2787,7 +2568,7 @@
                         "start_line": 1
                     }
                 },
-                "89": {
+                "77": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2805,9 +2586,9 @@
                         "parent_location": [
                             {
                                 "end_col": 25,
-                                "end_line": 28,
+                                "end_line": 27,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2819,12 +2600,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 25,
-                                                "end_line": 28,
+                                                "end_line": 27,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 27
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -2834,7 +2615,7 @@
                                     "While expanding the reference 'retdata_size' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 27
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2842,7 +2623,7 @@
                         "start_line": 4
                     }
                 },
-                "91": {
+                "79": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2860,9 +2641,9 @@
                         "parent_location": [
                             {
                                 "end_col": 25,
-                                "end_line": 28,
+                                "end_line": 27,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2874,12 +2655,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 25,
-                                                "end_line": 28,
+                                                "end_line": 27,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 28
+                                                "start_line": 27
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -2889,7 +2670,7 @@
                                     "While expanding the reference 'retdata' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 27
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2897,7 +2678,7 @@
                         "start_line": 3
                     }
                 },
-                "92": {
+                "80": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2915,12 +2696,12 @@
                         "parent_location": [
                             {
                                 "end_col": 25,
-                                "end_line": 28,
+                                "end_line": 27,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 28
+                                "start_line": 27
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -2928,7 +2709,7 @@
                         "start_line": 1
                     }
                 },
-                "93": {
+                "81": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2938,15 +2719,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 15,
-                        "end_line": 34,
+                        "end_line": 33,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 34
+                        "start_line": 33
                     }
                 },
-                "94": {
+                "82": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -2964,9 +2745,9 @@
                         "parent_location": [
                             {
                                 "end_col": 18,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2978,12 +2759,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 88,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 73,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While handling calldata argument 'calldata'"
                                         ],
@@ -2993,7 +2774,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -3001,7 +2782,7 @@
                         "start_line": 1
                     }
                 },
-                "95": {
+                "83": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3019,9 +2800,9 @@
                         "parent_location": [
                             {
                                 "end_col": 71,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3033,12 +2814,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 88,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 73,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While handling calldata argument 'calldata'"
                                         ],
@@ -3048,7 +2829,7 @@
                                     "While expanding the reference '__calldata_arg_calldata_len' in:"
                                 ],
                                 "start_col": 53,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While handling calldata argument 'calldata_len'"
                         ],
@@ -3056,7 +2837,7 @@
                         "start_line": 1
                     }
                 },
-                "96": {
+                "84": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3074,12 +2855,12 @@
                         "parent_location": [
                             {
                                 "end_col": 88,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 73,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While handling calldata argument 'calldata'"
                         ],
@@ -3087,7 +2868,7 @@
                         "start_line": 2
                     }
                 },
-                "97": {
+                "85": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3105,9 +2886,9 @@
                         "parent_location": [
                             {
                                 "end_col": 71,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3119,12 +2900,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 88,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 73,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While handling calldata argument 'calldata'"
                                         ],
@@ -3134,7 +2915,7 @@
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
                                 "start_col": 53,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While handling calldata argument 'calldata_len'"
                         ],
@@ -3142,7 +2923,7 @@
                         "start_line": 2
                     }
                 },
-                "99": {
+                "87": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3160,9 +2941,9 @@
                         "parent_location": [
                             {
                                 "end_col": 71,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3174,12 +2955,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 88,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 73,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While handling calldata argument 'calldata'"
                                         ],
@@ -3189,7 +2970,7 @@
                                     "While expanding the reference '__calldata_arg_calldata_len' in:"
                                 ],
                                 "start_col": 53,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While handling calldata argument 'calldata_len'"
                         ],
@@ -3197,7 +2978,7 @@
                         "start_line": 1
                     }
                 },
-                "100": {
+                "88": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3215,12 +2996,12 @@
                         "parent_location": [
                             {
                                 "end_col": 88,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 73,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While handling calldata argument 'calldata'"
                         ],
@@ -3228,7 +3009,7 @@
                         "start_line": 8
                     }
                 },
-                "101": {
+                "89": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3246,12 +3027,12 @@
                         "parent_location": [
                             {
                                 "end_col": 18,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While handling calldata of"
                         ],
@@ -3259,7 +3040,7 @@
                         "start_line": 1
                     }
                 },
-                "102": {
+                "90": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3277,9 +3058,9 @@
                         "parent_location": [
                             {
                                 "end_col": 35,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3291,12 +3072,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 18,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -3306,7 +3087,7 @@
                                     "While expanding the reference '__calldata_arg_contract_address' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While handling calldata argument 'contract_address'"
                         ],
@@ -3314,7 +3095,7 @@
                         "start_line": 1
                     }
                 },
-                "103": {
+                "91": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3332,9 +3113,9 @@
                         "parent_location": [
                             {
                                 "end_col": 51,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3346,12 +3127,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 18,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -3361,7 +3142,7 @@
                                     "While expanding the reference '__calldata_arg_selector' in:"
                                 ],
                                 "start_col": 37,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While handling calldata argument 'selector'"
                         ],
@@ -3369,7 +3150,7 @@
                         "start_line": 1
                     }
                 },
-                "104": {
+                "92": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3387,9 +3168,9 @@
                         "parent_location": [
                             {
                                 "end_col": 71,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3401,12 +3182,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 18,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -3416,7 +3197,7 @@
                                     "While expanding the reference '__calldata_arg_calldata_len' in:"
                                 ],
                                 "start_col": 53,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While handling calldata argument 'calldata_len'"
                         ],
@@ -3424,7 +3205,7 @@
                         "start_line": 1
                     }
                 },
-                "105": {
+                "93": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3442,9 +3223,9 @@
                         "parent_location": [
                             {
                                 "end_col": 88,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3456,12 +3237,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 18,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -3471,7 +3252,7 @@
                                     "While expanding the reference '__calldata_arg_calldata' in:"
                                 ],
                                 "start_col": 73,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While handling calldata argument 'calldata'"
                         ],
@@ -3479,7 +3260,7 @@
                         "start_line": 5
                     }
                 },
-                "107": {
+                "95": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3490,15 +3271,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 18,
-                        "end_line": 33,
+                        "end_line": 32,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 6,
-                        "start_line": 33
+                        "start_line": 32
                     }
                 },
-                "109": {
+                "97": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3517,12 +3298,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 18,
-                                        "end_line": 33,
+                                        "end_line": 32,
                                         "input_file": {
-                                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                         },
                                         "start_col": 6,
-                                        "start_line": 33
+                                        "start_line": 32
                                     },
                                     "While constructing the external wrapper for:"
                                 ],
@@ -3541,12 +3322,12 @@
                         "parent_location": [
                             {
                                 "end_col": 18,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -3554,7 +3335,7 @@
                         "start_line": 3
                     }
                 },
-                "111": {
+                "99": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3572,9 +3353,9 @@
                         "parent_location": [
                             {
                                 "end_col": 18,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3586,9 +3367,9 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 88,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
@@ -3600,12 +3381,12 @@
                                                         "parent_location": [
                                                             {
                                                                 "end_col": 18,
-                                                                "end_line": 33,
+                                                                "end_line": 32,
                                                                 "input_file": {
-                                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                                 },
                                                                 "start_col": 6,
-                                                                "start_line": 33
+                                                                "start_line": 32
                                                             },
                                                             "While constructing the external wrapper for:"
                                                         ],
@@ -3615,7 +3396,7 @@
                                                     "While expanding the reference 'range_check_ptr' in:"
                                                 ],
                                                 "start_col": 73,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While handling calldata argument 'calldata'"
                                         ],
@@ -3625,7 +3406,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -3633,7 +3414,7 @@
                         "start_line": 1
                     }
                 },
-                "112": {
+                "100": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3651,9 +3432,9 @@
                         "parent_location": [
                             {
                                 "end_col": 18,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3665,12 +3446,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 18,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -3680,7 +3461,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -3688,7 +3469,7 @@
                         "start_line": 1
                     }
                 },
-                "113": {
+                "101": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3706,9 +3487,9 @@
                         "parent_location": [
                             {
                                 "end_col": 18,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3720,12 +3501,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 18,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -3735,7 +3516,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -3743,7 +3524,7 @@
                         "start_line": 1
                     }
                 },
-                "114": {
+                "102": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3761,9 +3542,9 @@
                         "parent_location": [
                             {
                                 "end_col": 88,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3775,12 +3556,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 18,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -3790,7 +3571,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 73,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While handling calldata argument 'calldata'"
                         ],
@@ -3798,7 +3579,7 @@
                         "start_line": 3
                     }
                 },
-                "116": {
+                "104": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3816,9 +3597,9 @@
                         "parent_location": [
                             {
                                 "end_col": 18,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3830,12 +3611,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 18,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -3845,7 +3626,7 @@
                                     "While expanding the reference 'retdata_size' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -3853,7 +3634,7 @@
                         "start_line": 4
                     }
                 },
-                "118": {
+                "106": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3871,9 +3652,9 @@
                         "parent_location": [
                             {
                                 "end_col": 18,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -3885,12 +3666,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 18,
-                                                "end_line": 33,
+                                                "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 33
+                                                "start_line": 32
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -3900,7 +3681,7 @@
                                     "While expanding the reference 'retdata' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -3908,7 +3689,7 @@
                         "start_line": 3
                     }
                 },
-                "119": {
+                "107": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3926,12 +3707,12 @@
                         "parent_location": [
                             {
                                 "end_col": 18,
-                                "end_line": 33,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 33
+                                "start_line": 32
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -3939,7 +3720,7 @@
                         "start_line": 1
                     }
                 },
-                "120": {
+                "108": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3949,39 +3730,39 @@
                     "hints": [],
                     "inst": {
                         "end_col": 36,
-                        "end_line": 39,
+                        "end_line": 38,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 36,
-                                "end_line": 39,
+                                "end_line": 38,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 58,
-                                        "end_line": 42,
+                                        "end_line": 41,
                                         "input_file": {
-                                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 42
+                                        "start_line": 41
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 18,
-                                "start_line": 39
+                                "start_line": 38
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 18,
-                        "start_line": 39
+                        "start_line": 38
                     }
                 },
-                "121": {
+                "109": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -3991,39 +3772,39 @@
                     "hints": [],
                     "inst": {
                         "end_col": 64,
-                        "end_line": 39,
+                        "end_line": 38,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 64,
-                                "end_line": 39,
+                                "end_line": 38,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 58,
-                                        "end_line": 42,
+                                        "end_line": 41,
                                         "input_file": {
-                                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 42
+                                        "start_line": 41
                                     },
                                     "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 38,
-                                "start_line": 39
+                                "start_line": 38
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
                         "start_col": 38,
-                        "start_line": 39
+                        "start_line": 38
                     }
                 },
-                "122": {
+                "110": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4033,39 +3814,39 @@
                     "hints": [],
                     "inst": {
                         "end_col": 81,
-                        "end_line": 39,
+                        "end_line": 38,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 81,
-                                "end_line": 39,
+                                "end_line": 38,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 58,
-                                        "end_line": 42,
+                                        "end_line": 41,
                                         "input_file": {
-                                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 42
+                                        "start_line": 41
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
                                 "start_col": 66,
-                                "start_line": 39
+                                "start_line": 38
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
                         "start_col": 66,
-                        "start_line": 39
+                        "start_line": 38
                     }
                 },
-                "123": {
+                "111": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4075,27 +3856,27 @@
                     "hints": [],
                     "inst": {
                         "end_col": 57,
-                        "end_line": 40,
+                        "end_line": 39,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 38,
-                                "end_line": 42,
+                                "end_line": 41,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 26,
-                                "start_line": 42
+                                "start_line": 41
                             },
                             "While expanding the reference 'calldata_len' in:"
                         ],
                         "start_col": 39,
-                        "start_line": 40
+                        "start_line": 39
                     }
                 },
-                "124": {
+                "112": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4105,27 +3886,27 @@
                     "hints": [],
                     "inst": {
                         "end_col": 74,
-                        "end_line": 40,
+                        "end_line": 39,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 56,
-                                "end_line": 42,
+                                "end_line": 41,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 48,
-                                "start_line": 42
+                                "start_line": 41
                             },
                             "While expanding the reference 'calldata' in:"
                         ],
                         "start_col": 59,
-                        "start_line": 40
+                        "start_line": 39
                     }
                 },
-                "125": {
+                "113": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4135,15 +3916,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 58,
-                        "end_line": 42,
+                        "end_line": 41,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 42
+                        "start_line": 41
                     }
                 },
-                "126": {
+                "114": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4161,9 +3942,9 @@
                         "parent_location": [
                             {
                                 "end_col": 81,
-                                "end_line": 39,
+                                "end_line": 38,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4175,12 +3956,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 74,
-                                                "end_line": 40,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 59,
-                                                "start_line": 40
+                                                "start_line": 39
                                             },
                                             "While handling calldata argument 'calldata'"
                                         ],
@@ -4190,7 +3971,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 66,
-                                "start_line": 39
+                                "start_line": 38
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -4198,7 +3979,7 @@
                         "start_line": 1
                     }
                 },
-                "127": {
+                "115": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4216,9 +3997,9 @@
                         "parent_location": [
                             {
                                 "end_col": 57,
-                                "end_line": 40,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4230,12 +4011,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 74,
-                                                "end_line": 40,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 59,
-                                                "start_line": 40
+                                                "start_line": 39
                                             },
                                             "While handling calldata argument 'calldata'"
                                         ],
@@ -4245,7 +4026,7 @@
                                     "While expanding the reference '__calldata_arg_calldata_len' in:"
                                 ],
                                 "start_col": 39,
-                                "start_line": 40
+                                "start_line": 39
                             },
                             "While handling calldata argument 'calldata_len'"
                         ],
@@ -4253,7 +4034,7 @@
                         "start_line": 1
                     }
                 },
-                "128": {
+                "116": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4271,12 +4052,12 @@
                         "parent_location": [
                             {
                                 "end_col": 74,
-                                "end_line": 40,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 59,
-                                "start_line": 40
+                                "start_line": 39
                             },
                             "While handling calldata argument 'calldata'"
                         ],
@@ -4284,7 +4065,7 @@
                         "start_line": 2
                     }
                 },
-                "129": {
+                "117": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4302,9 +4083,9 @@
                         "parent_location": [
                             {
                                 "end_col": 57,
-                                "end_line": 40,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4316,12 +4097,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 74,
-                                                "end_line": 40,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 59,
-                                                "start_line": 40
+                                                "start_line": 39
                                             },
                                             "While handling calldata argument 'calldata'"
                                         ],
@@ -4331,7 +4112,7 @@
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
                                 "start_col": 39,
-                                "start_line": 40
+                                "start_line": 39
                             },
                             "While handling calldata argument 'calldata_len'"
                         ],
@@ -4339,7 +4120,7 @@
                         "start_line": 2
                     }
                 },
-                "131": {
+                "119": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4357,9 +4138,9 @@
                         "parent_location": [
                             {
                                 "end_col": 57,
-                                "end_line": 40,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4371,12 +4152,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 74,
-                                                "end_line": 40,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 59,
-                                                "start_line": 40
+                                                "start_line": 39
                                             },
                                             "While handling calldata argument 'calldata'"
                                         ],
@@ -4386,7 +4167,7 @@
                                     "While expanding the reference '__calldata_arg_calldata_len' in:"
                                 ],
                                 "start_col": 39,
-                                "start_line": 40
+                                "start_line": 39
                             },
                             "While handling calldata argument 'calldata_len'"
                         ],
@@ -4394,7 +4175,7 @@
                         "start_line": 1
                     }
                 },
-                "132": {
+                "120": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4412,12 +4193,12 @@
                         "parent_location": [
                             {
                                 "end_col": 74,
-                                "end_line": 40,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 59,
-                                "start_line": 40
+                                "start_line": 39
                             },
                             "While handling calldata argument 'calldata'"
                         ],
@@ -4425,7 +4206,7 @@
                         "start_line": 8
                     }
                 },
-                "133": {
+                "121": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4443,12 +4224,12 @@
                         "parent_location": [
                             {
                                 "end_col": 17,
-                                "end_line": 39,
+                                "end_line": 38,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 39
+                                "start_line": 38
                             },
                             "While handling calldata of"
                         ],
@@ -4456,7 +4237,7 @@
                         "start_line": 1
                     }
                 },
-                "134": {
+                "122": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4474,9 +4255,9 @@
                         "parent_location": [
                             {
                                 "end_col": 81,
-                                "end_line": 39,
+                                "end_line": 38,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4488,9 +4269,9 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 74,
-                                                "end_line": 40,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
@@ -4502,12 +4283,12 @@
                                                         "parent_location": [
                                                             {
                                                                 "end_col": 17,
-                                                                "end_line": 39,
+                                                                "end_line": 38,
                                                                 "input_file": {
-                                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                                 },
                                                                 "start_col": 6,
-                                                                "start_line": 39
+                                                                "start_line": 38
                                                             },
                                                             "While constructing the external wrapper for:"
                                                         ],
@@ -4517,7 +4298,7 @@
                                                     "While expanding the reference 'range_check_ptr' in:"
                                                 ],
                                                 "start_col": 59,
-                                                "start_line": 40
+                                                "start_line": 39
                                             },
                                             "While handling calldata argument 'calldata'"
                                         ],
@@ -4527,7 +4308,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 66,
-                                "start_line": 39
+                                "start_line": 38
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -4535,7 +4316,7 @@
                         "start_line": 1
                     }
                 },
-                "135": {
+                "123": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4553,9 +4334,9 @@
                         "parent_location": [
                             {
                                 "end_col": 36,
-                                "end_line": 39,
+                                "end_line": 38,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4567,12 +4348,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 39,
+                                                "end_line": 38,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 39
+                                                "start_line": 38
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -4582,7 +4363,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 18,
-                                "start_line": 39
+                                "start_line": 38
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -4590,7 +4371,7 @@
                         "start_line": 1
                     }
                 },
-                "136": {
+                "124": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4608,9 +4389,9 @@
                         "parent_location": [
                             {
                                 "end_col": 64,
-                                "end_line": 39,
+                                "end_line": 38,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4622,12 +4403,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 39,
+                                                "end_line": 38,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 39
+                                                "start_line": 38
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -4637,7 +4418,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 38,
-                                "start_line": 39
+                                "start_line": 38
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -4645,7 +4426,7 @@
                         "start_line": 1
                     }
                 },
-                "137": {
+                "125": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4663,9 +4444,9 @@
                         "parent_location": [
                             {
                                 "end_col": 74,
-                                "end_line": 40,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4677,12 +4458,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 39,
+                                                "end_line": 38,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 39
+                                                "start_line": 38
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -4692,7 +4473,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 59,
-                                "start_line": 40
+                                "start_line": 39
                             },
                             "While handling calldata argument 'calldata'"
                         ],
@@ -4700,7 +4481,7 @@
                         "start_line": 3
                     }
                 },
-                "139": {
+                "127": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4718,9 +4499,9 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 40,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4732,12 +4513,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 39,
+                                                "end_line": 38,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 39
+                                                "start_line": 38
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -4747,7 +4528,7 @@
                                     "While expanding the reference '__calldata_arg_contract_address' in:"
                                 ],
                                 "start_col": 5,
-                                "start_line": 40
+                                "start_line": 39
                             },
                             "While handling calldata argument 'contract_address'"
                         ],
@@ -4755,7 +4536,7 @@
                         "start_line": 1
                     }
                 },
-                "140": {
+                "128": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4773,9 +4554,9 @@
                         "parent_location": [
                             {
                                 "end_col": 37,
-                                "end_line": 40,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4787,12 +4568,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 39,
+                                                "end_line": 38,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 39
+                                                "start_line": 38
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -4802,7 +4583,7 @@
                                     "While expanding the reference '__calldata_arg_selector' in:"
                                 ],
                                 "start_col": 23,
-                                "start_line": 40
+                                "start_line": 39
                             },
                             "While handling calldata argument 'selector'"
                         ],
@@ -4810,7 +4591,7 @@
                         "start_line": 1
                     }
                 },
-                "141": {
+                "129": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4828,9 +4609,9 @@
                         "parent_location": [
                             {
                                 "end_col": 57,
-                                "end_line": 40,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4842,12 +4623,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 39,
+                                                "end_line": 38,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 39
+                                                "start_line": 38
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -4857,7 +4638,7 @@
                                     "While expanding the reference '__calldata_arg_calldata_len' in:"
                                 ],
                                 "start_col": 39,
-                                "start_line": 40
+                                "start_line": 39
                             },
                             "While handling calldata argument 'calldata_len'"
                         ],
@@ -4865,7 +4646,7 @@
                         "start_line": 1
                     }
                 },
-                "142": {
+                "130": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4883,9 +4664,9 @@
                         "parent_location": [
                             {
                                 "end_col": 74,
-                                "end_line": 40,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -4897,12 +4678,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
-                                                "end_line": 39,
+                                                "end_line": 38,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 39
+                                                "start_line": 38
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -4912,7 +4693,7 @@
                                     "While expanding the reference '__calldata_arg_calldata' in:"
                                 ],
                                 "start_col": 59,
-                                "start_line": 40
+                                "start_line": 39
                             },
                             "While handling calldata argument 'calldata'"
                         ],
@@ -4920,7 +4701,7 @@
                         "start_line": 5
                     }
                 },
-                "144": {
+                "132": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4931,15 +4712,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 17,
-                        "end_line": 39,
+                        "end_line": 38,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 6,
-                        "start_line": 39
+                        "start_line": 38
                     }
                 },
-                "146": {
+                "134": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4957,12 +4738,12 @@
                         "parent_location": [
                             {
                                 "end_col": 17,
-                                "end_line": 39,
+                                "end_line": 38,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 39
+                                "start_line": 38
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -4970,7 +4751,7 @@
                         "start_line": 1
                     }
                 },
-                "147": {
+                "135": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -4980,39 +4761,39 @@
                     "hints": [],
                     "inst": {
                         "end_col": 40,
-                        "end_line": 46,
+                        "end_line": 45,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 41,
-                                "end_line": 15,
+                                "end_line": 14,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 23,
-                                        "end_line": 52,
+                                        "end_line": 51,
                                         "input_file": {
-                                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 52
+                                        "start_line": 51
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 23,
-                                "start_line": 15
+                                "start_line": 14
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 22,
-                        "start_line": 46
+                        "start_line": 45
                     }
                 },
-                "148": {
+                "136": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5022,15 +4803,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 23,
-                        "end_line": 52,
+                        "end_line": 51,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 52
+                        "start_line": 51
                     }
                 },
-                "150": {
+                "138": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5040,27 +4821,27 @@
                     "hints": [],
                     "inst": {
                         "end_col": 21,
-                        "end_line": 47,
+                        "end_line": 46,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 30,
-                                "end_line": 54,
+                                "end_line": 53,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 20,
-                                "start_line": 54
+                                "start_line": 53
                             },
                             "While expanding the reference 'class_hash' in:"
                         ],
                         "start_col": 5,
-                        "start_line": 47
+                        "start_line": 46
                     }
                 },
-                "151": {
+                "139": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5070,27 +4851,27 @@
                     "hints": [],
                     "inst": {
                         "end_col": 32,
-                        "end_line": 48,
+                        "end_line": 47,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 52,
-                                "end_line": 55,
+                                "end_line": 54,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 31,
-                                "start_line": 55
+                                "start_line": 54
                             },
                             "While expanding the reference 'contract_address_salt' in:"
                         ],
                         "start_col": 5,
-                        "start_line": 48
+                        "start_line": 47
                     }
                 },
-                "152": {
+                "140": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5100,27 +4881,27 @@
                     "hints": [],
                     "inst": {
                         "end_col": 35,
-                        "end_line": 49,
+                        "end_line": 48,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 59,
-                                "end_line": 56,
+                                "end_line": 55,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 35,
-                                "start_line": 56
+                                "start_line": 55
                             },
                             "While expanding the reference 'constructor_calldata_len' in:"
                         ],
                         "start_col": 5,
-                        "start_line": 49
+                        "start_line": 48
                     }
                 },
-                "153": {
+                "141": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5130,27 +4911,27 @@
                     "hints": [],
                     "inst": {
                         "end_col": 32,
-                        "end_line": 50,
+                        "end_line": 49,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 50,
-                                "end_line": 57,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 30,
-                                "start_line": 57
+                                "start_line": 56
                             },
                             "While expanding the reference 'constructor_calldata' in:"
                         ],
                         "start_col": 5,
-                        "start_line": 50
+                        "start_line": 49
                     }
                 },
-                "154": {
+                "142": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5160,15 +4941,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 31,
-                        "end_line": 58,
+                        "end_line": 57,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 26,
-                        "start_line": 58
+                        "start_line": 57
                     }
                 },
-                "156": {
+                "144": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5178,15 +4959,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 6,
-                        "end_line": 59,
+                        "end_line": 58,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 30,
-                        "start_line": 53
+                        "start_line": 52
                     }
                 },
-                "158": {
+                "146": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5196,15 +4977,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 48,
-                        "end_line": 60,
+                        "end_line": 59,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 60
+                        "start_line": 59
                     }
                 },
-                "159": {
+                "147": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5223,12 +5004,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 21,
-                                        "end_line": 46,
+                                        "end_line": 45,
                                         "input_file": {
-                                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                         },
                                         "start_col": 6,
-                                        "start_line": 46
+                                        "start_line": 45
                                     },
                                     "While handling return value of"
                                 ],
@@ -5247,12 +5028,12 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While handling return value of"
                         ],
@@ -5260,7 +5041,7 @@
                         "start_line": 4
                     }
                 },
-                "161": {
+                "149": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5278,12 +5059,12 @@
                         "parent_location": [
                             {
                                 "end_col": 29,
-                                "end_line": 51,
+                                "end_line": 50,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 7,
-                                "start_line": 51
+                                "start_line": 50
                             },
                             "While handling return value 'contract_address'"
                         ],
@@ -5291,7 +5072,7 @@
                         "start_line": 1
                     }
                 },
-                "162": {
+                "150": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5309,9 +5090,9 @@
                         "parent_location": [
                             {
                                 "end_col": 29,
-                                "end_line": 51,
+                                "end_line": 50,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -5323,12 +5104,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While handling return value of"
                                         ],
@@ -5338,7 +5119,7 @@
                                     "While expanding the reference '__return_value_ptr' in:"
                                 ],
                                 "start_col": 7,
-                                "start_line": 51
+                                "start_line": 50
                             },
                             "While handling return value 'contract_address'"
                         ],
@@ -5346,7 +5127,7 @@
                         "start_line": 2
                     }
                 },
-                "164": {
+                "152": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5364,9 +5145,9 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -5378,12 +5159,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While handling return value of"
                                         ],
@@ -5393,7 +5174,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While handling return value of"
                         ],
@@ -5401,7 +5182,7 @@
                         "start_line": 1
                     }
                 },
-                "165": {
+                "153": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5419,12 +5200,12 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While handling return value of"
                         ],
@@ -5432,7 +5213,7 @@
                         "start_line": 11
                     }
                 },
-                "166": {
+                "154": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5450,9 +5231,9 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -5464,12 +5245,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While handling return value of"
                                         ],
@@ -5479,7 +5260,7 @@
                                     "While expanding the reference '__return_value_ptr_start' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While handling return value of"
                         ],
@@ -5487,7 +5268,7 @@
                         "start_line": 5
                     }
                 },
-                "167": {
+                "155": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5505,12 +5286,12 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While handling return value of"
                         ],
@@ -5518,7 +5299,7 @@
                         "start_line": 9
                     }
                 },
-                "168": {
+                "156": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5536,9 +5317,9 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -5550,12 +5331,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 32,
-                                                "end_line": 50,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 5,
-                                                "start_line": 50
+                                                "start_line": 49
                                             },
                                             "While handling calldata argument 'constructor_calldata'"
                                         ],
@@ -5565,7 +5346,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5573,7 +5354,7 @@
                         "start_line": 1
                     }
                 },
-                "169": {
+                "157": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5591,9 +5372,9 @@
                         "parent_location": [
                             {
                                 "end_col": 35,
-                                "end_line": 49,
+                                "end_line": 48,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -5605,12 +5386,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 32,
-                                                "end_line": 50,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 5,
-                                                "start_line": 50
+                                                "start_line": 49
                                             },
                                             "While handling calldata argument 'constructor_calldata'"
                                         ],
@@ -5620,7 +5401,7 @@
                                     "While expanding the reference '__calldata_arg_constructor_calldata_len' in:"
                                 ],
                                 "start_col": 5,
-                                "start_line": 49
+                                "start_line": 48
                             },
                             "While handling calldata argument 'constructor_calldata_len'"
                         ],
@@ -5628,7 +5409,7 @@
                         "start_line": 1
                     }
                 },
-                "170": {
+                "158": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5646,12 +5427,12 @@
                         "parent_location": [
                             {
                                 "end_col": 32,
-                                "end_line": 50,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 50
+                                "start_line": 49
                             },
                             "While handling calldata argument 'constructor_calldata'"
                         ],
@@ -5659,7 +5440,7 @@
                         "start_line": 2
                     }
                 },
-                "171": {
+                "159": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5677,9 +5458,9 @@
                         "parent_location": [
                             {
                                 "end_col": 35,
-                                "end_line": 49,
+                                "end_line": 48,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -5691,12 +5472,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 32,
-                                                "end_line": 50,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 5,
-                                                "start_line": 50
+                                                "start_line": 49
                                             },
                                             "While handling calldata argument 'constructor_calldata'"
                                         ],
@@ -5706,7 +5487,7 @@
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
                                 "start_col": 5,
-                                "start_line": 49
+                                "start_line": 48
                             },
                             "While handling calldata argument 'constructor_calldata_len'"
                         ],
@@ -5714,7 +5495,7 @@
                         "start_line": 2
                     }
                 },
-                "173": {
+                "161": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5732,9 +5513,9 @@
                         "parent_location": [
                             {
                                 "end_col": 35,
-                                "end_line": 49,
+                                "end_line": 48,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -5746,12 +5527,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 32,
-                                                "end_line": 50,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 5,
-                                                "start_line": 50
+                                                "start_line": 49
                                             },
                                             "While handling calldata argument 'constructor_calldata'"
                                         ],
@@ -5761,7 +5542,7 @@
                                     "While expanding the reference '__calldata_arg_constructor_calldata_len' in:"
                                 ],
                                 "start_col": 5,
-                                "start_line": 49
+                                "start_line": 48
                             },
                             "While handling calldata argument 'constructor_calldata_len'"
                         ],
@@ -5769,7 +5550,7 @@
                         "start_line": 1
                     }
                 },
-                "174": {
+                "162": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5787,12 +5568,12 @@
                         "parent_location": [
                             {
                                 "end_col": 32,
-                                "end_line": 50,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 50
+                                "start_line": 49
                             },
                             "While handling calldata argument 'constructor_calldata'"
                         ],
@@ -5800,7 +5581,7 @@
                         "start_line": 8
                     }
                 },
-                "175": {
+                "163": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5818,12 +5599,12 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While handling calldata of"
                         ],
@@ -5831,7 +5612,7 @@
                         "start_line": 1
                     }
                 },
-                "176": {
+                "164": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5849,9 +5630,9 @@
                         "parent_location": [
                             {
                                 "end_col": 40,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -5863,12 +5644,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5878,7 +5659,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 22,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5886,7 +5667,7 @@
                         "start_line": 1
                     }
                 },
-                "177": {
+                "165": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5904,9 +5685,9 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 47,
+                                "end_line": 46,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -5918,12 +5699,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5933,7 +5714,7 @@
                                     "While expanding the reference '__calldata_arg_class_hash' in:"
                                 ],
                                 "start_col": 5,
-                                "start_line": 47
+                                "start_line": 46
                             },
                             "While handling calldata argument 'class_hash'"
                         ],
@@ -5941,7 +5722,7 @@
                         "start_line": 1
                     }
                 },
-                "178": {
+                "166": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -5959,9 +5740,9 @@
                         "parent_location": [
                             {
                                 "end_col": 32,
-                                "end_line": 48,
+                                "end_line": 47,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -5973,12 +5754,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5988,7 +5769,7 @@
                                     "While expanding the reference '__calldata_arg_contract_address_salt' in:"
                                 ],
                                 "start_col": 5,
-                                "start_line": 48
+                                "start_line": 47
                             },
                             "While handling calldata argument 'contract_address_salt'"
                         ],
@@ -5996,7 +5777,7 @@
                         "start_line": 1
                     }
                 },
-                "179": {
+                "167": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6014,9 +5795,9 @@
                         "parent_location": [
                             {
                                 "end_col": 35,
-                                "end_line": 49,
+                                "end_line": 48,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -6028,12 +5809,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6043,7 +5824,7 @@
                                     "While expanding the reference '__calldata_arg_constructor_calldata_len' in:"
                                 ],
                                 "start_col": 5,
-                                "start_line": 49
+                                "start_line": 48
                             },
                             "While handling calldata argument 'constructor_calldata_len'"
                         ],
@@ -6051,7 +5832,7 @@
                         "start_line": 1
                     }
                 },
-                "180": {
+                "168": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6069,9 +5850,9 @@
                         "parent_location": [
                             {
                                 "end_col": 32,
-                                "end_line": 50,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -6083,12 +5864,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6098,7 +5879,7 @@
                                     "While expanding the reference '__calldata_arg_constructor_calldata' in:"
                                 ],
                                 "start_col": 5,
-                                "start_line": 50
+                                "start_line": 49
                             },
                             "While handling calldata argument 'constructor_calldata'"
                         ],
@@ -6106,7 +5887,7 @@
                         "start_line": 5
                     }
                 },
-                "182": {
+                "170": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6117,15 +5898,15 @@
                     "hints": [],
                     "inst": {
                         "end_col": 21,
-                        "end_line": 46,
+                        "end_line": 45,
                         "input_file": {
-                            "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                            "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                         },
                         "start_col": 6,
-                        "start_line": 46
+                        "start_line": 45
                     }
                 },
-                "184": {
+                "172": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6143,9 +5924,9 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -6157,9 +5938,9 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 32,
-                                                "end_line": 50,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
@@ -6171,12 +5952,12 @@
                                                         "parent_location": [
                                                             {
                                                                 "end_col": 21,
-                                                                "end_line": 46,
+                                                                "end_line": 45,
                                                                 "input_file": {
-                                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                                 },
                                                                 "start_col": 6,
-                                                                "start_line": 46
+                                                                "start_line": 45
                                                             },
                                                             "While constructing the external wrapper for:"
                                                         ],
@@ -6186,7 +5967,7 @@
                                                     "While expanding the reference 'range_check_ptr' in:"
                                                 ],
                                                 "start_col": 5,
-                                                "start_line": 50
+                                                "start_line": 49
                                             },
                                             "While handling calldata argument 'constructor_calldata'"
                                         ],
@@ -6196,7 +5977,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6204,7 +5985,7 @@
                         "start_line": 1
                     }
                 },
-                "185": {
+                "173": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6222,9 +6003,9 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -6236,12 +6017,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6251,7 +6032,7 @@
                                     "While expanding the reference 'ret_value' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6259,7 +6040,7 @@
                         "start_line": 1
                     }
                 },
-                "186": {
+                "174": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6277,9 +6058,9 @@
                         "parent_location": [
                             {
                                 "end_col": 32,
-                                "end_line": 50,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -6291,12 +6072,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6306,7 +6087,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 5,
-                                "start_line": 50
+                                "start_line": 49
                             },
                             "While handling calldata argument 'constructor_calldata'"
                         ],
@@ -6314,7 +6095,7 @@
                         "start_line": 3
                     }
                 },
-                "188": {
+                "176": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6332,12 +6113,12 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6345,7 +6126,7 @@
                         "start_line": 2
                     }
                 },
-                "190": {
+                "178": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6363,9 +6144,9 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -6377,12 +6158,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6392,7 +6173,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6400,7 +6181,7 @@
                         "start_line": 1
                     }
                 },
-                "191": {
+                "179": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6418,9 +6199,9 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -6432,12 +6213,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6447,7 +6228,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6455,7 +6236,7 @@
                         "start_line": 1
                     }
                 },
-                "192": {
+                "180": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6473,9 +6254,9 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -6487,12 +6268,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6502,7 +6283,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6510,7 +6291,7 @@
                         "start_line": 2
                     }
                 },
-                "193": {
+                "181": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6528,9 +6309,9 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -6542,12 +6323,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6557,7 +6338,7 @@
                                     "While expanding the reference 'retdata_size' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6565,7 +6346,7 @@
                         "start_line": 2
                     }
                 },
-                "194": {
+                "182": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6583,9 +6364,9 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -6597,12 +6378,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 46,
+                                                "end_line": 45,
                                                 "input_file": {
-                                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 46
+                                                "start_line": 45
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6612,7 +6393,7 @@
                                     "While expanding the reference 'retdata' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6620,7 +6401,7 @@
                         "start_line": 2
                     }
                 },
-                "195": {
+                "183": {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
@@ -6638,12 +6419,12 @@
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 46,
+                                "end_line": 45,
                                 "input_file": {
-                                    "filename": "blockifier/feature_contracts/account_without_validations.cairo"
+                                    "filename": "blockifier/feature_contracts/account_without_some_syscalls.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 46
+                                "start_line": 45
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6654,25 +6435,7 @@
             }
         },
         "hints": {
-            "7": [
-                {
-                    "accessible_scopes": [
-                        "starkware.starknet.common.syscalls",
-                        "starkware.starknet.common.syscalls.call_contract"
-                    ],
-                    "code": "syscall_handler.call_contract(segments=segments, syscall_ptr=ids.syscall_ptr)",
-                    "flow_tracking_data": {
-                        "ap_tracking": {
-                            "group": 0,
-                            "offset": 1
-                        },
-                        "reference_ids": {
-                            "starkware.starknet.common.syscalls.call_contract.syscall_ptr": 0
-                        }
-                    }
-                }
-            ],
-            "20": [
+            "8": [
                 {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
@@ -6681,16 +6444,16 @@
                     "code": "syscall_handler.deploy(segments=segments, syscall_ptr=ids.syscall_ptr)",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 1,
+                            "group": 0,
                             "offset": 1
                         },
                         "reference_ids": {
-                            "starkware.starknet.common.syscalls.deploy.syscall_ptr": 1
+                            "starkware.starknet.common.syscalls.deploy.syscall_ptr": 0
                         }
                     }
                 }
             ],
-            "27": [
+            "15": [
                 {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
@@ -6699,16 +6462,16 @@
                     "code": "syscall_handler.get_caller_address(segments=segments, syscall_ptr=ids.syscall_ptr)",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 2,
+                            "group": 1,
                             "offset": 1
                         },
                         "reference_ids": {
-                            "starkware.starknet.common.syscalls.get_caller_address.syscall_ptr": 2
+                            "starkware.starknet.common.syscalls.get_caller_address.syscall_ptr": 1
                         }
                     }
                 }
             ],
-            "34": [
+            "22": [
                 {
                     "accessible_scopes": [
                         "starkware.starknet.common.syscalls",
@@ -6717,16 +6480,16 @@
                     "code": "syscall_handler.get_contract_address(segments=segments, syscall_ptr=ids.syscall_ptr)",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 3,
+                            "group": 2,
                             "offset": 1
                         },
                         "reference_ids": {
-                            "starkware.starknet.common.syscalls.get_contract_address.syscall_ptr": 3
+                            "starkware.starknet.common.syscalls.get_contract_address.syscall_ptr": 2
                         }
                     }
                 }
             ],
-            "51": [
+            "39": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -6737,14 +6500,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 5,
+                            "group": 4,
                             "offset": 16
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "67": [
+            "55": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -6755,14 +6518,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 7,
+                            "group": 6,
                             "offset": 4
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "84": [
+            "72": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -6773,14 +6536,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 9,
+                            "group": 8,
                             "offset": 5
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "109": [
+            "97": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -6791,14 +6554,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 11,
+                            "group": 10,
                             "offset": 11
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "159": [
+            "147": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -6809,7 +6572,7 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 15,
+                            "group": 14,
                             "offset": 0
                         },
                         "reference_ids": {}
@@ -6831,7 +6594,7 @@
                     "external",
                     "raw_output"
                 ],
-                "pc": 120,
+                "pc": 108,
                 "type": "function"
             },
             "__main__.__execute__.Args": {
@@ -6888,7 +6651,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 93,
+                "pc": 81,
                 "type": "function"
             },
             "__main__.__validate__.Args": {
@@ -6932,7 +6695,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 60,
+                "pc": 48,
                 "type": "function"
             },
             "__main__.__validate_declare__.Args": {
@@ -6964,7 +6727,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 76,
+                "pc": 64,
                 "type": "function"
             },
             "__main__.__validate_deploy__.Args": {
@@ -7000,7 +6763,7 @@
                 "decorators": [
                     "view"
                 ],
-                "pc": 38,
+                "pc": 26,
                 "type": "function"
             },
             "__main__.assert_only_self.Args": {
@@ -7028,10 +6791,6 @@
                 "type": "const",
                 "value": 0
             },
-            "__main__.call_contract": {
-                "destination": "starkware.starknet.common.syscalls.call_contract",
-                "type": "alias"
-            },
             "__main__.deploy": {
                 "destination": "starkware.starknet.common.syscalls.deploy",
                 "type": "alias"
@@ -7040,7 +6799,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 147,
+                "pc": 135,
                 "type": "function"
             },
             "__main__.deploy_contract.Args": {
@@ -7098,7 +6857,7 @@
                     "external",
                     "raw_output"
                 ],
-                "pc": 126,
+                "pc": 114,
                 "type": "function"
             },
             "__wrappers__.__execute__.Args": {
@@ -7133,7 +6892,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 94,
+                "pc": 82,
                 "type": "function"
             },
             "__wrappers__.__validate__.Args": {
@@ -7168,7 +6927,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 61,
+                "pc": 49,
                 "type": "function"
             },
             "__wrappers__.__validate_declare__.Args": {
@@ -7203,7 +6962,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 77,
+                "pc": 65,
                 "type": "function"
             },
             "__wrappers__.__validate_deploy__.Args": {
@@ -7238,7 +6997,7 @@
                 "decorators": [
                     "view"
                 ],
-                "pc": 47,
+                "pc": 35,
                 "type": "function"
             },
             "__wrappers__.assert_only_self.Args": {
@@ -7273,7 +7032,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 168,
+                "pc": 156,
                 "type": "function"
             },
             "__wrappers__.deploy_contract.Args": {
@@ -7302,7 +7061,7 @@
             },
             "__wrappers__.deploy_contract_encode_return": {
                 "decorators": [],
-                "pc": 159,
+                "pc": 147,
                 "type": "function"
             },
             "__wrappers__.deploy_contract_encode_return.Args": {
@@ -8198,79 +7957,9 @@
                 "size": 8,
                 "type": "struct"
             },
-            "starkware.starknet.common.syscalls.call_contract": {
-                "decorators": [],
-                "pc": 0,
-                "type": "function"
-            },
-            "starkware.starknet.common.syscalls.call_contract.Args": {
-                "full_name": "starkware.starknet.common.syscalls.call_contract.Args",
-                "members": {
-                    "calldata": {
-                        "cairo_type": "felt*",
-                        "offset": 3
-                    },
-                    "calldata_size": {
-                        "cairo_type": "felt",
-                        "offset": 2
-                    },
-                    "contract_address": {
-                        "cairo_type": "felt",
-                        "offset": 0
-                    },
-                    "function_selector": {
-                        "cairo_type": "felt",
-                        "offset": 1
-                    }
-                },
-                "size": 4,
-                "type": "struct"
-            },
-            "starkware.starknet.common.syscalls.call_contract.ImplicitArgs": {
-                "full_name": "starkware.starknet.common.syscalls.call_contract.ImplicitArgs",
-                "members": {
-                    "syscall_ptr": {
-                        "cairo_type": "felt*",
-                        "offset": 0
-                    }
-                },
-                "size": 1,
-                "type": "struct"
-            },
-            "starkware.starknet.common.syscalls.call_contract.Return": {
-                "cairo_type": "(retdata_size: felt, retdata: felt*)",
-                "type": "type_definition"
-            },
-            "starkware.starknet.common.syscalls.call_contract.SIZEOF_LOCALS": {
-                "type": "const",
-                "value": 0
-            },
-            "starkware.starknet.common.syscalls.call_contract.syscall_ptr": {
-                "cairo_type": "felt*",
-                "full_name": "starkware.starknet.common.syscalls.call_contract.syscall_ptr",
-                "references": [
-                    {
-                        "ap_tracking_data": {
-                            "group": 0,
-                            "offset": 0
-                        },
-                        "pc": 0,
-                        "value": "[cast(fp + (-7), felt**)]"
-                    },
-                    {
-                        "ap_tracking_data": {
-                            "group": 0,
-                            "offset": 1
-                        },
-                        "pc": 7,
-                        "value": "cast([fp + (-7)] + 7, felt*)"
-                    }
-                ],
-                "type": "reference"
-            },
             "starkware.starknet.common.syscalls.deploy": {
                 "decorators": [],
-                "pc": 12,
+                "pc": 0,
                 "type": "function"
             },
             "starkware.starknet.common.syscalls.deploy.Args": {
@@ -8325,18 +8014,18 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 1,
+                            "group": 0,
                             "offset": 0
                         },
-                        "pc": 12,
+                        "pc": 0,
                         "value": "[cast(fp + (-8), felt**)]"
                     },
                     {
                         "ap_tracking_data": {
-                            "group": 1,
+                            "group": 0,
                             "offset": 1
                         },
-                        "pc": 20,
+                        "pc": 8,
                         "value": "cast([fp + (-8)] + 9, felt*)"
                     }
                 ],
@@ -8344,7 +8033,7 @@
             },
             "starkware.starknet.common.syscalls.get_caller_address": {
                 "decorators": [],
-                "pc": 24,
+                "pc": 12,
                 "type": "function"
             },
             "starkware.starknet.common.syscalls.get_caller_address.Args": {
@@ -8378,18 +8067,18 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 2,
+                            "group": 1,
                             "offset": 0
                         },
-                        "pc": 24,
+                        "pc": 12,
                         "value": "[cast(fp + (-3), felt**)]"
                     },
                     {
                         "ap_tracking_data": {
-                            "group": 2,
+                            "group": 1,
                             "offset": 1
                         },
-                        "pc": 27,
+                        "pc": 15,
                         "value": "cast([fp + (-3)] + 2, felt*)"
                     }
                 ],
@@ -8397,7 +8086,7 @@
             },
             "starkware.starknet.common.syscalls.get_contract_address": {
                 "decorators": [],
-                "pc": 31,
+                "pc": 19,
                 "type": "function"
             },
             "starkware.starknet.common.syscalls.get_contract_address.Args": {
@@ -8431,18 +8120,18 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 3,
+                            "group": 2,
                             "offset": 0
                         },
-                        "pc": 31,
+                        "pc": 19,
                         "value": "[cast(fp + (-3), felt**)]"
                     },
                     {
                         "ap_tracking_data": {
-                            "group": 3,
+                            "group": 2,
                             "offset": 1
                         },
-                        "pc": 34,
+                        "pc": 22,
                         "value": "cast([fp + (-3)] + 2, felt*)"
                     }
                 ],
@@ -8459,7 +8148,7 @@
                         "offset": 0
                     },
                     "pc": 0,
-                    "value": "[cast(fp + (-7), felt**)]"
+                    "value": "[cast(fp + (-8), felt**)]"
                 },
                 {
                     "ap_tracking_data": {
@@ -8467,22 +8156,14 @@
                         "offset": 0
                     },
                     "pc": 12,
-                    "value": "[cast(fp + (-8), felt**)]"
+                    "value": "[cast(fp + (-3), felt**)]"
                 },
                 {
                     "ap_tracking_data": {
                         "group": 2,
                         "offset": 0
                     },
-                    "pc": 24,
-                    "value": "[cast(fp + (-3), felt**)]"
-                },
-                {
-                    "ap_tracking_data": {
-                        "group": 3,
-                        "offset": 0
-                    },
-                    "pc": 31,
+                    "pc": 19,
                     "value": "[cast(fp + (-3), felt**)]"
                 }
             ]


### PR DESCRIPTION
I talked with @elintul, and we decided to create another *temporary* account contract without syscalls (I'll add a TODO on the PR using it to remove it once we can).
Currently, I only removed the `call_ contract` syscall, and I'll move the others if necessary.

Reference to former PR with comments: https://github.com/starkware-libs/blockifier/pull/36.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/37)
<!-- Reviewable:end -->
