### PR TITLE
Use rust cache instead of vanilla github cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           components: rustfmt
           toolchain: nightly-2022-11-03
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: cargo +nightly-2022-11-03 fmt --all -- --check
 
   run-tests:
@@ -30,7 +30,7 @@ jobs:
         with:
           components: rustfmt
           toolchain: nightly-2022-11-03
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
@@ -44,24 +44,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master
+        name: "Rust Toolchain Setup"
         with:
           toolchain: nightly-2022-11-03
-        name: "Rust Toolchain Setup"
-      - uses: actions/cache@v3
-        name: "Cache Setup"
+      - uses: Swatinem/rust-cache@v2
         id: "cache-cargo"
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - if: ${{ steps.cache-cargo.outputs.cache-hit != 'true' }}
-        run:
-          wget https://github.com/est31/cargo-udeps/releases/download/v0.1.30/cargo-udeps-v0.1.30-x86_64-unknown-linux-gnu.tar.gz;
-          tar -xzf cargo-udeps-v0.1.30-x86_64-unknown-linux-gnu.tar.gz;
-          cargo-udeps-v0.1.30-x86_64-unknown-linux-gnu/cargo-udeps udeps
+        name: "Download and run cargo-udeps"
+        run: |
+          wget -O - -c https://github.com/est31/cargo-udeps/releases/download/v0.1.35/cargo-udeps-v0.1.35-x86_64-unknown-linux-gnu.tar.gz | tar -xz
+          cargo-udeps-*/cargo-udeps udeps
         env:
           RUSTUP_TOOLCHAIN: nightly-2022-11-03
 
@@ -73,5 +65,5 @@ jobs:
         with:
           components: clippy
           toolchain: stable
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets --all-features


### PR DESCRIPTION
Taken from Cairo's ci.yml.

Actions/cache is github's default cache for github actions, which is why it needed a bunch of manual stuff.

Swatinem/rust-cache is a widely used rust-cache for github, which already knows how to do these things.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/65)
<!-- Reviewable:end -->
