### PR TITLE
Use `State` instead of `CachedState`

### DIFF
--- a/blockifier/src/execution/entry_point.rs
+++ b/blockifier/src/execution/entry_point.rs
@@ -8,8 +8,7 @@ use starknet_api::transaction::{Calldata, EventContent, MessageToL1};
 use crate::execution::contract_class::ContractClass;
 use crate::execution::errors::{EntryPointExecutionError, PreExecutionError};
 use crate::execution::execution_utils::execute_entry_point_call;
-use crate::state::cached_state::CachedState;
-use crate::state::state_api::{State, StateReader};
+use crate::state::state_api::State;
 
 #[cfg(test)]
 #[path = "entry_point_test.rs"]
@@ -32,10 +31,7 @@ pub struct CallEntryPoint {
 }
 
 impl CallEntryPoint {
-    pub fn execute<SR: StateReader>(
-        self,
-        state: &mut CachedState<SR>,
-    ) -> EntryPointExecutionResult<CallInfo> {
+    pub fn execute(self, state: &mut dyn State) -> EntryPointExecutionResult<CallInfo> {
         execute_entry_point_call(self, state)
     }
 
@@ -73,8 +69,8 @@ pub struct CallInfo {
     pub l2_to_l1_messages: Vec<MessageToL1>,
 }
 
-pub fn execute_constructor_entry_point<SR: StateReader>(
-    state: &mut CachedState<SR>,
+pub fn execute_constructor_entry_point(
+    state: &mut dyn State,
     class_hash: ClassHash,
     storage_address: ContractAddress,
     caller_address: ContractAddress,

--- a/blockifier/src/execution/syscalls.rs
+++ b/blockifier/src/execution/syscalls.rs
@@ -15,7 +15,6 @@ use crate::execution::syscall_handling::{
     execute_inner_call, felt_to_bool, read_call_params, read_calldata, read_felt_array,
     write_retdata, SyscallHintProcessor,
 };
-use crate::state::state_api::{State, StateReader};
 
 pub type SyscallResult<T> = Result<T, SyscallExecutionError>;
 pub type ReadRequestResult = SyscallResult<SyscallRequest>;
@@ -65,10 +64,7 @@ impl StorageReadRequest {
         Ok(SyscallRequest::StorageRead(StorageReadRequest { address }))
     }
 
-    pub fn execute<SR: StateReader>(
-        self,
-        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
-    ) -> SyscallExecutionResult {
+    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
         let value =
             syscall_handler.state.get_storage_at(syscall_handler.storage_address, self.address)?;
         Ok(SyscallResponse::StorageRead(StorageReadResponse { value: *value }))
@@ -107,10 +103,7 @@ impl StorageWriteRequest {
         Ok(SyscallRequest::StorageWrite(StorageWriteRequest { address, value }))
     }
 
-    pub fn execute<SR: StateReader>(
-        self,
-        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
-    ) -> SyscallExecutionResult {
+    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
         syscall_handler.state.set_storage_at(
             syscall_handler.storage_address,
             self.address,
@@ -146,10 +139,7 @@ impl CallContractRequest {
         }))
     }
 
-    pub fn execute<SR: StateReader>(
-        self,
-        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
-    ) -> SyscallExecutionResult {
+    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
         let class_hash = *syscall_handler.state.get_class_hash_at(self.contract_address)?;
         let entry_point = CallEntryPoint {
             class_hash,
@@ -201,10 +191,7 @@ impl LibraryCallRequest {
         }))
     }
 
-    pub fn execute<SR: StateReader>(
-        self,
-        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
-    ) -> SyscallExecutionResult {
+    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
         let entry_point = CallEntryPoint {
             class_hash: self.class_hash,
             entry_point_type: EntryPointType::External,
@@ -252,10 +239,7 @@ impl DeployRequest {
         }))
     }
 
-    pub fn execute<SR: StateReader>(
-        self,
-        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
-    ) -> SyscallExecutionResult {
+    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
         let deployer_address = syscall_handler.storage_address;
         let deployer_address_for_calculation = match self.deploy_from_zero {
             true => ContractAddress::default(),
@@ -321,10 +305,7 @@ impl EmitEventRequest {
         Ok(SyscallRequest::EmitEvent(EmitEventRequest { content }))
     }
 
-    pub fn execute<SR: StateReader>(
-        self,
-        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
-    ) -> SyscallExecutionResult {
+    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
         syscall_handler.events.push(self.content);
         Ok(SyscallResponse::EmitEvent(EmptyResponse))
     }
@@ -351,10 +332,7 @@ impl SendMessageToL1Request {
         Ok(SyscallRequest::SendMessageToL1(SendMessageToL1Request { message }))
     }
 
-    pub fn execute<SR: StateReader>(
-        self,
-        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
-    ) -> SyscallExecutionResult {
+    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
         syscall_handler.l2_to_l1_messages.push(self.message);
         Ok(SyscallResponse::SendMessageToL1(EmptyResponse))
     }
@@ -374,10 +352,7 @@ impl GetCallerAddressRequest {
         Ok(SyscallRequest::GetCallerAddress(GetCallerAddressRequest))
     }
 
-    pub fn execute<SR: StateReader>(
-        self,
-        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
-    ) -> SyscallExecutionResult {
+    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
         Ok(SyscallResponse::GetCallerAddress(GetCallerAddressResponse {
             address: syscall_handler.caller_address,
         }))
@@ -410,10 +385,7 @@ impl GetContractAddressRequest {
         Ok(SyscallRequest::GetContractAddress(GetContractAddressRequest))
     }
 
-    pub fn execute<SR: StateReader>(
-        self,
-        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
-    ) -> SyscallExecutionResult {
+    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
         Ok(SyscallResponse::GetContractAddress(GetContractAddressResponse {
             address: syscall_handler.storage_address,
         }))
@@ -454,10 +426,7 @@ impl SyscallRequest {
         }
     }
 
-    pub fn execute<SR: StateReader>(
-        self,
-        syscall_handler: &mut SyscallHintProcessor<'_, SR>,
-    ) -> SyscallExecutionResult {
+    pub fn execute(self, syscall_handler: &mut SyscallHintProcessor<'_>) -> SyscallExecutionResult {
         match self {
             SyscallRequest::CallContract(request) => request.execute(syscall_handler),
             SyscallRequest::Deploy(request) => request.execute(syscall_handler),

--- a/blockifier/src/transaction.rs
+++ b/blockifier/src/transaction.rs
@@ -4,13 +4,10 @@ pub mod invoke_transaction;
 pub mod objects;
 pub mod transaction_utils;
 
-use crate::state::cached_state::CachedState;
-use crate::state::state_api::StateReader;
+use crate::state::state_api::State;
 use crate::transaction::objects::{TransactionExecutionInfo, TransactionExecutionResult};
 
-pub trait ExecuteTransaction<SR: StateReader> {
-    fn execute(
-        self,
-        state: &mut CachedState<SR>,
-    ) -> TransactionExecutionResult<TransactionExecutionInfo>;
+pub trait ExecuteTransaction {
+    fn execute(self, state: &mut dyn State)
+    -> TransactionExecutionResult<TransactionExecutionInfo>;
 }

--- a/blockifier/src/transaction/invoke_transaction.rs
+++ b/blockifier/src/transaction/invoke_transaction.rs
@@ -5,8 +5,7 @@ use starknet_api::state::EntryPointType;
 use starknet_api::transaction::{Fee, InvokeTransaction};
 
 use crate::execution::entry_point::{CallEntryPoint, CallInfo};
-use crate::state::cached_state::CachedState;
-use crate::state::state_api::StateReader;
+use crate::state::state_api::State;
 use crate::test_utils::TEST_ACCOUNT_CONTRACT_CLASS_HASH;
 use crate::transaction::constants::{EXECUTE_ENTRY_POINT_SELECTOR, VALIDATE_ENTRY_POINT_SELECTOR};
 use crate::transaction::objects::{
@@ -21,9 +20,9 @@ use crate::transaction::ExecuteTransaction;
 #[path = "invoke_transaction_test.rs"]
 mod test;
 
-pub fn validate_tx<SR: StateReader>(
+pub fn validate_tx(
     tx: &InvokeTransaction,
-    state: &mut CachedState<SR>,
+    state: &mut dyn State,
     class_hash: ClassHash,
 ) -> TransactionExecutionResult<CallInfo> {
     let validate_call = CallEntryPoint {
@@ -41,9 +40,9 @@ pub fn validate_tx<SR: StateReader>(
     Ok(validate_call.execute(state)?)
 }
 
-pub fn execute_tx<SR: StateReader>(
+pub fn execute_tx(
     tx: &InvokeTransaction,
-    state: &mut CachedState<SR>,
+    state: &mut dyn State,
     class_hash: ClassHash,
 ) -> TransactionExecutionResult<CallInfo> {
     let execute_call = CallEntryPoint {
@@ -67,10 +66,10 @@ pub fn charge_fee(tx: InvokeTransaction) -> TransactionExecutionResult<(Fee, Cal
     Ok((actual_fee, fee_transfer_call_info))
 }
 
-impl<SR: StateReader> ExecuteTransaction<SR> for InvokeTransaction {
+impl ExecuteTransaction for InvokeTransaction {
     fn execute(
         self,
-        state: &mut CachedState<SR>,
+        state: &mut dyn State,
     ) -> TransactionExecutionResult<TransactionExecutionInfo> {
         // TODO(Adi, 10/12/2022): Consider moving the transaction version verification to the
         // TransactionVersion constructor.


### PR DESCRIPTION
- This allows execution methods to be reused without depending on
`CachedState`'s implementation of `State`.

- Use dynamic dispatch: these methods are IO-bound anyway, so the
performance hit is negligeable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/129)
<!-- Reviewable:end -->
