### PR TITLE
Add `StateDiff::from(CachedState)`

### DIFF
--- a/blockifier/src/state/cached_state.rs
+++ b/blockifier/src/state/cached_state.rs
@@ -4,11 +4,12 @@ use derive_more::IntoIterator;
 use indexmap::IndexMap;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
-use starknet_api::state::StorageKey;
+use starknet_api::state::{StateDiff, StorageKey};
 
 use crate::execution::contract_class::ContractClass;
 use crate::state::errors::{StateError, StateReaderError};
 use crate::state::state_reader::{StateReader, StateReaderResult};
+use crate::utils::subtract_mappings;
 
 #[cfg(test)]
 #[path = "cached_state_test.rs"]
@@ -129,6 +130,38 @@ impl<SR: StateReader> CachedState<SR> {
 
         self.cache.set_class_hash_write(contract_address, class_hash);
         Ok(())
+    }
+}
+
+impl<SR: StateReader> From<CachedState<SR>> for StateDiff {
+    fn from(cached_state: CachedState<SR>) -> Self {
+        type ContractClassApi = starknet_api::state::ContractClass;
+        type StorageDiff = IndexMap<ContractAddress, IndexMap<StorageKey, StarkFelt>>;
+
+        let state_cache = cached_state.cache;
+
+        // Contract instance attributes.
+        let deployed_contracts = subtract_mappings(
+            &state_cache.class_hash_writes,
+            &state_cache.class_hash_initial_values,
+        );
+        let storage_diffs =
+            subtract_mappings(&state_cache.storage_writes, &state_cache.storage_initial_values);
+        let nonces =
+            subtract_mappings(&state_cache.nonce_writes, &state_cache.nonce_initial_values);
+
+        // Contract class attributes.
+        let mut declared_classes: IndexMap<ClassHash, ContractClassApi> = IndexMap::new();
+        for (class_hash, contract_class) in cached_state.class_hash_to_class {
+            declared_classes.insert(class_hash, ContractClassApi::from(contract_class));
+        }
+
+        Self {
+            deployed_contracts: IndexMap::from_iter(deployed_contracts),
+            storage_diffs: StorageDiff::from(StorageView(storage_diffs)),
+            declared_classes,
+            nonces: IndexMap::from_iter(nonces),
+        }
     }
 }
 


### PR DESCRIPTION
- Declared classes need to convert our `ContractClass` into `starknet_api::state::contract_class`.
- The storage mapping in `StateDiff` has a different structure, hence the cast through the newtype `StorageMapping`
- All `HashMap` are converted into `IndexMap`, which is what `StateDiff` uses.


Tests are in a separate PR: https://reviewable.io/reviews/starkware-libs/blockifier/116

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/117)
<!-- Reviewable:end -->
