### PR TITLE
Use `Arc` in `StateReader` + update docstrings

### DIFF
--- a/blockifier/src/cached_state.rs
+++ b/blockifier/src/cached_state.rs
@@ -1,26 +1,29 @@
+use std::sync::Arc;
+
 use anyhow::Result;
 use starknet_api::{ClassHash, ContractAddress, Nonce, StarkFelt, StorageKey};
 
 /// A read-only API for accessing StarkNet global state.
 pub trait StateReader {
     /// Returns the storage value under the given key in the given contract instance (represented by
-    /// its address).
+    /// its address); 0 if the contract address is uninitialized.
     fn get_storage_at(
         &self,
         _contract_address: ContractAddress,
         _key: StorageKey,
-    ) -> Result<StarkFelt> {
+    ) -> Result<Arc<StarkFelt>> {
         unimplemented!();
     }
 
-    /// Returns the nonce of the given contract instance.
-    fn get_nonce_at(&self, _contract_address: ContractAddress) -> Result<Nonce> {
+    /// Returns the nonce of the given contract instance;
+    /// 0 if the contract address is uninitialized.
+    fn get_nonce_at(&self, _contract_address: ContractAddress) -> Result<Arc<Nonce>> {
         unimplemented!();
     }
 
     /// Returns the class hash of the contract class at the given contract instance;
     /// uninitialized class hash, if the address is unassigned.
-    fn get_class_hash_at(&self, _contract_address: ContractAddress) -> Result<ClassHash> {
+    fn get_class_hash_at(&self, _contract_address: ContractAddress) -> Result<Arc<ClassHash>> {
         unimplemented!();
     }
 }


### PR DESCRIPTION
We use `Arc` for two reasons:
* Multiple ownerships for the retrieved data: By whoever implements `StateReader` and in cache at the (yet to be implemented) `CachedState`.

* Each of the methods returns a reference to the retrieved value or a default (owned) value, a type that can be modeled with `Arc`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/39)
<!-- Reviewable:end -->
