### PR TITLE
state-reader trait definition fix

### DIFF
--- a/blockifier/src/state/state_reader.rs
+++ b/blockifier/src/state/state_reader.rs
@@ -1,6 +1,5 @@
 use std::rc::Rc;
 
-use anyhow::Result;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
@@ -27,12 +26,8 @@ pub trait StateReader {
 
     /// Returns the class hash of the contract class at the given contract instance.
     /// Default: 0 (uninitialized class hash) for an uninitialized contract address.
-    fn get_class_hash_at(
-        &self,
-        _contract_address: ContractAddress,
-    ) -> StateReaderResult<ClassHash> {
-        unimplemented!();
-    }
+    fn get_class_hash_at(&self, _contract_address: ContractAddress)
+    -> StateReaderResult<ClassHash>;
 
     /// Returns the contract class of the given class hash.
     fn get_contract_class(&self, class_hash: &ClassHash) -> StateReaderResult<Rc<ContractClass>>;


### PR DESCRIPTION
* `unimplemented!` no longer necessary, it was only relevant for when we hadn't had a full state-reader implementation.
* `anyhow` not used in this module, can be removed (i guess `clippy` doesn't catch `anyhow`?)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/109)
<!-- Reviewable:end -->
