### PR TITLE
Grab blockifier by path instead of by git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,28 +227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blockifier"
-version = "0.1.0"
-source = "git+https://github.com/starkware-libs/blockifier#c086ac6b6f3673dbd4833bf3982d79ed7e030df2"
-dependencies = [
- "cairo-felt",
- "cairo-vm",
- "derive_more",
- "indexmap",
- "itertools",
- "num-bigint",
- "num-integer",
- "num-traits",
- "once_cell",
- "papyrus_storage",
- "serde",
- "serde_json",
- "sha3 0.10.6",
- "starknet_api",
- "thiserror",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,7 +1234,7 @@ dependencies = [
 name = "native_blockifier"
 version = "0.1.0"
 dependencies = [
- "blockifier 0.1.0 (git+https://github.com/starkware-libs/blockifier)",
+ "blockifier",
  "hex",
  "indexmap",
  "num-bigint",

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -13,7 +13,7 @@ name = "native_blockifier"
 crate-type = ["cdylib"]
 
 [dependencies]
-blockifier = { git = "https://github.com/starkware-libs/blockifier" }
+blockifier = { path = "../blockifier" }
 hex = { version = "0.4.3" }
 indexmap = { version = "1.9.2" }
 num-bigint = { version = "0.4" }

--- a/crates/native_blockifier/build.sh
+++ b/crates/native_blockifier/build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -ex
-
-docker run --rm -v `pwd`:/io quay.io/pypa/manylinux2014_x86_64 bash /io/build_wheels.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+
+root_dir="$(cd `dirname $0` && pwd -P)/../"
+
+docker run --rm -v $root_dir:/io quay.io/pypa/manylinux2014_x86_64 bash /io/scripts/build_wheels.sh

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+pushd /io/crates/native_blockifier/
+
 # Install crate dependencies.
 yum -y install centos-release-scl
 yum -y install openssl-devel llvm-toolset-7.0
@@ -19,14 +21,14 @@ pypy_bins=$(echo /opt/python/pp{37,38,39}*/bin)
 
 # Compile wheels.
 for py_bin in ${cpython_bins} ${pypy_bins}; do
-    rm -rf /io/build/
+    rm -rf build/
     "${py_bin}/pip" install -U setuptools setuptools-rust wheel
-    "${py_bin}/pip" wheel /io/ -w /io/dist/ --no-deps
+    "${py_bin}/pip" wheel ./ -w ./dist/ --no-deps
 done
 
 # Bundle external shared libraries into the wheels.
-for whl in /io/dist/*{cp37,cp38,cp39,cp310,pp37,pp38,pp39}*.whl; do
-    auditwheel repair "$whl" -w /io/dist/
+for whl in dist/*{cp37,cp38,cp39,cp310,pp37,pp38,pp39}*.whl; do
+    auditwheel repair "$whl" -w ./dist/
 done
 
 # Install packages and test.
@@ -35,3 +37,5 @@ for py_bin in ${cpython_bins} ${pypy_bins}; do
     echo "Testing with $("${py_bin}/python" --version) ..."
     "${py_bin}/python" -c "import native_blockifier; print('native_blockifier import success')"
 done
+
+popd


### PR DESCRIPTION
Taking by git creates divergence of versions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/283)
<!-- Reviewable:end -->
