### PR TITLE
Replace usage of anyhow errors with thiserror for 'bigint_to_felt'.

### DIFF
--- a/blockifier/src/execution/errors.rs
+++ b/blockifier/src/execution/errors.rs
@@ -5,6 +5,7 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::StarknetApiError;
 use thiserror::Error;
 
+use crate::general_errors::ConversionError;
 use crate::state::errors::StateError;
 
 #[derive(Debug, Error)]
@@ -27,6 +28,8 @@ impl From<cairo_rs_vm_errors::runner_errors::RunnerError> for PreExecutionError 
 
 #[derive(Debug, Error)]
 pub enum PostExecutionError {
+    #[error(transparent)]
+    ConversionError(#[from] ConversionError),
     #[error(transparent)]
     MemoryError(#[from] cairo_rs_vm_errors::memory_errors::MemoryError),
     #[error(transparent)]

--- a/blockifier/src/execution/execution_utils.rs
+++ b/blockifier/src/execution/execution_utils.rs
@@ -2,7 +2,6 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::mem;
 
-use anyhow::{bail, Result};
 use cairo_rs::bigint;
 use cairo_rs::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
 use cairo_rs::serde::deserialize_program::{
@@ -26,6 +25,7 @@ use crate::execution::errors::{
     PostExecutionError, PreExecutionError, VirtualMachineExecutionError,
 };
 use crate::execution::syscall_handling::{initialize_syscall_handler, SyscallHandler};
+use crate::general_errors::ConversionError;
 use crate::state::cached_state::{CachedState, DictStateReader};
 
 #[cfg(test)]
@@ -36,17 +36,14 @@ pub fn felt_to_bigint(felt: StarkFelt) -> BigInt {
     BigInt::from_bytes_be(Sign::Plus, felt.bytes())
 }
 
-pub fn bigint_to_felt(bigint: &BigInt) -> Result<StarkFelt> {
+pub fn bigint_to_felt(bigint: &BigInt) -> Result<StarkFelt, ConversionError> {
     // TODO(Adi, 29/11/2022): Make sure lambdaclass always maintain that their bigints' are
     // non-negative.
     if bigint.is_negative() {
-        bail!("The given BigInt, {}, is negative.", bigint)
-    }
-
-    let bigint_hex = format!("{bigint:#x}");
-    match StarkFelt::try_from(bigint_hex.as_str()) {
-        Ok(felt) => Ok(felt),
-        Err(e) => bail!(e),
+        Err(ConversionError::NegativeBigIntToFelt(bigint.clone()))
+    } else {
+        let bigint_hex = format!("{bigint:#x}");
+        Ok(StarkFelt::try_from(bigint_hex.as_str())?)
     }
 }
 

--- a/blockifier/src/general_errors.rs
+++ b/blockifier/src/general_errors.rs
@@ -1,0 +1,12 @@
+use num_bigint::BigInt;
+use starknet_api::StarknetApiError;
+use thiserror::Error;
+
+/// Errors caused by converting different types.
+#[derive(Error, Debug)]
+pub enum ConversionError {
+    #[error("The given BigInt, {0}, is negative.")]
+    NegativeBigIntToFelt(BigInt),
+    #[error(transparent)]
+    StarknetApiError(#[from] StarknetApiError),
+}

--- a/blockifier/src/lib.rs
+++ b/blockifier/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod execution;
+pub mod general_errors;
 pub mod state;
 pub mod test_utils;
 pub mod transaction;


### PR DESCRIPTION
I had a problem testing it, as the `StarknetApiError` does not implement the `PartialEq` trait.
For now I tested it manually, and I'll add tests later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/38)
<!-- Reviewable:end -->
