### PR TITLE
rename `get_test_block_context` -> `create_for_testing`

### DIFF
--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -115,14 +115,14 @@ impl CallEntryPoint {
     pub fn execute_directly(self, state: &mut dyn State) -> EntryPointExecutionResult<CallInfo> {
         self.execute(
             state,
-            &BlockContext::get_test_block_context(),
+            &BlockContext::create_for_testing(),
             &AccountTransactionContext::default(),
         )
     }
 }
 
 impl BlockContext {
-    pub fn get_test_block_context() -> BlockContext {
+    pub fn create_for_testing() -> BlockContext {
         BlockContext {
             chain_id: ChainId("SN_GOERLI".to_string()),
             block_number: BlockNumber::default(),

--- a/crates/blockifier/src/transaction/invoke_transaction_test.rs
+++ b/crates/blockifier/src/transaction/invoke_transaction_test.rs
@@ -32,7 +32,7 @@ use crate::transaction::errors::{FeeTransferError, TransactionExecutionError};
 use crate::transaction::objects::{ResourcesMapping, TransactionExecutionInfo};
 
 fn create_test_state() -> CachedState<DictStateReader> {
-    let block_context = BlockContext::get_test_block_context();
+    let block_context = BlockContext::create_for_testing();
 
     let test_contract_class_hash = ClassHash(stark_felt!(TEST_CLASS_HASH));
     let test_account_class_hash = ClassHash(stark_felt!(TEST_ACCOUNT_CONTRACT_CLASS_HASH));
@@ -95,7 +95,7 @@ fn get_tested_actual_fee() -> Fee {
 #[test]
 fn test_invoke_tx() {
     let mut state = create_test_state();
-    let block_context = BlockContext::get_test_block_context();
+    let block_context = BlockContext::create_for_testing();
 
     // Extract invoke transaction fields for testing, as the transaction execution consumes
     // the transaction.
@@ -224,7 +224,7 @@ fn test_invoke_tx() {
 #[test]
 fn test_negative_invoke_tx_flows() {
     let mut state = create_test_state();
-    let block_context = BlockContext::get_test_block_context();
+    let block_context = BlockContext::create_for_testing();
     let valid_invoke_tx = get_tested_valid_invoke_tx();
 
     // Invalid version.


### PR DESCRIPTION
- avoid `get_`
- no need to duplicate the `block_context` context in the name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/188)
<!-- Reviewable:end -->
