### PR TITLE
Fix code after cargo update (changes done by LC).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 [[package]]
 name = "cairo-felt"
 version = "0.1.3"
-source = "git+https://github.com/lambdaclass/cairo-rs.git#d13f4968508af28b0f586e2bee7fa4bd372fa8d0"
+source = "git+https://github.com/lambdaclass/cairo-rs.git#abaf2151036e094abe573f6be40123bb0aed2002"
 dependencies = [
  "lazy_static",
  "num-bigint",
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "0.1.3"
-source = "git+https://github.com/lambdaclass/cairo-rs.git#d13f4968508af28b0f586e2bee7fa4bd372fa8d0"
+source = "git+https://github.com/lambdaclass/cairo-rs.git#abaf2151036e094abe573f6be40123bb0aed2002"
 dependencies = [
  "bincode",
  "cairo-felt",
@@ -313,9 +313,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
+checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
 dependencies = [
  "glob",
  "libc",
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "papyrus_storage"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/papyrus#e5657ddccc1653b3760d1d852fba55c537779477"
+source = "git+https://github.com/starkware-libs/papyrus#b18ccbfc08a33a54c502ea91735a859083609901"
 dependencies = [
  "bincode",
  "flate2",
@@ -1455,7 +1455,7 @@ dependencies = [
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "git+https://github.com/lambdaclass/cairo-rs.git#d13f4968508af28b0f586e2bee7fa4bd372fa8d0"
+source = "git+https://github.com/lambdaclass/cairo-rs.git#abaf2151036e094abe573f6be40123bb0aed2002"
 dependencies = [
  "nom",
 ]
@@ -2265,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "test_utils"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/papyrus#e5657ddccc1653b3760d1d852fba55c537779477"
+source = "git+https://github.com/starkware-libs/papyrus#b18ccbfc08a33a54c502ea91735a859083609901"
 dependencies = [
  "indexmap",
  "rand",

--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -354,7 +354,7 @@ fn test_post_run_validation_security_failure() {
     );
 
     run_security_test(
-        "Missing memory cells for builtin hash",
+        "Missing memory cells for builtin pedersen",
         "test_missing_pedersen_values",
         calldata![],
         &mut state,

--- a/crates/blockifier/src/execution/syscalls.rs
+++ b/crates/blockifier/src/execution/syscalls.rs
@@ -86,13 +86,13 @@ const ARRAY_METADATA_SIZE: usize = 2;
 pub trait SyscallRequest: Sized {
     const SIZE: usize;
 
-    fn read(_vm: &VirtualMachine, _ptr: &Relocatable) -> SyscallResult<Self>;
+    fn read(_vm: &VirtualMachine, _ptr: Relocatable) -> SyscallResult<Self>;
 }
 
 pub trait SyscallResponse {
     const SIZE: usize;
 
-    fn write(self, _vm: &mut VirtualMachine, _ptr: &Relocatable) -> WriteResponseResult;
+    fn write(self, _vm: &mut VirtualMachine, _ptr: Relocatable) -> WriteResponseResult;
 }
 
 // Common structs.
@@ -103,7 +103,7 @@ pub struct EmptyRequest;
 impl SyscallRequest for EmptyRequest {
     const SIZE: usize = 0;
 
-    fn read(_vm: &VirtualMachine, _ptr: &Relocatable) -> SyscallResult<EmptyRequest> {
+    fn read(_vm: &VirtualMachine, _ptr: Relocatable) -> SyscallResult<EmptyRequest> {
         Ok(EmptyRequest)
     }
 }
@@ -114,7 +114,7 @@ pub struct EmptyResponse;
 impl SyscallResponse for EmptyResponse {
     const SIZE: usize = 0;
 
-    fn write(self, _vm: &mut VirtualMachine, _ptr: &Relocatable) -> WriteResponseResult {
+    fn write(self, _vm: &mut VirtualMachine, _ptr: Relocatable) -> WriteResponseResult {
         Ok(())
     }
 }
@@ -127,9 +127,9 @@ pub struct SingleSegmentResponse {
 impl SyscallResponse for SingleSegmentResponse {
     const SIZE: usize = ARRAY_METADATA_SIZE;
 
-    fn write(self, vm: &mut VirtualMachine, ptr: &Relocatable) -> WriteResponseResult {
+    fn write(self, vm: &mut VirtualMachine, ptr: Relocatable) -> WriteResponseResult {
         vm.insert_value(ptr, self.segment.length)?;
-        Ok(vm.insert_value(&(ptr + 1), self.segment.start_ptr)?)
+        Ok(vm.insert_value(ptr + 1, self.segment.start_ptr)?)
     }
 }
 
@@ -143,7 +143,7 @@ pub struct StorageReadRequest {
 impl SyscallRequest for StorageReadRequest {
     const SIZE: usize = 1;
 
-    fn read(vm: &VirtualMachine, ptr: &Relocatable) -> SyscallResult<StorageReadRequest> {
+    fn read(vm: &VirtualMachine, ptr: Relocatable) -> SyscallResult<StorageReadRequest> {
         let address = StorageKey::try_from(felt_from_memory_ptr(vm, ptr)?)?;
         Ok(StorageReadRequest { address })
     }
@@ -157,7 +157,7 @@ pub struct StorageReadResponse {
 impl SyscallResponse for StorageReadResponse {
     const SIZE: usize = 1;
 
-    fn write(self, vm: &mut VirtualMachine, ptr: &Relocatable) -> WriteResponseResult {
+    fn write(self, vm: &mut VirtualMachine, ptr: Relocatable) -> WriteResponseResult {
         write_felt(vm, ptr, self.value)
     }
 }
@@ -184,9 +184,9 @@ pub struct StorageWriteRequest {
 impl SyscallRequest for StorageWriteRequest {
     const SIZE: usize = 2;
 
-    fn read(vm: &VirtualMachine, ptr: &Relocatable) -> SyscallResult<StorageWriteRequest> {
+    fn read(vm: &VirtualMachine, ptr: Relocatable) -> SyscallResult<StorageWriteRequest> {
         let address = StorageKey::try_from(felt_from_memory_ptr(vm, ptr)?)?;
-        let value = felt_from_memory_ptr(vm, &(ptr + 1))?;
+        let value = felt_from_memory_ptr(vm, ptr + 1)?;
         Ok(StorageWriteRequest { address, value })
     }
 }
@@ -219,9 +219,9 @@ pub struct CallContractRequest {
 impl SyscallRequest for CallContractRequest {
     const SIZE: usize = 2 + ARRAY_METADATA_SIZE;
 
-    fn read(vm: &VirtualMachine, ptr: &Relocatable) -> SyscallResult<CallContractRequest> {
+    fn read(vm: &VirtualMachine, ptr: Relocatable) -> SyscallResult<CallContractRequest> {
         let contract_address = ContractAddress::try_from(felt_from_memory_ptr(vm, ptr)?)?;
-        let (function_selector, calldata) = read_call_params(vm, &(ptr + 1))?;
+        let (function_selector, calldata) = read_call_params(vm, ptr + 1)?;
 
         Ok(CallContractRequest { contract_address, function_selector, calldata })
     }
@@ -259,9 +259,9 @@ pub struct LibraryCallRequest {
 impl SyscallRequest for LibraryCallRequest {
     const SIZE: usize = 2 + ARRAY_METADATA_SIZE;
 
-    fn read(vm: &VirtualMachine, ptr: &Relocatable) -> SyscallResult<LibraryCallRequest> {
+    fn read(vm: &VirtualMachine, ptr: Relocatable) -> SyscallResult<LibraryCallRequest> {
         let class_hash = ClassHash(felt_from_memory_ptr(vm, ptr)?);
-        let (function_selector, calldata) = read_call_params(vm, &(ptr + 1))?;
+        let (function_selector, calldata) = read_call_params(vm, ptr + 1)?;
 
         Ok(LibraryCallRequest { class_hash, function_selector, calldata })
     }
@@ -365,11 +365,11 @@ pub struct DeployRequest {
 impl SyscallRequest for DeployRequest {
     const SIZE: usize = 3 + ARRAY_METADATA_SIZE;
 
-    fn read(vm: &VirtualMachine, ptr: &Relocatable) -> SyscallResult<DeployRequest> {
+    fn read(vm: &VirtualMachine, ptr: Relocatable) -> SyscallResult<DeployRequest> {
         let class_hash = ClassHash(felt_from_memory_ptr(vm, ptr)?);
-        let contract_address_salt = ContractAddressSalt(felt_from_memory_ptr(vm, &(ptr + 1))?);
-        let constructor_calldata = read_calldata(vm, &(ptr + 2))?;
-        let deploy_from_zero = felt_from_memory_ptr(vm, &(ptr + 2 + ARRAY_METADATA_SIZE))?;
+        let contract_address_salt = ContractAddressSalt(felt_from_memory_ptr(vm, ptr + 1)?);
+        let constructor_calldata = read_calldata(vm, ptr + 2)?;
+        let deploy_from_zero = felt_from_memory_ptr(vm, ptr + 2 + ARRAY_METADATA_SIZE)?;
 
         Ok(DeployRequest {
             class_hash,
@@ -391,10 +391,10 @@ impl SyscallResponse for DeployResponse {
     // Nonempty constructor retdata is currently not supported.
     const SIZE: usize = 1 + ARRAY_METADATA_SIZE;
 
-    fn write(self, vm: &mut VirtualMachine, ptr: &Relocatable) -> WriteResponseResult {
+    fn write(self, vm: &mut VirtualMachine, ptr: Relocatable) -> WriteResponseResult {
         write_felt(vm, ptr, *self.contract_address.0.key())?;
-        vm.insert_value(&(ptr + 1), 0)?;
-        Ok(vm.insert_value(&(ptr + 2), 0)?)
+        vm.insert_value(ptr + 1, 0)?;
+        Ok(vm.insert_value(ptr + 2, 0)?)
     }
 }
 
@@ -440,9 +440,9 @@ impl SyscallRequest for EmitEventRequest {
     // The Cairo struct contains: `keys_len`, `keys`, `data_len`, `data`·
     const SIZE: usize = 2 * ARRAY_METADATA_SIZE;
 
-    fn read(vm: &VirtualMachine, ptr: &Relocatable) -> SyscallResult<EmitEventRequest> {
+    fn read(vm: &VirtualMachine, ptr: Relocatable) -> SyscallResult<EmitEventRequest> {
         let keys = read_felt_array(vm, ptr)?.into_iter().map(EventKey).collect();
-        let data = EventData(read_felt_array(vm, &(ptr + ARRAY_METADATA_SIZE))?);
+        let data = EventData(read_felt_array(vm, ptr + ARRAY_METADATA_SIZE)?);
 
         Ok(EmitEventRequest { content: EventContent { keys, data } })
     }
@@ -471,9 +471,9 @@ impl SyscallRequest for SendMessageToL1Request {
     // The Cairo struct contains: `to_address`, `payload_size`, `payload`.
     const SIZE: usize = 1 + ARRAY_METADATA_SIZE;
 
-    fn read(vm: &VirtualMachine, ptr: &Relocatable) -> SyscallResult<SendMessageToL1Request> {
+    fn read(vm: &VirtualMachine, ptr: Relocatable) -> SyscallResult<SendMessageToL1Request> {
         let to_address = EthAddress::try_from(felt_from_memory_ptr(vm, ptr)?)?;
-        let payload = L2ToL1Payload(read_felt_array(vm, &(ptr + 1))?);
+        let payload = L2ToL1Payload(read_felt_array(vm, ptr + 1)?);
 
         Ok(SendMessageToL1Request { message: MessageToL1 { to_address, payload } })
     }
@@ -503,7 +503,7 @@ pub struct GetContractAddressResponse {
 impl SyscallResponse for GetContractAddressResponse {
     const SIZE: usize = 1;
 
-    fn write(self, vm: &mut VirtualMachine, ptr: &Relocatable) -> WriteResponseResult {
+    fn write(self, vm: &mut VirtualMachine, ptr: Relocatable) -> WriteResponseResult {
         write_felt(vm, ptr, *self.address.0.key())
     }
 }
@@ -554,7 +554,7 @@ pub struct GetBlockNumberResponse {
 impl SyscallResponse for GetBlockNumberResponse {
     const SIZE: usize = 1;
 
-    fn write(self, vm: &mut VirtualMachine, ptr: &Relocatable) -> WriteResponseResult {
+    fn write(self, vm: &mut VirtualMachine, ptr: Relocatable) -> WriteResponseResult {
         Ok(vm.insert_value(ptr, Felt::from(self.block_number.0))?)
     }
 }
@@ -579,7 +579,7 @@ pub struct GetBlockTimestampResponse {
 impl SyscallResponse for GetBlockTimestampResponse {
     const SIZE: usize = 1;
 
-    fn write(self, vm: &mut VirtualMachine, ptr: &Relocatable) -> WriteResponseResult {
+    fn write(self, vm: &mut VirtualMachine, ptr: Relocatable) -> WriteResponseResult {
         Ok(vm.insert_value(ptr, Felt::from(self.block_timestamp.0))?)
     }
 }
@@ -620,7 +620,7 @@ pub struct GetTxInfoResponse {
 impl SyscallResponse for GetTxInfoResponse {
     const SIZE: usize = 1;
 
-    fn write(self, vm: &mut VirtualMachine, ptr: &Relocatable) -> WriteResponseResult {
+    fn write(self, vm: &mut VirtualMachine, ptr: Relocatable) -> WriteResponseResult {
         Ok(vm.insert_value(ptr, self.tx_info_start_ptr)?)
     }
 }


### PR DESCRIPTION
- Change the `Program` `builtin` field to type `Vec<&'static str>` (extract it using the `BuiltinName` enum) [#841](https://github.com/lambdaclass/cairo-rs/pull/841/files).
- Remove references to Relocatable [#850](https://github.com/lambdaclass/cairo-rs/pull/850/files)
- Change the hash to be named pedersen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/288)
<!-- Reviewable:end -->
