### PR TITLE
Fix build script for native extension

### DIFF
--- a/crates/native_blockifier/build_wheels.sh
+++ b/crates/native_blockifier/build_wheels.sh
@@ -1,30 +1,35 @@
 #!/bin/bash
 set -e
 
-# The starknet-api dependency requires the dependency `rust-openssl`, which needs openssl-devel
-# to be installed locally.
-yum -y install openssl-devel
+# Install crate dependencies.
+yum -y install centos-release-scl
+yum -y install openssl-devel llvm-toolset-7.0
 
+
+# Install Rust.
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
 export PATH="$HOME/.cargo/bin:$PATH"
 
+# Required for libclang > 3.9, by default there is only clang 3.4 in this image.
+source /opt/rh/llvm-toolset-7.0/enable
 
 cpython_bins=$(echo /opt/python/cp{37,38,39,310}*/bin)
 pypy_bins=$(echo /opt/python/pp{37,38,39}*/bin)
 
-# Compile wheels
+# Compile wheels.
 for py_bin in ${cpython_bins} ${pypy_bins}; do
     rm -rf /io/build/
     "${py_bin}/pip" install -U setuptools setuptools-rust wheel
     "${py_bin}/pip" wheel /io/ -w /io/dist/ --no-deps
 done
 
-# Bundle external shared libraries into the wheels
+# Bundle external shared libraries into the wheels.
 for whl in /io/dist/*{cp37,cp38,cp39,cp310,pp37,pp38,pp39}*.whl; do
     auditwheel repair "$whl" -w /io/dist/
 done
 
-# Install packages and test
+# Install packages and test.
 for py_bin in ${cpython_bins} ${pypy_bins}; do
     "${py_bin}/pip" install native_blockifier -f /io/dist/
     echo "Testing with $("${py_bin}/python" --version) ..."


### PR DESCRIPTION
- added centos-release-scl and llvm-toolset to manylinux docker, for clang > 3.9 support.
  When `blockifier` is added as a dep (which will happen soon),
  one of the dependencies requires this clang dependency.

- Ditto for openssel-devel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/258)
<!-- Reviewable:end -->
