### PR TITLE
Rename `get_tested_felts_and_corresponding_bigints`

### DIFF
--- a/crates/blockifier/src/execution/execution_utils_test.rs
+++ b/crates/blockifier/src/execution/execution_utils_test.rs
@@ -1,3 +1,5 @@
+use std::iter::zip;
+
 use cairo_felt::Felt;
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
@@ -6,23 +8,23 @@ use starknet_api::hash::StarkFelt;
 
 use crate::execution::execution_utils::{felt_to_stark_felt, stark_felt_to_felt};
 
-fn get_tested_felts_and_corresponding_bigints() -> (Vec<StarkFelt>, Vec<Felt>) {
+fn starkfelt_to_felt_pairs() -> Vec<(StarkFelt, Felt)> {
     // The STARK prime is 2 ^ 251 + 17 * 2 ^ 192 + 1.
     const STARK_PRIME: &str = "0x800000000000011000000000000000000000000000000000000000000000001";
     const STARK_PRIME_MINUS_ONE: &str =
         "0x800000000000011000000000000000000000000000000000000000000000000";
 
-    let felt_from_hex_error_message = "`StarkFelt` construction from hex has failed.";
-    let felts = vec![
+    let starkfelt_from_hex_error_message = "`StarkFelt` construction from hex has failed.";
+    let starkfelts = vec![
         StarkFelt::from(0),
         StarkFelt::from(1),
         StarkFelt::from(1234),
         // TODO(Adi, 10/12/2022): The construction of a StarkFelt holding the STARK prime should
         // fail once full-node have a field representation; remove this test case.
-        StarkFelt::try_from(STARK_PRIME).expect(felt_from_hex_error_message),
-        StarkFelt::try_from(STARK_PRIME_MINUS_ONE).expect(felt_from_hex_error_message),
+        StarkFelt::try_from(STARK_PRIME).expect(starkfelt_from_hex_error_message),
+        StarkFelt::try_from(STARK_PRIME_MINUS_ONE).expect(starkfelt_from_hex_error_message),
     ];
-    let bigints = vec![
+    let felts = vec![
         Felt::zero(),
         Felt::one(),
         Felt::from(1234),
@@ -32,21 +34,19 @@ fn get_tested_felts_and_corresponding_bigints() -> (Vec<StarkFelt>, Vec<Felt>) {
         Felt::from(BigUint::new(vec![0, 0, 0, 0, 0, 0, 17, 134217728])),
     ];
 
-    (felts, bigints)
+    zip(starkfelts, felts).collect()
 }
 
 #[test]
 fn test_stark_felt_to_felt() {
-    let (felts, expected_bigints) = get_tested_felts_and_corresponding_bigints();
-    let converted_bigints: Vec<Felt> = felts.iter().map(stark_felt_to_felt).collect();
-
-    assert_eq!(converted_bigints, expected_bigints);
+    for (stark_felt, equivalent_felt) in starkfelt_to_felt_pairs() {
+        assert_eq!(stark_felt_to_felt(&stark_felt), equivalent_felt);
+    }
 }
 
 #[test]
 fn test_felt_to_stark_felt() {
-    let (expected_felts, bigints) = get_tested_felts_and_corresponding_bigints();
-    let converted_felts: Vec<StarkFelt> = bigints.iter().map(felt_to_stark_felt).collect();
-
-    assert_eq!(converted_felts, expected_felts);
+    for (equivalent_stark_felt, felt) in starkfelt_to_felt_pairs() {
+        assert_eq!(felt_to_stark_felt(&felt), equivalent_stark_felt);
+    }
 }


### PR DESCRIPTION
- avoid `get_`
- "tested" is implied from the location, a test file.
- refactor

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier-old/189)
<!-- Reviewable:end -->
