### PR TITLE
Add `State` trait

### DIFF
--- a/blockifier/src/execution/entry_point.rs
+++ b/blockifier/src/execution/entry_point.rs
@@ -9,7 +9,7 @@ use crate::execution::contract_class::ContractClass;
 use crate::execution::errors::{EntryPointExecutionError, PreExecutionError};
 use crate::execution::execution_utils::execute_entry_point_call;
 use crate::state::cached_state::CachedState;
-use crate::state::state_api::StateReader;
+use crate::state::state_api::{State, StateReader};
 
 #[cfg(test)]
 #[path = "entry_point_test.rs"]

--- a/blockifier/src/execution/entry_point_test.rs
+++ b/blockifier/src/execution/entry_point_test.rs
@@ -8,6 +8,7 @@ use starknet_api::transaction::Calldata;
 use crate::abi::abi_utils::get_selector_from_name;
 use crate::execution::entry_point::{CallEntryPoint, CallExecution, CallInfo, Retdata};
 use crate::state::cached_state::{CachedState, DictStateReader};
+use crate::state::state_api::State;
 use crate::test_utils::{
     create_security_test_state, create_test_state, BITWISE_AND_SELECTOR, RETURN_RESULT_SELECTOR,
     SQRT_SELECTOR, TEST_CALL_CONTRACT_SELECTOR, TEST_CLASS_HASH, TEST_CONTRACT_ADDRESS,

--- a/blockifier/src/execution/execution_utils.rs
+++ b/blockifier/src/execution/execution_utils.rs
@@ -25,7 +25,7 @@ use crate::execution::errors::{
 use crate::execution::syscall_handling::{initialize_syscall_handler, SyscallHintProcessor};
 use crate::general_errors::ConversionError;
 use crate::state::cached_state::CachedState;
-use crate::state::state_api::StateReader;
+use crate::state::state_api::{State, StateReader};
 
 #[cfg(test)]
 #[path = "execution_utils_test.rs"]

--- a/blockifier/src/execution/syscalls.rs
+++ b/blockifier/src/execution/syscalls.rs
@@ -15,7 +15,7 @@ use crate::execution::syscall_handling::{
     execute_inner_call, felt_to_bool, read_call_params, read_calldata, read_felt_array,
     write_retdata, SyscallHintProcessor,
 };
-use crate::state::state_api::StateReader;
+use crate::state::state_api::{State, StateReader};
 
 pub type SyscallResult<T> = Result<T, SyscallExecutionError>;
 pub type ReadRequestResult = SyscallResult<SyscallRequest>;

--- a/blockifier/src/state/cached_state.rs
+++ b/blockifier/src/state/cached_state.rs
@@ -8,14 +8,13 @@ use starknet_api::state::{StateDiff, StorageKey};
 
 use crate::execution::contract_class::ContractClass;
 use crate::state::errors::{StateError, StateReaderError};
-use crate::state::state_api::{StateReader, StateReaderResult};
+use crate::state::state_api::{State, StateReader, StateReaderResult, StateResult};
 use crate::utils::subtract_mappings;
 
 #[cfg(test)]
 #[path = "cached_state_test.rs"]
 mod test;
 
-pub type StateResult<T> = Result<T, StateError>;
 type ContractClassMapping = HashMap<ClassHash, ContractClass>;
 
 /// Caches read and write requests.
@@ -27,6 +26,7 @@ pub struct CachedState<SR: StateReader> {
     pub state_reader: SR,
     // Invariant: following attributes should remain private.
     cache: StateCache,
+    // Invariant: Read-only mapping
     class_hash_to_class: ContractClassMapping,
 }
 
@@ -34,8 +34,11 @@ impl<SR: StateReader> CachedState<SR> {
     pub fn new(state_reader: SR) -> Self {
         Self { state_reader, cache: StateCache::default(), class_hash_to_class: HashMap::default() }
     }
+}
 
-    pub fn get_storage_at(
+/// Refer to `StateReader` for documentation on the getter functions.
+impl<SR: StateReader> State for CachedState<SR> {
+    fn get_storage_at(
         &mut self,
         contract_address: ContractAddress,
         key: StorageKey,
@@ -51,16 +54,7 @@ impl<SR: StateReader> CachedState<SR> {
         Ok(value)
     }
 
-    pub fn set_storage_at(
-        &mut self,
-        contract_address: ContractAddress,
-        key: StorageKey,
-        value: StarkFelt,
-    ) {
-        self.cache.set_storage_value(contract_address, key, value);
-    }
-
-    pub fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<&Nonce> {
+    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<&Nonce> {
         if self.cache.get_nonce_at(contract_address).is_none() {
             let nonce = self.state_reader.get_nonce_at(contract_address)?;
             self.cache.set_nonce_initial_value(contract_address, nonce);
@@ -73,19 +67,7 @@ impl<SR: StateReader> CachedState<SR> {
         Ok(nonce)
     }
 
-    // TODO(Gilad, 1/12/22) consider moving some this logic into starknet-api; Nonce should
-    // be able to increment itself.
-    pub fn increment_nonce(&mut self, contract_address: ContractAddress) -> StateResult<()> {
-        let current_nonce = *self.get_nonce_at(contract_address)?;
-        let current_nonce_as_u64 = usize::try_from(current_nonce.0)? as u64;
-        let next_nonce_val = 1_u64 + current_nonce_as_u64;
-        let next_nonce = Nonce(StarkFelt::from(next_nonce_val));
-        self.cache.set_nonce_value(contract_address, next_nonce);
-
-        Ok(())
-    }
-
-    pub fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<&ContractClass> {
+    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<&ContractClass> {
         if !self.class_hash_to_class.contains_key(class_hash) {
             let contract_class = self.state_reader.get_contract_class(class_hash)?;
             self.class_hash_to_class.insert(*class_hash, contract_class);
@@ -98,10 +80,7 @@ impl<SR: StateReader> CachedState<SR> {
         Ok(contract_class)
     }
 
-    pub fn get_class_hash_at(
-        &mut self,
-        contract_address: ContractAddress,
-    ) -> StateResult<&ClassHash> {
+    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<&ClassHash> {
         if self.cache.get_class_hash_at(contract_address).is_none() {
             let class_hash = self.state_reader.get_class_hash_at(contract_address)?;
             self.cache.set_class_hash_initial_value(contract_address, class_hash);
@@ -114,7 +93,28 @@ impl<SR: StateReader> CachedState<SR> {
         Ok(class_hash)
     }
 
-    pub fn set_class_hash_at(
+    fn set_storage_at(
+        &mut self,
+        contract_address: ContractAddress,
+        key: StorageKey,
+        value: StarkFelt,
+    ) {
+        self.cache.set_storage_value(contract_address, key, value);
+    }
+
+    // TODO(Gilad, 1/12/22) consider moving some this logic into starknet-api; Nonce should
+    // be able to increment itself.
+    fn increment_nonce(&mut self, contract_address: ContractAddress) -> StateResult<()> {
+        let current_nonce = *self.get_nonce_at(contract_address)?;
+        let current_nonce_as_u64 = usize::try_from(current_nonce.0)? as u64;
+        let next_nonce_val = 1_u64 + current_nonce_as_u64;
+        let next_nonce = Nonce(StarkFelt::from(next_nonce_val));
+        self.cache.set_nonce_value(contract_address, next_nonce);
+
+        Ok(())
+    }
+
+    fn set_class_hash_at(
         &mut self,
         contract_address: ContractAddress,
         class_hash: ClassHash,

--- a/blockifier/src/state/state_api.rs
+++ b/blockifier/src/state/state_api.rs
@@ -2,9 +2,10 @@ use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 
-use super::errors::StateReaderError;
 use crate::execution::contract_class::ContractClass;
+use crate::state::errors::{StateError, StateReaderError};
 
+pub type StateResult<T> = Result<T, StateError>;
 pub type StateReaderResult<T> = Result<T, StateReaderError>;
 
 /// A read-only API for accessing StarkNet global state.
@@ -28,4 +29,42 @@ pub trait StateReader {
 
     /// Returns the contract class of the given class hash.
     fn get_contract_class(&self, class_hash: &ClassHash) -> StateReaderResult<ContractClass>;
+}
+
+/// A class defining the API for writing to StarkNet global state.
+
+/// Reader functionality should be delegated to the associated type; which is passed in by
+/// dependency-injection.
+pub trait State {
+    fn get_storage_at(
+        &mut self,
+        contract_address: ContractAddress,
+        key: StorageKey,
+    ) -> StateResult<&StarkFelt>;
+
+    /// Sets the storage value under the given key in the given contract instance.
+    fn set_storage_at(
+        &mut self,
+        contract_address: ContractAddress,
+        key: StorageKey,
+        value: StarkFelt,
+    );
+
+    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<&Nonce>;
+
+    /// Increments the nonce of the given contract instance.
+    fn increment_nonce(&mut self, contract_address: ContractAddress) -> StateResult<()>;
+
+    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<&ClassHash>;
+
+    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<&ContractClass>;
+
+    // Allocates the given address to the given class hash.
+    // Raises an exception if the address is already assigned;
+    // meaning: this is a write once action.
+    fn set_class_hash_at(
+        &mut self,
+        contract_address: ContractAddress,
+        class_hash: ClassHash,
+    ) -> StateResult<()>;
 }


### PR DESCRIPTION
- Like the similar trait in Python, this trait encapsulates read/write
actions to the state (note that read methods have a different signature
from those in `StateReader`).

- Reader functionality should be implemented by the associated type, and dependency-injected.

- Also moved `StateResult` into state-api.rs

- In a subsequent PR we'll change all `CachedState<SR>` type bound to just
`State`.

---

**Stack**:
- #129
- #128 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/128)
<!-- Reviewable:end -->
