### PR TITLE
Make `CachedState` work generically

### DIFF
--- a/blockifier/src/execution/entry_point.rs
+++ b/blockifier/src/execution/entry_point.rs
@@ -6,7 +6,8 @@ use starknet_api::transaction::{CallData, EventContent};
 use crate::execution::contract_class::ContractClass;
 use crate::execution::errors::{EntryPointExecutionError, PreExecutionError};
 use crate::execution::execution_utils::execute_entry_point_call;
-use crate::state::cached_state::{CachedState, DictStateReader};
+use crate::state::cached_state::CachedState;
+use crate::state::state_reader::StateReader;
 
 #[cfg(test)]
 #[path = "entry_point_test.rs"]
@@ -28,9 +29,9 @@ pub struct CallEntryPoint {
 }
 
 impl CallEntryPoint {
-    pub fn execute(
+    pub fn execute<SR: StateReader>(
         self,
-        state: &mut CachedState<DictStateReader>,
+        state: &mut CachedState<SR>,
     ) -> EntryPointExecutionResult<CallInfo> {
         execute_entry_point_call(self, state)
     }
@@ -65,8 +66,8 @@ pub struct CallInfo {
     pub events: Vec<EventContent>,
 }
 
-pub fn execute_constructor_entry_point(
-    state: &mut CachedState<DictStateReader>,
+pub fn execute_constructor_entry_point<SR: StateReader>(
+    state: &mut CachedState<SR>,
     class_hash: ClassHash,
     storage_address: ContractAddress,
     calldata: CallData,

--- a/blockifier/src/execution/syscall_handling.rs
+++ b/blockifier/src/execution/syscall_handling.rs
@@ -24,12 +24,13 @@ use crate::execution::execution_utils::{
 };
 use crate::execution::hint_code;
 use crate::execution::syscalls::{SyscallRequest, SyscallResult};
-use crate::state::cached_state::{CachedState, DictStateReader};
+use crate::state::cached_state::CachedState;
+use crate::state::state_reader::StateReader;
 
 /// Executes StarkNet syscalls (stateful protocol hints) during the execution of an EP call.
-pub struct SyscallHintProcessor<'a> {
+pub struct SyscallHintProcessor<'a, SR: StateReader> {
     // Input for execution.
-    pub state: &'a mut CachedState<DictStateReader>,
+    pub state: &'a mut CachedState<SR>,
     pub storage_address: ContractAddress,
     builtin_hint_processor: BuiltinHintProcessor,
 
@@ -42,10 +43,10 @@ pub struct SyscallHintProcessor<'a> {
     expected_syscall_ptr: Relocatable,
 }
 
-impl<'a> SyscallHintProcessor<'a> {
+impl<'a, SR: StateReader> SyscallHintProcessor<'a, SR> {
     pub fn new(
         initial_syscall_ptr: Relocatable,
-        state: &'a mut CachedState<DictStateReader>,
+        state: &'a mut CachedState<SR>,
         // TODO(AlonH, 21/12/2022): Consider referencing outer_call when lifetimes make it possible
         // (LambdaClass).
         storage_address: ContractAddress,
@@ -100,7 +101,7 @@ impl<'a> SyscallHintProcessor<'a> {
     }
 }
 
-impl HintProcessor for SyscallHintProcessor<'_> {
+impl<SR: StateReader> HintProcessor for SyscallHintProcessor<'_, SR> {
     fn execute_hint(
         &mut self,
         vm: &mut VirtualMachine,
@@ -129,11 +130,11 @@ impl HintProcessor for SyscallHintProcessor<'_> {
     }
 }
 
-pub fn initialize_syscall_handler<'a>(
+pub fn initialize_syscall_handler<'a, SR: StateReader>(
     vm: &mut VirtualMachine,
-    state: &'a mut CachedState<DictStateReader>,
+    state: &'a mut CachedState<SR>,
     call_entry_point: &CallEntryPoint,
-) -> (Relocatable, SyscallHintProcessor<'a>) {
+) -> (Relocatable, SyscallHintProcessor<'a, SR>) {
     let syscall_segment = vm.add_memory_segment();
     let syscall_handler =
         SyscallHintProcessor::new(syscall_segment, state, call_entry_point.storage_address);
@@ -198,9 +199,9 @@ pub fn read_call_params(
     Ok((function_selector, calldata))
 }
 
-pub fn execute_inner_call(
+pub fn execute_inner_call<SR: StateReader>(
     call_entry_point: CallEntryPoint,
-    syscall_handler: &mut SyscallHintProcessor<'_>,
+    syscall_handler: &mut SyscallHintProcessor<'_, SR>,
 ) -> SyscallResult<Vec<StarkFelt>> {
     let call_info = call_entry_point.execute(syscall_handler.state)?;
     let retdata = call_info.execution.retdata.clone();

--- a/blockifier/src/execution/syscalls.rs
+++ b/blockifier/src/execution/syscalls.rs
@@ -14,6 +14,7 @@ use crate::execution::syscall_handling::{
     execute_inner_call, felt_to_bool, read_call_params, read_calldata, write_retdata,
     SyscallHintProcessor,
 };
+use crate::state::state_reader::StateReader;
 
 pub type SyscallResult<T> = Result<T, SyscallExecutionError>;
 pub type ReadRequestResult = SyscallResult<SyscallRequest>;
@@ -54,7 +55,10 @@ impl StorageReadRequest {
         Ok(SyscallRequest::StorageRead(StorageReadRequest { address }))
     }
 
-    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
+    pub fn execute<SR: StateReader>(
+        self,
+        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
+    ) -> SyscallExecutionResult {
         let value =
             syscall_handler.state.get_storage_at(syscall_handler.storage_address, self.address)?;
         Ok(SyscallResponse::StorageRead(StorageReadResponse { value: *value }))
@@ -91,7 +95,10 @@ impl StorageWriteRequest {
         Ok(SyscallRequest::StorageWrite(StorageWriteRequest { address, value }))
     }
 
-    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
+    pub fn execute<SR: StateReader>(
+        self,
+        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
+    ) -> SyscallExecutionResult {
         syscall_handler.state.set_storage_at(
             syscall_handler.storage_address,
             self.address,
@@ -127,7 +134,10 @@ impl CallContractRequest {
         }))
     }
 
-    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
+    pub fn execute<SR: StateReader>(
+        self,
+        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
+    ) -> SyscallExecutionResult {
         let class_hash = *syscall_handler.state.get_class_hash_at(self.contract_address)?;
         let entry_point = CallEntryPoint {
             class_hash,
@@ -176,7 +186,10 @@ impl LibraryCallRequest {
         }))
     }
 
-    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
+    pub fn execute<SR: StateReader>(
+        self,
+        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
+    ) -> SyscallExecutionResult {
         let entry_point = CallEntryPoint {
             class_hash: self.class_hash,
             entry_point_type: EntryPointType::External,
@@ -220,7 +233,10 @@ impl DeployRequest {
         }))
     }
 
-    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
+    pub fn execute<SR: StateReader>(
+        self,
+        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
+    ) -> SyscallExecutionResult {
         let deployer_address = match self.deploy_from_zero {
             true => ContractAddress::default(),
             false => syscall_handler.storage_address,
@@ -282,7 +298,10 @@ impl EmitEventRequest {
         Ok(SyscallRequest::EmitEvent(EmitEventRequest { content }))
     }
 
-    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
+    pub fn execute<SR: StateReader>(
+        self,
+        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
+    ) -> SyscallExecutionResult {
         syscall_handler.events.push(self.content);
         Ok(SyscallResponse::EmitEvent(EmptyResponse))
     }
@@ -316,7 +335,10 @@ impl SyscallRequest {
         }
     }
 
-    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
+    pub fn execute<SR: StateReader>(
+        self,
+        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
+    ) -> SyscallExecutionResult {
         match self {
             SyscallRequest::CallContract(request) => request.execute(syscall_handler),
             SyscallRequest::Deploy(request) => request.execute(syscall_handler),

--- a/blockifier/src/transaction.rs
+++ b/blockifier/src/transaction.rs
@@ -4,12 +4,13 @@ pub mod invoke_transaction;
 pub mod objects;
 pub mod transaction_utils;
 
-use crate::state::cached_state::{CachedState, DictStateReader};
+use crate::state::cached_state::CachedState;
+use crate::state::state_reader::StateReader;
 use crate::transaction::objects::{TransactionExecutionInfo, TransactionExecutionResult};
 
-pub trait ExecuteTransaction {
+pub trait ExecuteTransaction<SR: StateReader> {
     fn execute(
         self,
-        state: &mut CachedState<DictStateReader>,
+        state: &mut CachedState<SR>,
     ) -> TransactionExecutionResult<TransactionExecutionInfo>;
 }

--- a/blockifier/src/transaction/invoke_transaction.rs
+++ b/blockifier/src/transaction/invoke_transaction.rs
@@ -5,7 +5,8 @@ use starknet_api::state::EntryPointType;
 use starknet_api::transaction::{Fee, InvokeTransaction};
 
 use crate::execution::entry_point::{CallEntryPoint, CallInfo};
-use crate::state::cached_state::{CachedState, DictStateReader};
+use crate::state::cached_state::CachedState;
+use crate::state::state_reader::StateReader;
 use crate::test_utils::TEST_ACCOUNT_CONTRACT_CLASS_HASH;
 use crate::transaction::constants::{EXECUTE_ENTRY_POINT_SELECTOR, VALIDATE_ENTRY_POINT_SELECTOR};
 use crate::transaction::objects::{
@@ -20,9 +21,9 @@ use crate::transaction::ExecuteTransaction;
 #[path = "invoke_transaction_test.rs"]
 mod test;
 
-pub fn validate_tx(
+pub fn validate_tx<SR: StateReader>(
     tx: &InvokeTransaction,
-    state: &mut CachedState<DictStateReader>,
+    state: &mut CachedState<SR>,
     class_hash: ClassHash,
 ) -> TransactionExecutionResult<CallInfo> {
     let validate_call = CallEntryPoint {
@@ -39,9 +40,9 @@ pub fn validate_tx(
     Ok(validate_call.execute(state)?)
 }
 
-pub fn execute_tx(
+pub fn execute_tx<SR: StateReader>(
     tx: &InvokeTransaction,
-    state: &mut CachedState<DictStateReader>,
+    state: &mut CachedState<SR>,
     class_hash: ClassHash,
 ) -> TransactionExecutionResult<CallInfo> {
     let execute_call = CallEntryPoint {
@@ -64,10 +65,10 @@ pub fn charge_fee(tx: InvokeTransaction) -> TransactionExecutionResult<(Fee, Cal
     Ok((actual_fee, fee_transfer_call_info))
 }
 
-impl ExecuteTransaction for InvokeTransaction {
+impl<SR: StateReader> ExecuteTransaction<SR> for InvokeTransaction {
     fn execute(
         self,
-        state: &mut CachedState<DictStateReader>,
+        state: &mut CachedState<SR>,
     ) -> TransactionExecutionResult<TransactionExecutionInfo> {
         // TODO(Adi, 10/12/2022): Consider moving the transaction version verification to the
         // TransactionVersion constructor.


### PR DESCRIPTION
Next step will be to make `CachedState` implement a `State` trait and do this again, this time with `state: State<SR>` instead of `state: CachedState<SR>`.

Tests still use `DictStateReader` as they require a concrete implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/119)
<!-- Reviewable:end -->
