### PR TITLE
Remove license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 <br />
 
 [![GitHub Workflow Status](https://github.com/starkware-libs/blockifier/actions/workflows/post-merge.yml/badge.svg)](https://github.com/starkware-libs/blockifier/actions/workflows/post-merge.yml)
-[![License](https://img.shields.io/github/license/starkware-libs/blockifier.svg?style=flat-square)](LICENSE)
 
 </div>
 


### PR DESCRIPTION
Showing up as "repo not found" for some reason, will investigate later.