### PR TITLE
Import `subtract_mappings` util from Python

### DIFF
--- a/blockifier/src/lib.rs
+++ b/blockifier/src/lib.rs
@@ -2,3 +2,4 @@ pub mod execution;
 pub mod state;
 pub mod test_utils;
 pub mod transaction;
+pub mod utils;

--- a/blockifier/src/utils.rs
+++ b/blockifier/src/utils.rs
@@ -1,0 +1,16 @@
+use std::collections::HashMap;
+
+#[cfg(test)]
+#[path = "utils_test.rs"]
+pub mod test;
+
+/// Returns a `HashMap` containing key-value pairs from `a` that are not included in `b` (if
+/// a key appears in `b` with a different value, it will be part of the output).
+/// Usage: Get updated items from a mapping.
+pub fn subtract_mappings<K, V>(lhs: &HashMap<K, V>, rhs: &HashMap<K, V>) -> HashMap<K, V>
+where
+    K: Clone + Eq + std::hash::Hash,
+    V: Clone + PartialEq,
+{
+    lhs.iter().filter(|(k, v)| rhs.get(k) != Some(v)).map(|(k, v)| (k.clone(), v.clone())).collect()
+}

--- a/blockifier/src/utils_test.rs
+++ b/blockifier/src/utils_test.rs
@@ -1,0 +1,20 @@
+use std::collections::HashMap;
+
+use pretty_assertions::assert_eq;
+
+use crate::utils::subtract_mappings;
+
+#[test]
+fn test_subtract_mappings() {
+    let not_empty = HashMap::from([("foo", "bar")]);
+    let empty = HashMap::default();
+
+    assert_eq!(empty, subtract_mappings(&empty, &not_empty));
+    assert_eq!(not_empty, subtract_mappings(&not_empty, &empty));
+
+    let map1 = HashMap::from([("red", 1), ("green", 2), ("blue", 3)]);
+    let map2 = HashMap::from([("yellow", 1), ("green", 2), ("blue", 4)]);
+
+    let expected = HashMap::from([("red", 1), ("blue", 3)]);
+    assert_eq!(expected, subtract_mappings(&map1, &map2));
+}


### PR DESCRIPTION
Will be used soon in the contruction of `StateDiff` from `CachedState`.

Template bounds: Hash and Eq are HashMap boilerplate, and `V:
PartialEq` is for the comparison inside `retain`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/102)
<!-- Reviewable:end -->
