### PR TITLE
Change native-blockifier version

### DIFF
--- a/crates/native_blockifier/setup.py
+++ b/crates/native_blockifier/setup.py
@@ -3,7 +3,7 @@ from setuptools_rust import Binding, RustExtension
 
 setup(
     name="native_blockifier",
-    version="1.0",
+    version="0.11.0",
     rust_extensions=[RustExtension("native_blockifier.native_blockifier", binding=Binding.PyO3)],
     author="Starkware",
     author_email="info@starkware.co",


### PR DESCRIPTION
This tag is used when deploying to pypi, and should be marked as a 0.X version, given its current state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/318)
<!-- Reviewable:end -->
