### PR TITLE
Remove testing feature from test_utils

### DIFF
--- a/crates/blockifier/src/lib.rs
+++ b/crates/blockifier/src/lib.rs
@@ -2,7 +2,8 @@ pub mod abi;
 pub mod block_context;
 pub mod execution;
 pub mod state;
-#[cfg(any(feature = "testing", test))]
+// TODO: uncomment once we fix native_extension; making it no longer require DictStateReader.
+// #[cfg(any(feature = "testing", test))]
 pub mod test_utils;
 pub mod transaction;
 pub mod utils;


### PR DESCRIPTION
Temporary change.
Currently native_extension needs `DictStateReader`, but it should require `State`. Until that's fixed, we remove the testing feature from test_utils, because we don't want to compile the extension in release mode, but with a `Testing` feature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/281)
<!-- Reviewable:end -->
