### PR TITLE
Python-Rust bridge POC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,6 +889,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2d6f23ffea9d7e76c53eee25dfb67bcd8fde7f1198b0855350698c9f07c780"
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1000,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mimalloc"
@@ -1359,6 +1374,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "parking_lot",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94144a1266e236b1c932682136dc35a9dee8d3589728f68130c7c3861ef96b28"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "python_rust_bridge"
+version = "0.1.0"
+dependencies = [
+ "pyo3",
 ]
 
 [[package]]
@@ -1885,6 +1967,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2217,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unindent"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,4 @@
 #   https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
 resolver = "2"
 
-members = [
-  "crates/blockifier"
-]
+members = ["crates/blockifier", "crates/python_rust_bridge"]

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -7,18 +7,20 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0.66" }
-cairo-rs =  { git = "https://github.com/lambdaclass/cairo-rs.git" }
+cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git" }
 derive_more = { version = "0.99.17" }
-felt =  { git = "https://github.com/lambdaclass/cairo-rs.git" }
+felt = { git = "https://github.com/lambdaclass/cairo-rs.git" }
 indexmap = { version = "1.9.2" }
 num-bigint = { version = "0.4" }
 num-integer = { version = "0.1.45" }
 num-traits = { version = "0.2" }
 once_cell = { version = "1.16.0" }
 serde = { version = "1.0.130", features = ["derive"] }
-serde_json = { version = "1.0.81" , features = ["arbitrary_precision"]}
-sha3 = { version ="0.10.6" }
-starknet_api =  { git = "https://github.com/starkware-libs/starknet-api", features=["testing"] }
+serde_json = { version = "1.0.81", features = ["arbitrary_precision"] }
+sha3 = { version = "0.10.6" }
+starknet_api = { git = "https://github.com/starkware-libs/starknet-api", features = [
+    "testing",
+] }
 thiserror = { version = "1.0.37" }
 
 [dev-dependencies]

--- a/crates/python_rust_bridge/Cargo.toml
+++ b/crates/python_rust_bridge/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "python_rust_bridge"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+name = "rust_extension_poc"
+# "cdylib" is necessary to produce a shared library for Python to import from.
+#
+# Downstream Rust code (including code in `bin/`, `examples/`, and `tests/`) will not be able
+# to `use string_sum;` unless the "rlib" or "lib" crate type is also included, e.g.:
+# crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.17.3", features = ["extension-module"] }

--- a/crates/python_rust_bridge/src/lib.rs
+++ b/crates/python_rust_bridge/src/lib.rs
@@ -1,0 +1,13 @@
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn hello_world() {
+    println!("Hello from rust.");
+}
+
+#[pymodule]
+fn rust_extension_poc(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(hello_world, m)?)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Usage:
- `Cargo build` as usual
- grab target/debug/librust_extension_poc.so and rename to rust_extension_poc.so
- in directories with rust_extension_poc.so in them, python can `import rust_extension_poc` and use its interface.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/168)
<!-- Reviewable:end -->
