### PR TITLE
Initialize `PyStateDiff` in Python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +792,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "headers"
@@ -1243,6 +1257,8 @@ name = "native_blockifier"
 version = "0.1.0"
 dependencies = [
  "blockifier 0.1.0 (git+https://github.com/starkware-libs/blockifier)",
+ "hex",
+ "indexmap",
  "num-bigint",
  "papyrus_storage",
  "pyo3",
@@ -1612,6 +1628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
 dependencies = [
  "cfg-if",
+ "hashbrown",
  "indoc",
  "libc",
  "memoffset",

--- a/crates/native_blockifier/Cargo.lock
+++ b/crates/native_blockifier/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +746,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "headers"
@@ -1197,7 +1211,10 @@ name = "native_blockifier"
 version = "0.1.0"
 dependencies = [
  "blockifier",
+ "hex",
+ "indexmap",
  "num-bigint",
+ "papyrus_storage",
  "pyo3",
  "starknet_api",
  "thiserror",
@@ -1337,10 +1354,14 @@ dependencies = [
  "indexmap",
  "integer-encoding",
  "libmdbx",
+ "rand",
+ "rand_chacha",
  "reqwest",
  "serde",
  "serde_json",
  "starknet_api",
+ "tempfile",
+ "test_utils",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1540,6 +1561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
 dependencies = [
  "cfg-if",
+ "hashbrown",
  "indoc",
  "libc",
  "memoffset",
@@ -2170,6 +2192,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test_utils"
+version = "0.1.0"
+source = "git+https://github.com/starkware-libs/papyrus#734b66193dfacac96f1627ab4016fb7c8da1522c"
+dependencies = [
+ "indexmap",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "serde_json",
+ "starknet_api",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -16,11 +16,17 @@ crate-type = ["cdylib"]
 blockifier = { git = "https://github.com/starkware-libs/blockifier", features = [
     "testing",
 ] }
+hex = { version = "0.4.3" }
+indexmap = { version = "1.9.2" }
 num-bigint = { version = "0.4" }
 papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", features = [
     "testing",
 ] }
-pyo3 = { version = "0.17.3", features = ["extension-module", "num-bigint"] }
+pyo3 = { version = "0.17.3", features = [
+    "extension-module",
+    "num-bigint",
+    "hashbrown",
+] }
 # We need this rev to be the same as in both `blockifier` and `papyrus_storage`.
 starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "0a11ad3", features = [
     "testing",

--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -1,9 +1,20 @@
-mod py_transaction;
+pub mod py_transaction;
+pub mod py_utils;
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
 
 use blockifier::transaction::errors::TransactionExecutionError;
+use indexmap::IndexMap;
+use papyrus_storage::header::HeaderStorageReader;
+use papyrus_storage::state::{StateStorageReader, StateStorageWriter};
 use py_transaction::PyTransactionExecutor;
+use py_utils::PyFelt;
 use pyo3::exceptions::PyOSError;
 use pyo3::prelude::*;
+use starknet_api::block::BlockNumber;
+use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::state::{ContractClass, StateDiff, StorageKey};
 use starknet_api::StarknetApiError;
 
 pub type NativeBlockifierResult<T> = Result<T, NativeBlockifierError>;
@@ -12,8 +23,6 @@ pub type NativeBlockifierResult<T> = Result<T, NativeBlockifierError>;
 fn native_blockifier(_py: Python<'_>, py_module: &PyModule) -> PyResult<()> {
     py_module.add_class::<Storage>()?;
     py_module.add_class::<PyTransactionExecutor>()?;
-
-    py_module.add_function(wrap_pyfunction!(test_storage, py_module)?)?;
 
     Ok(())
 }
@@ -24,10 +33,10 @@ pub struct Storage {
     pub writer: papyrus_storage::StorageWriter,
 }
 
-// TODO: Add rest of the storage api.
 #[pymethods]
 impl Storage {
     #[new]
+    #[args(path)]
     pub fn new(path: String) -> NativeBlockifierResult<Storage> {
         let db_config = papyrus_storage::db::DbConfig {
             path,
@@ -37,12 +46,97 @@ impl Storage {
         let (reader, writer) = papyrus_storage::open_storage(db_config)?;
         Ok(Storage { reader, writer })
     }
+
+    pub fn get_state_marker(&self) -> NativeBlockifierResult<u64> {
+        let block_number = self.reader.begin_ro_txn()?.get_state_marker()?;
+        Ok(block_number.0)
+    }
+
+    #[args(block_number)]
+    pub fn get_block_hash(&self, block_number: u64) -> NativeBlockifierResult<Option<Vec<u8>>> {
+        let block_number = BlockNumber(block_number);
+        let block_hash = self
+            .reader
+            .begin_ro_txn()?
+            .get_block_header(block_number)?
+            .map(|block_header| Vec::from(block_header.block_hash.0.bytes()));
+        Ok(block_hash)
+    }
+
+    #[args(block_number)]
+    pub fn revert_state_diff(&mut self, block_number: u64) -> NativeBlockifierResult<()> {
+        let (revert_txn, _) =
+            self.writer.begin_rw_txn()?.revert_state_diff(BlockNumber(block_number))?;
+        revert_txn.commit()?;
+        Ok(())
+    }
+
+    #[args(block_number, py_state_diff, _py_deployed_contract_class_definitions)]
+    pub fn append_state_diff(
+        &mut self,
+        block_number: u64,
+        py_state_diff: PyStateDiff,
+        _py_deployed_contract_class_definitions: &PyAny,
+    ) -> NativeBlockifierResult<()> {
+        let block_number = BlockNumber(block_number);
+        let state_diff = StateDiff::try_from(py_state_diff)?;
+        // TODO: Figure out how to go from `py_state_diff.class_hash_to_compiled_class_hash` into
+        // this type.
+        let deployed_contract_class_definitions = IndexMap::<ClassHash, ContractClass>::new();
+
+        let append_txn = self.writer.begin_rw_txn()?.append_state_diff(
+            block_number,
+            state_diff,
+            deployed_contract_class_definitions,
+        );
+        append_txn?.commit()?;
+        Ok(())
+    }
 }
 
-#[pyfunction]
-fn test_storage() -> Storage {
-    let (reader, writer) = papyrus_storage::test_utils::get_test_storage();
-    Storage { reader, writer }
+#[derive(FromPyObject)]
+pub struct PyStateDiff {
+    pub address_to_class_hash: HashMap<PyFelt, PyFelt>,
+    pub address_to_nonce: HashMap<PyFelt, PyFelt>,
+    pub class_hash_to_compiled_class_hash: HashMap<PyFelt, PyFelt>,
+    pub storage_updates: HashMap<PyFelt, HashMap<PyFelt, PyFelt>>,
+}
+
+impl TryFrom<PyStateDiff> for StateDiff {
+    type Error = NativeBlockifierError;
+
+    fn try_from(state_diff: PyStateDiff) -> NativeBlockifierResult<Self> {
+        let mut deployed_contracts: IndexMap<ContractAddress, ClassHash> = IndexMap::new();
+        for (address, class_hash) in state_diff.address_to_class_hash {
+            let address = ContractAddress::try_from(address.0)?;
+            let class_hash = ClassHash(class_hash.0);
+            deployed_contracts.insert(address, class_hash);
+        }
+
+        let mut storage_diffs = IndexMap::new();
+        for (address, storage_mapping) in state_diff.storage_updates {
+            let address = ContractAddress::try_from(address.0)?;
+            storage_diffs.insert(address, IndexMap::new());
+
+            for (key, value) in storage_mapping {
+                let storage_key = StorageKey::try_from(key.0)?;
+                let storage_value = value.0;
+                storage_diffs.entry(address).and_modify(|changes| {
+                    changes.insert(storage_key, storage_value);
+                });
+            }
+        }
+
+        let declared_classes = IndexMap::new();
+        let mut nonces = IndexMap::new();
+        for (address, nonce) in state_diff.address_to_nonce {
+            let address = ContractAddress::try_from(address.0)?;
+            let nonce = Nonce(nonce.0);
+            nonces.insert(address, nonce);
+        }
+
+        Ok(Self { deployed_contracts, storage_diffs, declared_classes, nonces })
+    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -21,8 +21,9 @@ pub type NativeBlockifierResult<T> = Result<T, NativeBlockifierError>;
 
 #[pymodule]
 fn native_blockifier(_py: Python<'_>, py_module: &PyModule) -> PyResult<()> {
-    py_module.add_class::<Storage>()?;
+    py_module.add_class::<PyStateDiff>()?;
     py_module.add_class::<PyTransactionExecutor>()?;
+    py_module.add_class::<Storage>()?;
 
     Ok(())
 }
@@ -94,12 +95,31 @@ impl Storage {
     }
 }
 
-#[derive(FromPyObject)]
+#[pyclass]
+#[derive(Clone)]
 pub struct PyStateDiff {
     pub address_to_class_hash: HashMap<PyFelt, PyFelt>,
     pub address_to_nonce: HashMap<PyFelt, PyFelt>,
-    pub class_hash_to_compiled_class_hash: HashMap<PyFelt, PyFelt>,
+    pub declared_contract_hashes: Vec<PyFelt>,
     pub storage_updates: HashMap<PyFelt, HashMap<PyFelt, PyFelt>>,
+}
+
+#[pymethods]
+impl PyStateDiff {
+    #[new]
+    pub fn new(
+        address_to_class_hash: HashMap<PyFelt, PyFelt>,
+        address_to_nonce: HashMap<PyFelt, PyFelt>,
+        declared_contract_hashes: Vec<PyFelt>,
+        storage_updates: HashMap<PyFelt, HashMap<PyFelt, PyFelt>>,
+    ) -> NativeBlockifierResult<PyStateDiff> {
+        Ok(PyStateDiff {
+            address_to_class_hash,
+            address_to_nonce,
+            declared_contract_hashes,
+            storage_updates,
+        })
+    }
 }
 
 impl TryFrom<PyStateDiff> for StateDiff {

--- a/crates/native_blockifier/src/py_transaction.rs
+++ b/crates/native_blockifier/src/py_transaction.rs
@@ -18,12 +18,8 @@ use starknet_api::transaction::{
     TransactionVersion,
 };
 
+use crate::py_utils::biguint_to_felt;
 use crate::{NativeBlockifierError, NativeBlockifierResult};
-
-fn biguint_to_felt(biguint: BigUint) -> NativeBlockifierResult<StarkFelt> {
-    let biguint_hex = format!("{biguint:#x}");
-    Ok(StarkFelt::try_from(&*biguint_hex)?)
-}
 
 fn py_attr<T>(obj: &PyAny, attr: &str) -> NativeBlockifierResult<T>
 where

--- a/crates/native_blockifier/src/py_utils.rs
+++ b/crates/native_blockifier/src/py_utils.rs
@@ -1,0 +1,22 @@
+use std::convert::TryFrom;
+
+use num_bigint::BigUint;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use starknet_api::hash::StarkFelt;
+
+use crate::NativeBlockifierResult;
+
+#[derive(Eq, FromPyObject, Hash, PartialEq)]
+pub struct PyFelt(#[pyo3(from_py_with = "pyint_to_stark_felt")] pub StarkFelt);
+
+fn pyint_to_stark_felt(int: &PyAny) -> PyResult<StarkFelt> {
+    let biguint: BigUint = int.extract()?;
+    biguint_to_felt(biguint).map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
+// TODO: Convert to a `TryFrom` cast and put in starknet-api (In StarkFelt).
+pub fn biguint_to_felt(biguint: BigUint) -> NativeBlockifierResult<StarkFelt> {
+    let biguint_hex = format!("{biguint:#x}");
+    Ok(StarkFelt::try_from(&*biguint_hex)?)
+}

--- a/crates/native_blockifier/src/py_utils.rs
+++ b/crates/native_blockifier/src/py_utils.rs
@@ -7,7 +7,7 @@ use starknet_api::hash::StarkFelt;
 
 use crate::NativeBlockifierResult;
 
-#[derive(Eq, FromPyObject, Hash, PartialEq)]
+#[derive(Eq, FromPyObject, Hash, PartialEq, Clone, Copy, Debug)]
 pub struct PyFelt(#[pyo3(from_py_with = "pyint_to_stark_felt")] pub StarkFelt);
 
 fn pyint_to_stark_felt(int: &PyAny) -> PyResult<StarkFelt> {


### PR DESCRIPTION
Passing `StateDiff` from Python is a problem, since it uses `frozendict` as hashes, which isn't supported in Pyo3.

The field `class_hash_to_compiled_class_hash` was changed into `declared_contract_hashes`, for compatibility with `ThinStateDiff`, which will be fetched from Papyrus in a subsequent commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/272)
<!-- Reviewable:end -->
