### PR TITLE
Rename state-reader into state-api

### DIFF
--- a/blockifier/src/execution/entry_point.rs
+++ b/blockifier/src/execution/entry_point.rs
@@ -9,7 +9,7 @@ use crate::execution::contract_class::ContractClass;
 use crate::execution::errors::{EntryPointExecutionError, PreExecutionError};
 use crate::execution::execution_utils::execute_entry_point_call;
 use crate::state::cached_state::CachedState;
-use crate::state::state_reader::StateReader;
+use crate::state::state_api::StateReader;
 
 #[cfg(test)]
 #[path = "entry_point_test.rs"]

--- a/blockifier/src/execution/execution_utils.rs
+++ b/blockifier/src/execution/execution_utils.rs
@@ -25,7 +25,7 @@ use crate::execution::errors::{
 use crate::execution::syscall_handling::{initialize_syscall_handler, SyscallHintProcessor};
 use crate::general_errors::ConversionError;
 use crate::state::cached_state::CachedState;
-use crate::state::state_reader::StateReader;
+use crate::state::state_api::StateReader;
 
 #[cfg(test)]
 #[path = "execution_utils_test.rs"]

--- a/blockifier/src/execution/syscall_handling.rs
+++ b/blockifier/src/execution/syscall_handling.rs
@@ -25,7 +25,7 @@ use crate::execution::execution_utils::{
 use crate::execution::hint_code;
 use crate::execution::syscalls::{SyscallRequest, SyscallResult};
 use crate::state::cached_state::CachedState;
-use crate::state::state_reader::StateReader;
+use crate::state::state_api::StateReader;
 
 /// Executes StarkNet syscalls (stateful protocol hints) during the execution of an EP call.
 pub struct SyscallHintProcessor<'a, SR: StateReader> {

--- a/blockifier/src/execution/syscalls.rs
+++ b/blockifier/src/execution/syscalls.rs
@@ -15,7 +15,7 @@ use crate::execution::syscall_handling::{
     execute_inner_call, felt_to_bool, read_call_params, read_calldata, read_felt_array,
     write_retdata, SyscallHintProcessor,
 };
-use crate::state::state_reader::StateReader;
+use crate::state::state_api::StateReader;
 
 pub type SyscallResult<T> = Result<T, SyscallExecutionError>;
 pub type ReadRequestResult = SyscallResult<SyscallRequest>;

--- a/blockifier/src/state.rs
+++ b/blockifier/src/state.rs
@@ -1,3 +1,3 @@
 pub mod cached_state;
 pub mod errors;
-pub mod state_reader;
+pub mod state_api;

--- a/blockifier/src/state/cached_state.rs
+++ b/blockifier/src/state/cached_state.rs
@@ -8,7 +8,7 @@ use starknet_api::state::{StateDiff, StorageKey};
 
 use crate::execution::contract_class::ContractClass;
 use crate::state::errors::{StateError, StateReaderError};
-use crate::state::state_reader::{StateReader, StateReaderResult};
+use crate::state::state_api::{StateReader, StateReaderResult};
 use crate::utils::subtract_mappings;
 
 #[cfg(test)]

--- a/blockifier/src/state/state_api.rs
+++ b/blockifier/src/state/state_api.rs
@@ -24,8 +24,7 @@ pub trait StateReader {
 
     /// Returns the class hash of the contract class at the given contract instance.
     /// Default: 0 (uninitialized class hash) for an uninitialized contract address.
-    fn get_class_hash_at(&self, _contract_address: ContractAddress)
-    -> StateReaderResult<ClassHash>;
+    fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateReaderResult<ClassHash>;
 
     /// Returns the contract class of the given class hash.
     fn get_contract_class(&self, class_hash: &ClassHash) -> StateReaderResult<ContractClass>;

--- a/blockifier/src/transaction.rs
+++ b/blockifier/src/transaction.rs
@@ -5,7 +5,7 @@ pub mod objects;
 pub mod transaction_utils;
 
 use crate::state::cached_state::CachedState;
-use crate::state::state_reader::StateReader;
+use crate::state::state_api::StateReader;
 use crate::transaction::objects::{TransactionExecutionInfo, TransactionExecutionResult};
 
 pub trait ExecuteTransaction<SR: StateReader> {

--- a/blockifier/src/transaction/invoke_transaction.rs
+++ b/blockifier/src/transaction/invoke_transaction.rs
@@ -6,7 +6,7 @@ use starknet_api::transaction::{Fee, InvokeTransaction};
 
 use crate::execution::entry_point::{CallEntryPoint, CallInfo};
 use crate::state::cached_state::CachedState;
-use crate::state::state_reader::StateReader;
+use crate::state::state_api::StateReader;
 use crate::test_utils::TEST_ACCOUNT_CONTRACT_CLASS_HASH;
 use crate::transaction::constants::{EXECUTE_ENTRY_POINT_SELECTOR, VALIDATE_ENTRY_POINT_SELECTOR};
 use crate::transaction::objects::{


### PR DESCRIPTION
- rename to conform with Python and as a setup to addding `trait State`.
- fixed typo in `get_class_hash_at` variable, doesn't need a leading
  underscore.

commit-id:461c1762

---

**Stack**:
- #129
- #128
- #127 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/127)
<!-- Reviewable:end -->
