### PR TITLE
Add `CallInfo` pre-order iterator.

### DIFF
--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -94,6 +94,34 @@ pub struct CallInfo {
     pub l2_to_l1_messages: Vec<MessageToL1>,
 }
 
+pub struct CallInfoIter<'a> {
+    call_infos: Vec<&'a CallInfo>,
+}
+
+impl<'a> Iterator for CallInfoIter<'a> {
+    type Item = &'a CallInfo;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some(call_info) = self.call_infos.pop() else {
+            return None;
+        };
+
+        // Push order is right to left.
+        self.call_infos.extend(call_info.inner_calls.iter().rev());
+        Some(call_info)
+    }
+}
+
+impl<'a> IntoIterator for &'a CallInfo {
+    type Item = &'a CallInfo;
+
+    type IntoIter = CallInfoIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        CallInfoIter { call_infos: vec![self] }
+    }
+}
+
 pub fn execute_constructor_entry_point(
     state: &mut dyn State,
     block_context: &BlockContext,


### PR DESCRIPTION
Later, we can generalize it to different types if we want.
We can instead use [this](https://docs.rs/traversal/latest/traversal/) crate, but it was so simple that I didn't know if we should rely on it (and I didn't know how to evaluate this crate).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/183)
<!-- Reviewable:end -->
