### PR TITLE
Revert `b263efc`

### DIFF
--- a/blockifier/src/execution/syscall_handling.rs
+++ b/blockifier/src/execution/syscall_handling.rs
@@ -125,7 +125,7 @@ pub fn add_syscall_hints(hint_processor: &mut BuiltinHintProcessor) {
 pub fn initialize_syscall_handler(
     cairo_runner: &mut CairoRunner,
     vm: &mut VirtualMachine,
-    state: &CachedState<DictStateReader>,
+    state: &mut CachedState<DictStateReader>, // `mut` will be used soon here, don't remove.
     call_entry_point: &CallEntryPoint,
 ) -> (Relocatable, BuiltinHintProcessor) {
     let syscall_segment = vm.add_memory_segment();


### PR DESCRIPTION
While the `mut` isn't necessary right now, it will be soon so we keep it here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/112)
<!-- Reviewable:end -->
