### PR TITLE
Add Papyrus state reader 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +130,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +204,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "once_cell",
+ "papyrus_storage",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -258,10 +284,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -331,6 +377,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -503,6 +558,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +720,12 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -903,6 +974,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,10 +1031,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
+name = "libmdbx"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7645d94f8ad38f2a67d8a6d4e5adb86a04aa88c0221361ceeb62690eec890e"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "derive_more",
+ "indexmap",
+ "libc",
+ "lifetimed-bytes",
+ "mdbx-sys",
+ "parking_lot",
+ "thiserror",
+]
 
 [[package]]
 name = "libmimalloc-sys"
@@ -967,6 +1077,15 @@ checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "lifetimed-bytes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c970c8ea4c7b023a41cfa4af4c785a16694604c2f2a3b0d1f20a9bcb73fa550"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -993,6 +1112,17 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "mdbx-sys"
+version = "0.11.9-0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652ada7dd2b8012698f20fca85665f84ab3a5d07eaec333535c82760e068f291"
+dependencies = [
+ "bindgen",
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -1029,6 +1159,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -1184,6 +1323,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "papyrus_storage"
+version = "0.1.0"
+source = "git+https://github.com/starkware-libs/papyrus#5a3f52a0954fe8b9e5d2348ffdf243392ec89ad3"
+dependencies = [
+ "bincode",
+ "flate2",
+ "futures-util",
+ "indexmap",
+ "integer-encoding",
+ "libmdbx",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "starknet_api",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "url",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1406,12 @@ name = "paste"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -1497,6 +1664,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,6 +1744,12 @@ dependencies = [
  "bytes",
  "rustc-hex",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hex"
@@ -1796,6 +1984,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/starknet-api#0a11ad394f0def968d690816c6403f5e23fe3f23"
+source = "git+https://github.com/starkware-libs/starknet-api?rev=0a11ad3#0a11ad394f0def968d690816c6403f5e23fe3f23"
 dependencies = [
  "derive_more",
  "hex",

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -14,10 +14,11 @@ num-bigint = { version = "0.4" }
 num-integer = { version = "0.1.45" }
 num-traits = { version = "0.2" }
 once_cell = { version = "1.16.0" }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus" }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0.81", features = ["arbitrary_precision"] }
 sha3 = { version = "0.10.6" }
-starknet_api = { git = "https://github.com/starkware-libs/starknet-api", features = [
+starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "0a11ad3", features = [
     "testing",
 ] }
 thiserror = { version = "1.0.37" }

--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -28,6 +28,17 @@ impl From<ContractClass> for starknet_api::state::ContractClass {
     }
 }
 
+impl From<starknet_api::state::ContractClass> for ContractClass {
+    fn from(contract_class: starknet_api::state::ContractClass) -> Self {
+        Self {
+            program: contract_class.program,
+            entry_points_by_type: contract_class.entry_points_by_type,
+            // ABI is not used for execution.
+            abi: None,
+        }
+    }
+}
+
 /// Instantiates a contract class object given a compiled contract file path.
 impl TryFrom<PathBuf> for ContractClass {
     type Error = io::Error;

--- a/crates/blockifier/src/state.rs
+++ b/crates/blockifier/src/state.rs
@@ -1,3 +1,4 @@
 pub mod cached_state;
 pub mod errors;
+pub mod papyrus_state;
 pub mod state_api;

--- a/crates/blockifier/src/state/papyrus_state.rs
+++ b/crates/blockifier/src/state/papyrus_state.rs
@@ -1,0 +1,73 @@
+use papyrus_storage::TransactionKind;
+use starknet_api::block::BlockNumber;
+use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::hash::StarkFelt;
+use starknet_api::state::{StateNumber, StorageKey};
+
+use crate::execution::contract_class::ContractClass;
+use crate::state::errors::StateReaderError;
+use crate::state::state_api::{StateReader, StateReaderResult};
+
+type RawPapyrusStateReader<'env, Mode> = papyrus_storage::state::StateReader<'env, Mode>;
+
+pub struct PapyrusStateReader<'env, Mode: TransactionKind> {
+    pub reader: RawPapyrusStateReader<'env, Mode>,
+    // TODO(Gilad): replace with BlockContext.
+    // Invariant: Read-Only.
+    latest_block: BlockNumber,
+}
+
+impl<'env, Mode: TransactionKind> PapyrusStateReader<'env, Mode> {
+    pub fn new(reader: RawPapyrusStateReader<'env, Mode>, latest_block: BlockNumber) -> Self {
+        Self { reader, latest_block }
+    }
+
+    pub fn latest_block(&self) -> &BlockNumber {
+        &self.latest_block
+    }
+}
+
+impl<'env, Mode: TransactionKind> StateReader for PapyrusStateReader<'env, Mode> {
+    fn get_storage_at(
+        &self,
+        contract_address: ContractAddress,
+        key: StorageKey,
+    ) -> StateReaderResult<StarkFelt> {
+        let state_number = StateNumber(*self.latest_block());
+        self.reader
+            .get_storage_at(state_number, &contract_address, &key)
+            .map_err(|err| StateReaderError::ReadError(err.to_string()))
+    }
+
+    fn get_nonce_at(&self, contract_address: ContractAddress) -> StateReaderResult<Nonce> {
+        let state_number = StateNumber(*self.latest_block());
+        match self.reader.get_nonce_at(state_number, &contract_address) {
+            Ok(Some(nonce)) => Ok(nonce),
+            Ok(None) => Ok(Nonce::default()),
+            Err(err) => Err(StateReaderError::ReadError(err.to_string())),
+        }
+    }
+
+    fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateReaderResult<ClassHash> {
+        let state_number = StateNumber(*self.latest_block());
+        match self.reader.get_class_hash_at(state_number, &contract_address) {
+            Ok(Some(class_hash)) => Ok(class_hash),
+            Ok(None) => Ok(ClassHash::default()),
+            Err(err) => Err(StateReaderError::ReadError(err.to_string())),
+        }
+    }
+
+    fn get_contract_class(
+        &self,
+        class_hash: &starknet_api::core::ClassHash,
+    ) -> StateReaderResult<ContractClass> {
+        let state_number = StateNumber(*self.latest_block());
+        match self.reader.get_class_definition_at(state_number, class_hash) {
+            Ok(Some(starknet_api_contract_class)) => {
+                Ok(ContractClass::from(starknet_api_contract_class))
+            }
+            Ok(None) => Err(StateReaderError::UndeclaredClassHash(*class_hash)),
+            Err(err) => Err(StateReaderError::ReadError(err.to_string())),
+        }
+    }
+}


### PR DESCRIPTION
Assumption: When the Blockifier is initialized, it is given the latest `BlockNumber` by the Python calling code.

We need to save this in a wrapper around Papyrus' state reader, since it requires a StateNumber on which to work on (the Blockifier's state-api doesn't need this argument since we are always working on the latest block).

Finally, this wrapper fixes captures the different return types from Papyrus and converts them to the ones we are working on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier-old/152)
<!-- Reviewable:end -->
