### PR TITLE
Stop using unmaintained `action-rs/toolchain`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
           toolchain: nightly-2022-11-03
@@ -40,12 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        name: "Rust Toolchain Setup"
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly-2022-11-03
-          override: true
+        name: "Rust Toolchain Setup"
       - uses: actions/cache@v3
         name: "Cache Setup"
         id: "cache-cargo"


### PR DESCRIPTION
Use `dtolnay/rust-toolchain`, which is more maintained. Other repos have made this step as well: https://github.com/PyO3/pyo3/pull/2720. Also, we are already partially using this in Cairo.

The removed `with:` steps are the defaults in rust-toolchain except for
the "toolchain: " one, which is embedded in the uses statement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/64)
<!-- Reviewable:end -->
