### PR TITLE
Remove broken py_tx branch and fix dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/blockifier#54997e60ae9e3e87fd8fb3c73372837d8562770f"
+source = "git+https://github.com/starkware-libs/blockifier#c086ac6b6f3673dbd4833bf3982d79ed7e030df2"
 dependencies = [
  "cairo-felt",
  "cairo-vm",
@@ -275,7 +275,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 [[package]]
 name = "cairo-felt"
 version = "0.1.3"
-source = "git+https://github.com/lambdaclass/cairo-rs.git#0991fb459420debad28732f539ff829fbebfe57d"
+source = "git+https://github.com/lambdaclass/cairo-rs.git#d13f4968508af28b0f586e2bee7fa4bd372fa8d0"
 dependencies = [
  "lazy_static",
  "num-bigint",
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "0.1.3"
-source = "git+https://github.com/lambdaclass/cairo-rs.git#0991fb459420debad28732f539ff829fbebfe57d"
+source = "git+https://github.com/lambdaclass/cairo-rs.git#d13f4968508af28b0f586e2bee7fa4bd372fa8d0"
 dependencies = [
  "bincode",
  "cairo-felt",
@@ -1224,14 +1224,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1328,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -1401,7 +1401,7 @@ dependencies = [
 [[package]]
 name = "papyrus_storage"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/papyrus#4c2882b62859a695befbb1f81d0126d1acf87035"
+source = "git+https://github.com/starkware-libs/papyrus#494e759eb3795816633d3cd30a463901709caaf7"
 dependencies = [
  "bincode",
  "flate2",
@@ -1476,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "git+https://github.com/lambdaclass/cairo-rs.git#0991fb459420debad28732f539ff829fbebfe57d"
+source = "git+https://github.com/lambdaclass/cairo-rs.git#d13f4968508af28b0f586e2bee7fa4bd372fa8d0"
 dependencies = [
  "nom",
 ]
@@ -2286,7 +2286,7 @@ dependencies = [
 [[package]]
 name = "test_utils"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/papyrus#4c2882b62859a695befbb1f81d0126d1acf87035"
+source = "git+https://github.com/starkware-libs/papyrus#494e759eb3795816633d3cd30a463901709caaf7"
 dependencies = [
  "indexmap",
  "rand",

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -13,9 +13,7 @@ name = "native_blockifier"
 crate-type = ["cdylib"]
 
 [dependencies]
-blockifier = { git = "https://github.com/starkware-libs/blockifier", features = [
-    "testing",
-] }
+blockifier = { git = "https://github.com/starkware-libs/blockifier" }
 hex = { version = "0.4.3" }
 indexmap = { version = "1.9.2" }
 num-bigint = { version = "0.4" }

--- a/crates/native_blockifier/src/py_transaction.rs
+++ b/crates/native_blockifier/src/py_transaction.rs
@@ -125,11 +125,8 @@ pub fn py_l1_handler(tx: &PyAny) -> NativeBlockifierResult<L1HandlerTransaction>
 }
 
 pub fn py_tx(tx: &PyAny, tx_type: &str) -> NativeBlockifierResult<Transaction> {
+    // TODO: Add "DECLARE".
     match tx_type {
-        "DECLARE" => {
-            let declare_tx = AccountTransaction::Declare(py_declare(tx)?);
-            Ok(Transaction::AccountTransaction(declare_tx))
-        }
         "DEPLOY_ACCOUNT" => {
             let deploy_account_tx = AccountTransaction::DeployAccount(py_deploy_account(tx)?);
             Ok(Transaction::AccountTransaction(deploy_account_tx))


### PR DESCRIPTION
- The broken branch was caused by a divergence of versions between blockifier and native_blockifier, will be fixed soon.
- The import we need from blockifier is no longer behind a testing feature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/282)
<!-- Reviewable:end -->
