### PR TITLE
Specify cloning an Rc/Arc.

### DIFF
--- a/crates/blockifier/src/execution/syscall_handling.rs
+++ b/crates/blockifier/src/execution/syscall_handling.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use cairo_felt::Felt;
 use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::{
@@ -246,7 +247,7 @@ pub fn execute_inner_call(
         syscall_handler.block_context,
         syscall_handler.account_tx_context,
     )?;
-    let retdata = call_info.execution.retdata.clone();
+    let retdata = Retdata(Rc::clone(&call_info.execution.retdata.0));
     syscall_handler.inner_calls.push(call_info);
 
     Ok(retdata)

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use once_cell::sync::Lazy;
 use starknet_api::calldata;
 use starknet_api::core::{ContractAddress, EntryPointSelector};
@@ -151,7 +153,7 @@ impl AccountTransaction {
                     get_selector(VALIDATE_ENTRY_POINT_NAME),
                     // The validation calldata for invoke transaction is the same calldata as for
                     // the execution itself.
-                    tx.calldata.clone(),
+                    Calldata(Arc::clone(&tx.calldata.0)),
                 )?;
 
                 // Execute invoke transaction.

--- a/crates/blockifier/src/transaction/transactions.rs
+++ b/crates/blockifier/src/transaction/transactions.rs
@@ -1,6 +1,10 @@
+use std::sync::Arc;
+
 use starknet_api::core::ContractAddress;
 use starknet_api::state::EntryPointType;
-use starknet_api::transaction::{DeclareTransaction, DeployAccountTransaction, InvokeTransaction};
+use starknet_api::transaction::{
+    Calldata, DeclareTransaction, DeployAccountTransaction, InvokeTransaction,
+};
 
 use crate::abi::abi_utils::get_selector;
 use crate::block_context::BlockContext;
@@ -25,7 +29,7 @@ impl ExecuteTransaction for InvokeTransaction {
         let execute_call = CallEntryPoint {
             entry_point_type: EntryPointType::External,
             entry_point_selector: get_selector(EXECUTE_ENTRY_POINT_NAME),
-            calldata: self.calldata.clone(),
+            calldata: Calldata(Arc::clone(&self.calldata.0)),
             class_hash: None,
             storage_address: self.sender_address,
             caller_address: ContractAddress::default(),

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use pretty_assertions::assert_eq;
@@ -104,7 +106,7 @@ fn test_invoke_tx() {
     // Extract invoke transaction fields for testing, as the transaction execution consumes
     // the transaction.
     let invoke_tx = invoke_tx();
-    let calldata = invoke_tx.calldata.clone();
+    let calldata = Calldata(Arc::clone(&invoke_tx.calldata.0));
     let sender_address = invoke_tx.sender_address;
 
     let account_tx = AccountTransaction::Invoke(invoke_tx);
@@ -143,7 +145,7 @@ fn test_invoke_tx() {
     let expected_return_result_retdata = Retdata(expected_return_result_calldata.into());
     let expected_execute_call_info = CallInfo {
         call: expected_execute_call,
-        execution: CallExecution { retdata: expected_return_result_retdata.clone() },
+        execution: CallExecution { retdata: Retdata(Rc::clone(&expected_return_result_retdata.0)) },
         inner_calls: vec![CallInfo {
             call: expected_return_result_call,
             execution: CallExecution { retdata: expected_return_result_retdata },


### PR DESCRIPTION
I really don't like the usage of `.0` :(
I tried looking a bit in derive more, to overcome it, but I didn't find anything. @giladchase, perhaps you know something?
Also, there are still clones of objects that contain calldata, e.g., `CallEntryPoint` and transaction that can possibly be big, but I'm not sure if we have anything to do with it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier-old/204)
<!-- Reviewable:end -->
