### PR TITLE
Remove `Rc` from `StateReader`

### DIFF
--- a/blockifier/src/execution/execution_utils.rs
+++ b/blockifier/src/execution/execution_utils.rs
@@ -60,6 +60,9 @@ pub fn initialize_execution_context<'a>(
     // TODO(Noa, 18/12/22): Remove. Change state to be mutable.
     let contract_class = state.get_contract_class(&call_entry_point.class_hash)?;
 
+    // Resolve initial PC from EP indicator.
+    let entry_point_pc = call_entry_point.resolve_entry_point_pc(contract_class)?;
+
     // Instantiate Cairo runner.
     let program = convert_program_to_cairo_runner_format(&contract_class.program)?;
     let mut cairo_runner = CairoRunner::new(&program, "all", false)?;
@@ -68,9 +71,6 @@ pub fn initialize_execution_context<'a>(
     cairo_runner.initialize_segments(&mut vm, None);
     let (syscall_segment, syscall_handler) =
         initialize_syscall_handler(&mut vm, state, call_entry_point);
-
-    // Resolve initial PC from EP indicator.
-    let entry_point_pc = call_entry_point.resolve_entry_point_pc(&contract_class)?;
 
     Ok(ExecutionContext {
         runner: cairo_runner,

--- a/blockifier/src/state/state_reader.rs
+++ b/blockifier/src/state/state_reader.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
@@ -30,5 +28,5 @@ pub trait StateReader {
     -> StateReaderResult<ClassHash>;
 
     /// Returns the contract class of the given class hash.
-    fn get_contract_class(&self, class_hash: &ClassHash) -> StateReaderResult<Rc<ContractClass>>;
+    fn get_contract_class(&self, class_hash: &ClassHash) -> StateReaderResult<ContractClass>;
 }

--- a/blockifier/src/test_utils.rs
+++ b/blockifier/src/test_utils.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::rc::Rc;
 
 use starknet_api::core::{ClassHash, ContractAddress, PatriciaKey};
 use starknet_api::hash::StarkHash;
@@ -56,7 +55,7 @@ pub fn get_test_contract_class() -> ContractClass {
 
 pub fn create_test_state() -> CachedState<DictStateReader> {
     let class_hash_to_class =
-        HashMap::from([(ClassHash(shash!(TEST_CLASS_HASH)), Rc::new(get_test_contract_class()))]);
+        HashMap::from([(ClassHash(shash!(TEST_CLASS_HASH)), get_test_contract_class())]);
     let address_to_class_hash = HashMap::from([(
         ContractAddress(patky!(TEST_CONTRACT_ADDRESS)),
         ClassHash(shash!(TEST_CLASS_HASH)),
@@ -71,7 +70,7 @@ pub fn create_test_state() -> CachedState<DictStateReader> {
 pub fn create_security_test_state() -> CachedState<DictStateReader> {
     let class_hash_to_class = HashMap::from([(
         ClassHash(shash!(TEST_CLASS_HASH)),
-        Rc::new(get_contract_class(SECURITY_TEST_CONTRACT_PATH)),
+        get_contract_class(SECURITY_TEST_CONTRACT_PATH),
     )]);
     CachedState::new(DictStateReader { class_hash_to_class, ..Default::default() })
 }

--- a/blockifier/src/transaction/invoke_transaction_test.rs
+++ b/blockifier/src/transaction/invoke_transaction_test.rs
@@ -29,7 +29,7 @@ use crate::transaction::ExecuteTransaction;
 fn create_test_state() -> CachedState<DictStateReader> {
     let class_hash_to_class = HashMap::from([(
         ClassHash(shash!(TEST_ACCOUNT_CONTRACT_CLASS_HASH)),
-        Rc::new(get_contract_class(ACCOUNT_CONTRACT_PATH)),
+        get_contract_class(ACCOUNT_CONTRACT_PATH),
     )]);
     CachedState::new(DictStateReader { class_hash_to_class, ..Default::default() })
 }


### PR DESCRIPTION
Even though `Rc` has better performance when cloning `ContractClass`,
this doesn't make sense for db-centric implementations of
`StateReader`, which don't typically own the data they return.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/110)
<!-- Reviewable:end -->
