### PR TITLE
Remove unnecessary `mut` from `state` in initialize_syscall_handler

### DIFF
--- a/blockifier/src/execution/syscall_handling.rs
+++ b/blockifier/src/execution/syscall_handling.rs
@@ -125,7 +125,7 @@ pub fn add_syscall_hints(hint_processor: &mut BuiltinHintProcessor) {
 pub fn initialize_syscall_handler(
     cairo_runner: &mut CairoRunner,
     vm: &mut VirtualMachine,
-    state: &mut CachedState<DictStateReader>,
+    state: &CachedState<DictStateReader>,
     call_entry_point: &CallEntryPoint,
 ) -> (Relocatable, BuiltinHintProcessor) {
     let syscall_segment = vm.add_memory_segment();


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/108)
<!-- Reviewable:end -->
