### PR TITLE
Create `BlockHeader` when appending state diff

### DIFF
--- a/crates/native_blockifier/src/errors.rs
+++ b/crates/native_blockifier/src/errors.rs
@@ -1,0 +1,27 @@
+use blockifier::transaction::errors::TransactionExecutionError;
+use pyo3::exceptions::PyOSError;
+use pyo3::prelude::*;
+use starknet_api::StarknetApiError;
+
+pub type NativeBlockifierResult<T> = Result<T, NativeBlockifierError>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum NativeBlockifierError {
+    #[error(transparent)]
+    Pyo3Error(#[from] PyErr),
+    #[error(transparent)]
+    StarknetApiError(#[from] StarknetApiError),
+    #[error(transparent)]
+    TransactionExecutionError(#[from] TransactionExecutionError),
+    #[error(transparent)]
+    StorageError(#[from] papyrus_storage::StorageError),
+}
+
+impl From<NativeBlockifierError> for PyErr {
+    fn from(error: NativeBlockifierError) -> PyErr {
+        match error {
+            NativeBlockifierError::Pyo3Error(py_error) => py_error,
+            _ => PyOSError::new_err(error.to_string()),
+        }
+    }
+}

--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -1,24 +1,14 @@
+pub mod errors;
 pub mod py_state_diff;
 pub mod py_transaction;
 pub mod py_utils;
+pub mod storage;
 
-use std::convert::TryFrom;
-
-use blockifier::transaction::errors::TransactionExecutionError;
-use indexmap::IndexMap;
-use papyrus_storage::header::HeaderStorageReader;
-use papyrus_storage::state::{StateStorageReader, StateStorageWriter};
 use py_transaction::PyTransactionExecutor;
-use pyo3::exceptions::PyOSError;
 use pyo3::prelude::*;
-use starknet_api::block::BlockNumber;
-use starknet_api::core::ClassHash;
-use starknet_api::state::{ContractClass, StateDiff};
-use starknet_api::StarknetApiError;
+use storage::Storage;
 
 use crate::py_state_diff::PyStateDiff;
-
-pub type NativeBlockifierResult<T> = Result<T, NativeBlockifierError>;
 
 #[pymodule]
 fn native_blockifier(_py: Python<'_>, py_module: &PyModule) -> PyResult<()> {
@@ -27,92 +17,4 @@ fn native_blockifier(_py: Python<'_>, py_module: &PyModule) -> PyResult<()> {
     py_module.add_class::<Storage>()?;
 
     Ok(())
-}
-
-#[pyclass]
-pub struct Storage {
-    pub reader: papyrus_storage::StorageReader,
-    pub writer: papyrus_storage::StorageWriter,
-}
-
-#[pymethods]
-impl Storage {
-    #[new]
-    #[args(path)]
-    pub fn new(path: String) -> NativeBlockifierResult<Storage> {
-        let db_config = papyrus_storage::db::DbConfig {
-            path,
-            max_size: 1 << 35, // 32GB.
-        };
-
-        let (reader, writer) = papyrus_storage::open_storage(db_config)?;
-        Ok(Storage { reader, writer })
-    }
-
-    pub fn get_state_marker(&self) -> NativeBlockifierResult<u64> {
-        let block_number = self.reader.begin_ro_txn()?.get_state_marker()?;
-        Ok(block_number.0)
-    }
-
-    #[args(block_number)]
-    pub fn get_block_hash(&self, block_number: u64) -> NativeBlockifierResult<Option<Vec<u8>>> {
-        let block_number = BlockNumber(block_number);
-        let block_hash = self
-            .reader
-            .begin_ro_txn()?
-            .get_block_header(block_number)?
-            .map(|block_header| Vec::from(block_header.block_hash.0.bytes()));
-        Ok(block_hash)
-    }
-
-    #[args(block_number)]
-    pub fn revert_state_diff(&mut self, block_number: u64) -> NativeBlockifierResult<()> {
-        let (revert_txn, _) =
-            self.writer.begin_rw_txn()?.revert_state_diff(BlockNumber(block_number))?;
-        revert_txn.commit()?;
-        Ok(())
-    }
-
-    #[args(block_number, py_state_diff, _py_deployed_contract_class_definitions)]
-    pub fn append_state_diff(
-        &mut self,
-        block_number: u64,
-        py_state_diff: PyStateDiff,
-        _py_deployed_contract_class_definitions: &PyAny,
-    ) -> NativeBlockifierResult<()> {
-        let block_number = BlockNumber(block_number);
-        let state_diff = StateDiff::try_from(py_state_diff)?;
-        // TODO: Figure out how to go from `py_state_diff.class_hash_to_compiled_class_hash` into
-        // this type.
-        let deployed_contract_class_definitions = IndexMap::<ClassHash, ContractClass>::new();
-
-        let append_txn = self.writer.begin_rw_txn()?.append_state_diff(
-            block_number,
-            state_diff,
-            deployed_contract_class_definitions,
-        );
-        append_txn?.commit()?;
-        Ok(())
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum NativeBlockifierError {
-    #[error(transparent)]
-    Pyo3Error(#[from] PyErr),
-    #[error(transparent)]
-    StarknetApiError(#[from] StarknetApiError),
-    #[error(transparent)]
-    TransactionExecutionError(#[from] TransactionExecutionError),
-    #[error(transparent)]
-    StorageError(#[from] papyrus_storage::StorageError),
-}
-
-impl From<NativeBlockifierError> for PyErr {
-    fn from(error: NativeBlockifierError) -> PyErr {
-        match error {
-            NativeBlockifierError::Pyo3Error(py_error) => py_error,
-            _ => PyOSError::new_err(error.to_string()),
-        }
-    }
 }

--- a/crates/native_blockifier/src/py_state_diff.rs
+++ b/crates/native_blockifier/src/py_state_diff.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::state::{StateDiff, StorageKey};
 
-use super::{NativeBlockifierError, NativeBlockifierResult};
+use crate::errors::{NativeBlockifierError, NativeBlockifierResult};
 use crate::py_utils::PyFelt;
 
 #[pyclass]
@@ -80,4 +80,12 @@ impl From<StateDiff> for PyStateDiff {
 
         Self { address_to_class_hash, address_to_nonce, storage_updates }
     }
+}
+
+#[derive(FromPyObject)]
+pub struct PyBlockInfo {
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    pub gas_price: u128,
+    pub sequencer_address: PyFelt,
 }

--- a/crates/native_blockifier/src/py_transaction.rs
+++ b/crates/native_blockifier/src/py_transaction.rs
@@ -20,9 +20,9 @@ use starknet_api::transaction::{
     TransactionVersion,
 };
 
+use crate::errors::{NativeBlockifierError, NativeBlockifierResult};
 use crate::py_state_diff::PyStateDiff;
 use crate::py_utils::biguint_to_felt;
-use crate::{NativeBlockifierError, NativeBlockifierResult};
 
 fn py_attr<T>(obj: &PyAny, attr: &str) -> NativeBlockifierResult<T>
 where

--- a/crates/native_blockifier/src/py_utils.rs
+++ b/crates/native_blockifier/src/py_utils.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 use starknet_api::core::ContractAddress;
 use starknet_api::hash::StarkFelt;
 
-use crate::NativeBlockifierResult;
+use crate::errors::NativeBlockifierResult;
 
 #[derive(Eq, FromPyObject, Hash, PartialEq, Clone, Copy)]
 pub struct PyFelt(#[pyo3(from_py_with = "pyint_to_stark_felt")] pub StarkFelt);

--- a/crates/native_blockifier/src/storage.rs
+++ b/crates/native_blockifier/src/storage.rs
@@ -1,0 +1,99 @@
+use std::convert::TryFrom;
+
+use indexmap::IndexMap;
+use papyrus_storage::header::{HeaderStorageReader, HeaderStorageWriter};
+use papyrus_storage::state::{StateStorageReader, StateStorageWriter};
+use pyo3::prelude::*;
+use starknet_api::block::{BlockHash, BlockHeader, BlockNumber, BlockTimestamp, GasPrice};
+use starknet_api::core::{ClassHash, ContractAddress, GlobalRoot};
+use starknet_api::hash::StarkHash;
+use starknet_api::state::{ContractClass, StateDiff};
+
+use crate::errors::NativeBlockifierResult;
+use crate::py_state_diff::PyBlockInfo;
+use crate::PyStateDiff;
+
+#[pyclass]
+pub struct Storage {
+    pub reader: papyrus_storage::StorageReader,
+    pub writer: papyrus_storage::StorageWriter,
+}
+
+#[pymethods]
+impl Storage {
+    #[new]
+    #[args(path)]
+    pub fn new(path: String) -> NativeBlockifierResult<Storage> {
+        let db_config = papyrus_storage::db::DbConfig {
+            path,
+            max_size: 1 << 35, // 32GB.
+        };
+
+        let (reader, writer) = papyrus_storage::open_storage(db_config)?;
+        Ok(Storage { reader, writer })
+    }
+
+    pub fn get_state_marker(&self) -> NativeBlockifierResult<u64> {
+        let block_number = self.reader.begin_ro_txn()?.get_state_marker()?;
+        Ok(block_number.0)
+    }
+
+    #[args(block_number)]
+    pub fn get_block_hash(&self, block_number: u64) -> NativeBlockifierResult<Option<Vec<u8>>> {
+        let block_number = BlockNumber(block_number);
+        let block_hash = self
+            .reader
+            .begin_ro_txn()?
+            .get_block_header(block_number)?
+            .map(|block_header| Vec::from(block_header.block_hash.0.bytes()));
+        Ok(block_hash)
+    }
+
+    #[args(block_number)]
+    pub fn revert_state_diff(&mut self, block_number: u64) -> NativeBlockifierResult<()> {
+        let block_number = BlockNumber(block_number);
+        let revert_txn = self.writer.begin_rw_txn()?;
+        let (revert_txn, _) = revert_txn.revert_state_diff(block_number)?;
+        let revert_txn = revert_txn.revert_header(block_number)?;
+
+        revert_txn.commit()?;
+        Ok(())
+    }
+
+    #[args(block_number, py_state_diff, _py_deployed_contract_class_definitions)]
+    /// Appends state diff and block header into Papyrus storage.
+    pub fn append_state_diff(
+        &mut self,
+        block_id: u64,
+        previous_block_id: u64,
+        py_block_info: PyBlockInfo,
+        py_state_diff: PyStateDiff,
+        _py_deployed_contract_class_definitions: &PyAny,
+    ) -> NativeBlockifierResult<()> {
+        let block_number = BlockNumber(py_block_info.block_number);
+        let state_diff = StateDiff::try_from(py_state_diff)?;
+        // TODO: Figure out how to go from `py_state_diff.class_hash_to_compiled_class_hash` into
+        // this type.
+        let deployed_contract_class_definitions = IndexMap::<ClassHash, ContractClass>::new();
+        let append_txn = self.writer.begin_rw_txn()?.append_state_diff(
+            block_number,
+            state_diff,
+            deployed_contract_class_definitions,
+        );
+        let append_txn = append_txn?;
+
+        let block_header = BlockHeader {
+            block_hash: BlockHash(StarkHash::from(block_id)),
+            parent_hash: BlockHash(StarkHash::from(previous_block_id)),
+            block_number,
+            gas_price: GasPrice(py_block_info.gas_price),
+            state_root: GlobalRoot::default(),
+            sequencer: ContractAddress::try_from(py_block_info.sequencer_address.0)?,
+            timestamp: BlockTimestamp(py_block_info.block_timestamp),
+        };
+        let append_txn = append_txn.append_header(block_number, &block_header)?;
+
+        append_txn.commit()?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Motivation: block hashes are needed for comparisons between blocks into Python DB vs Rust DB.
Block hashes are currently set as the block ids of the Python blocks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/286)
<!-- Reviewable:end -->
