### PR TITLE
Use `StateResult` in all `CachedState` methods.

### DIFF
--- a/blockifier/src/cached_state_test.rs
+++ b/blockifier/src/cached_state_test.rs
@@ -2,27 +2,27 @@ use std::collections::HashMap;
 
 use assert_matches::assert_matches;
 use pretty_assertions::assert_eq;
+use starknet_api::core::PatriciaKey;
 use starknet_api::hash::StarkHash;
-use starknet_api::shash;
+use starknet_api::{patky, shash};
 
 use super::*;
 
 #[test]
-fn get_uninitialized_storage_value() -> Result<()> {
+fn get_uninitialized_storage_value() {
     let mut state: CachedState<DictStateReader> = CachedState::default();
-    let contract_address = ContractAddress::try_from(shash!("0x1"))?;
-    let key = StorageKey::try_from(shash!("0x10"))?;
+    let contract_address = ContractAddress(patky!("0x1"));
+    let key = StorageKey(patky!("0x10"));
 
     assert_eq!(*state.get_storage_at(contract_address, key).unwrap(), StarkFelt::default());
-    Ok(())
 }
 
 #[test]
-fn get_and_set_storage_value() -> Result<()> {
-    let contract_address0 = ContractAddress::try_from(shash!("0x100"))?;
-    let contract_address1 = ContractAddress::try_from(shash!("0x200"))?;
-    let key0 = StorageKey::try_from(shash!("0x10"))?;
-    let key1 = StorageKey::try_from(shash!("0x20"))?;
+fn get_and_set_storage_value() {
+    let contract_address0 = ContractAddress(patky!("0x100"));
+    let contract_address1 = ContractAddress(patky!("0x200"));
+    let key0 = StorageKey(patky!("0x10"));
+    let key1 = StorageKey(patky!("0x20"));
     let storage_val0: StarkFelt = shash!("0x1");
     let storage_val1: StarkFelt = shash!("0x5");
 
@@ -45,22 +45,20 @@ fn get_and_set_storage_value() -> Result<()> {
     state.set_storage_at(contract_address1, key1, modified_storage_value1);
     assert_eq!(*state.get_storage_at(contract_address0, key0).unwrap(), modified_storage_value0);
     assert_eq!(*state.get_storage_at(contract_address1, key1).unwrap(), modified_storage_value1);
-    Ok(())
 }
 
 #[test]
-fn get_uninitialized_value() -> Result<()> {
+fn get_uninitialized_value() {
     let mut state = CachedState::new(DictStateReader::default());
-    let contract_address = ContractAddress::try_from(shash!("0x1"))?;
+    let contract_address = ContractAddress(patky!("0x1"));
 
     assert_eq!(*state.get_nonce_at(contract_address).unwrap(), Nonce::default());
-    Ok(())
 }
 
 #[test]
-fn get_and_increment_nonce() -> Result<()> {
-    let contract_address1 = ContractAddress::try_from(shash!("0x100"))?;
-    let contract_address2 = ContractAddress::try_from(shash!("0x200"))?;
+fn get_and_increment_nonce() {
+    let contract_address1 = ContractAddress(patky!("0x100"));
+    let contract_address2 = ContractAddress(patky!("0x200"));
     let initial_nonce = Nonce(shash!("0x1"));
 
     let mut state = CachedState::new(DictStateReader {
@@ -73,26 +71,24 @@ fn get_and_increment_nonce() -> Result<()> {
     assert_eq!(*state.get_nonce_at(contract_address1).unwrap(), initial_nonce);
     assert_eq!(*state.get_nonce_at(contract_address2).unwrap(), initial_nonce);
 
-    state.increment_nonce(contract_address1)?;
+    assert!(state.increment_nonce(contract_address1).is_ok());
     let nonce1_plus_one = Nonce(shash!("0x2"));
     assert_eq!(*state.get_nonce_at(contract_address1).unwrap(), nonce1_plus_one);
     assert_eq!(*state.get_nonce_at(contract_address2).unwrap(), initial_nonce);
 
-    state.increment_nonce(contract_address1)?;
+    assert!(state.increment_nonce(contract_address1).is_ok());
     let nonce1_plus_two = Nonce(shash!("0x3"));
     assert_eq!(*state.get_nonce_at(contract_address1).unwrap(), nonce1_plus_two);
     assert_eq!(*state.get_nonce_at(contract_address2).unwrap(), initial_nonce);
 
-    state.increment_nonce(contract_address2)?;
+    assert!(state.increment_nonce(contract_address2).is_ok());
     let nonce2_plus_one = Nonce(shash!("0x2"));
     assert_eq!(*state.get_nonce_at(contract_address1).unwrap(), nonce1_plus_two);
     assert_eq!(*state.get_nonce_at(contract_address2).unwrap(), nonce2_plus_one);
-
-    Ok(())
 }
 
 #[test]
-fn get_contract_class() -> Result<()> {
+fn get_contract_class() {
     // Positive flow.
     let existing_class_hash = ClassHash(shash!("0x100"));
     let contract_class = ContractClass::default();
@@ -107,8 +103,8 @@ fn get_contract_class() -> Result<()> {
 
     // Negative flow.
     let missing_class_hash = ClassHash(shash!("0x101"));
-    assert_matches!(state.get_contract_class(&missing_class_hash),
-    Err(StateReaderError::UndeclaredClassHash(class_hash)) if class_hash == missing_class_hash);
-
-    Ok(())
+    assert_matches!(
+        state.get_contract_class(&missing_class_hash).unwrap_err(),
+        StateError::StateReaderError(StateReaderError::UndeclaredClassHash(undeclared)) if undeclared == missing_class_hash
+    );
 }

--- a/blockifier/src/execution/errors.rs
+++ b/blockifier/src/execution/errors.rs
@@ -4,7 +4,7 @@ use starknet_api::core::EntryPointSelector;
 use starknet_api::StarknetApiError;
 use thiserror::Error;
 
-use crate::state::errors::StateReaderError;
+use crate::state::errors::StateError;
 
 #[derive(Debug, Error)]
 pub enum PreExecutionError {
@@ -15,7 +15,7 @@ pub enum PreExecutionError {
     #[error(transparent)]
     RunnerError(Box<cairo_rs_vm_errors::runner_errors::RunnerError>),
     #[error(transparent)]
-    StateReaderError(#[from] StateReaderError),
+    StateError(#[from] StateError),
 }
 
 impl From<cairo_rs_vm_errors::runner_errors::RunnerError> for PreExecutionError {

--- a/blockifier/src/state/errors.rs
+++ b/blockifier/src/state/errors.rs
@@ -1,4 +1,5 @@
 use starknet_api::core::{ClassHash, ContractAddress};
+use starknet_api::StarknetApiError;
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -11,12 +12,16 @@ pub enum StateReaderError {
     ReadError(String),
 }
 
-#[derive(Error, Debug, PartialEq, Eq)]
+// TODO(Gilad, 1/12/2022): Derive partialeq/eq in StarknetApiError (or document why that shouldn't
+// be done), then derive them here as well.
+#[derive(Error, Debug)]
 pub enum StateError {
     #[error("Cannot deploy contract at address 0.")]
     OutOfRangeContractAddress,
     #[error("Requested {0:?} is unavailable for deployment.")]
     UnavailableContractAddress(ContractAddress),
+    #[error(transparent)]
+    StarknetApiError(#[from] StarknetApiError),
     #[error(transparent)]
     StateReaderError(#[from] StateReaderError),
 }


### PR DESCRIPTION
- deprecate `anyhow` in `cached_state` module.
- use `patky` in tests (shorter without `Result`s).
- The `u64` cast uses unwrap because the API of `bytes()` needs to return a more useful type, which contains the actual size of the size. Users can then narrow this down to smaller types with `from` instead of `try_from`.
- Add `StarknetApiError` to `StateError` (becuase of the `nonce_try_from_u64`)
- increment_nonce test now needs `is_ok` because the returned result is not `anyhow`, therefore should not be ignored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/79)
<!-- Reviewable:end -->
