### PR TITLE
Add `derive_more`, `indexmap` and add statediff storage cached_state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,8 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "cairo-rs",
+ "derive_more",
+ "indexmap",
  "num-bigint",
  "num-traits",
  "pretty_assertions",

--- a/blockifier/Cargo.toml
+++ b/blockifier/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.66"
 cairo-rs =  { git = "https://github.com/lambdaclass/cairo-rs.git" } # This is how they instructed to use their package.
+derive_more = {version = "0.99.17"}
+indexmap = { version = "1.9.2" }
 num-bigint = "0.4"
 num-traits = "0.2"
 serde = { version = "1.0.130", features = ["derive"] }

--- a/blockifier/src/state/cached_state.rs
+++ b/blockifier/src/state/cached_state.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use derive_more::IntoIterator;
+use indexmap::IndexMap;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
@@ -171,6 +173,26 @@ impl StateReader for DictStateReader {
         let class_hash =
             self.address_to_class_hash.get(&contract_address).copied().unwrap_or_default();
         Ok(class_hash)
+    }
+}
+
+#[derive(IntoIterator, Debug, Clone, Default)]
+pub struct StorageView(HashMap<ContractStorageKey, StarkFelt>);
+
+/// Converts a `CachedState`'s storage mapping into a `StateDiff`'s storage mapping.
+impl From<StorageView> for IndexMap<ContractAddress, IndexMap<StorageKey, StarkFelt>> {
+    fn from(storage_view: StorageView) -> Self {
+        let mut storage_updates = Self::new();
+        for ((address, key), value) in storage_view.into_iter() {
+            storage_updates
+                .entry(address)
+                .and_modify(|map| {
+                    map.insert(key, value);
+                })
+                .or_insert_with(|| IndexMap::from([(key, value)]));
+        }
+
+        storage_updates
     }
 }
 


### PR DESCRIPTION
This is an analogue to Python's `to_state_diff_storage_mapping`, which maps `CachedState`'s `storage_view` mapping into the type used by `StateDiff`.

In Rust it makes more sense to make this a `From` cast.

Indexmap is needed since that's the type of StateDiff in StarknetApi.

`derive_more` makes the wrapper behave more nicely.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/99)
<!-- Reviewable:end -->
