### PR TITLE
Fix `papyrus_state_test` after merge conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,10 +1341,14 @@ dependencies = [
  "integer-encoding",
  "libmdbx",
  "log",
+ "rand",
+ "rand_chacha",
  "reqwest",
  "serde",
  "serde_json",
  "starknet_api",
+ "tempfile",
+ "test_utils",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2185,6 +2189,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test_utils"
+version = "0.1.0"
+source = "git+https://github.com/starkware-libs/papyrus#5a3f52a0954fe8b9e5d2348ffdf243392ec89ad3"
+dependencies = [
+ "indexmap",
+ "log",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "serde_json",
+ "starknet_api",
 ]
 
 [[package]]

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -25,4 +25,7 @@ thiserror = { version = "1.0.37" }
 
 [dev-dependencies]
 assert_matches = { version = "1.5.0" }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", features = [
+    "testing",
+] }
 pretty_assertions = { version = "1.2.1" }

--- a/crates/blockifier/src/state/papyrus_state.rs
+++ b/crates/blockifier/src/state/papyrus_state.rs
@@ -8,6 +8,10 @@ use crate::execution::contract_class::ContractClass;
 use crate::state::errors::StateReaderError;
 use crate::state::state_api::{StateReader, StateReaderResult};
 
+#[cfg(test)]
+#[path = "papyrus_state_test.rs"]
+mod test;
+
 type RawPapyrusStateReader<'env, Mode> = papyrus_storage::state::StateReader<'env, Mode>;
 
 pub struct PapyrusStateReader<'env, Mode: TransactionKind> {

--- a/crates/blockifier/src/state/papyrus_state_test.rs
+++ b/crates/blockifier/src/state/papyrus_state_test.rs
@@ -1,20 +1,21 @@
-use blockifier::execution::entry_point::{CallEntryPoint, CallExecution, Retdata};
-use blockifier::retdata;
-use blockifier::state::cached_state::CachedState;
-use blockifier::state::papyrus_state::PapyrusStateReader;
-use blockifier::state::state_api::State;
-use blockifier::test_utils::{
-    get_test_contract_class, trivial_external_entry_point, TEST_CLASS_HASH, TEST_CONTRACT_ADDRESS,
-    TEST_STORAGE_READ_WRITE_SELECTOR,
-};
 use indexmap::IndexMap;
-use papyrus_storage::{self, StateStorageReader, StateStorageWriter};
+use papyrus_storage::state::{StateStorageReader, StateStorageWriter};
 use starknet_api::block::BlockNumber;
-use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, PatriciaKey};
+use starknet_api::core::{ClassHash, ContractAddress, PatriciaKey};
 use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::state::{StateDiff, StorageKey};
 use starknet_api::transaction::Calldata;
 use starknet_api::{calldata, patricia_key, stark_felt};
+
+use crate::abi::abi_utils::selector_from_name;
+use crate::execution::entry_point::{CallEntryPoint, CallExecution, Retdata};
+use crate::retdata;
+use crate::state::cached_state::CachedState;
+use crate::state::papyrus_state::PapyrusStateReader;
+use crate::state::state_api::State;
+use crate::test_utils::{
+    get_test_contract_class, trivial_external_entry_point, TEST_CLASS_HASH, TEST_CONTRACT_ADDRESS,
+};
 
 #[test]
 fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
@@ -47,7 +48,7 @@ fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
     let calldata = calldata![key, value];
     let entry_point_call = CallEntryPoint {
         calldata,
-        entry_point_selector: EntryPointSelector(stark_felt!(TEST_STORAGE_READ_WRITE_SELECTOR)),
+        entry_point_selector: selector_from_name("test_storage_read_write"),
         ..trivial_external_entry_point()
     };
     let storage_address = entry_point_call.storage_address;


### PR DESCRIPTION
- move to correct location
- fix imports
- use `get_selector_from_name` instead of deprecated const.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/225)
<!-- Reviewable:end -->
