### PR TITLE
Add logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +247,7 @@ dependencies = [
  "derive_more",
  "indexmap",
  "itertools",
+ "log",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1307,10 +1314,12 @@ dependencies = [
  "blockifier",
  "hex",
  "indexmap",
+ "log",
  "num-bigint",
  "ouroboros",
  "papyrus_storage",
  "pyo3",
+ "pyo3-log",
  "serde_json",
  "starknet_api",
  "thiserror",
@@ -1717,6 +1726,17 @@ checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
 dependencies = [
  "libc",
  "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-log"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c8b57fe71fb5dcf38970ebedc2b1531cf1c14b1b9b4c560a182a57e115575c"
+dependencies = [
+ "arc-swap",
+ "log",
+ "pyo3",
 ]
 
 [[package]]

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -14,6 +14,7 @@ cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git" , rev = "77fe09
 derive_more = { version = "0.99.17" }
 indexmap = { version = "1.9.2" }
 itertools = { version = "0.10.3" }
+log = { version = "0.4" }
 num-bigint = { version = "0.4" }
 num-integer = { version = "0.1.45" }
 num-traits = { version = "0.2" }

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -20,7 +20,7 @@ use crate::state::cached_state::TransactionalState;
 use crate::state::state_api::{State, StateReader};
 use crate::transaction::constants;
 use crate::transaction::errors::{
-    FeeTransferError, InvokeTransactionError, TransactionExecutionError,
+    FeeTransferError, InvokeTransactionError, TransactionExecutionError, ValidateTransactionError,
 };
 use crate::transaction::objects::{
     AccountTransactionContext, ResourcesMapping, TransactionExecutionInfo,
@@ -154,13 +154,15 @@ impl AccountTransaction {
         };
         let mut execution_context = ExecutionContext::default();
 
-        let validate_call_info = validate_call.execute(
-            state,
-            execution_resources,
-            &mut execution_context,
-            block_context,
-            account_tx_context,
-        )?;
+        let validate_call_info = validate_call
+            .execute(
+                state,
+                execution_resources,
+                &mut execution_context,
+                block_context,
+                account_tx_context,
+            )
+            .map_err(ValidateTransactionError::ValidateExecutionFailed)?;
         verify_no_calls_to_other_contracts(
             &validate_call_info,
             String::from(constants::VALIDATE_ENTRY_POINT_NAME),

--- a/crates/blockifier/src/transaction/errors.rs
+++ b/crates/blockifier/src/transaction/errors.rs
@@ -25,11 +25,33 @@ pub enum DeclareTransactionError {
 }
 
 #[derive(Debug, Error)]
+pub enum ContractConstructorExecutionError {
+    #[error("Contract constructor execution has failed.")]
+    ContractConstructorExecutionFailed(#[from] EntryPointExecutionError),
+}
+
+#[derive(Debug, Error)]
+pub enum ValidateTransactionError {
+    #[error("Transaction validation has failed.")]
+    ValidateExecutionFailed(#[from] EntryPointExecutionError),
+}
+
+#[derive(Debug, Error)]
+pub enum ExecuteTransactionError {
+    #[error("Transaction execution has failed.")]
+    ExecutionError(#[from] EntryPointExecutionError),
+}
+
+#[derive(Debug, Error)]
 pub enum TransactionExecutionError {
+    #[error(transparent)]
+    ContractConstructorExecutionFailed(#[from] ContractConstructorExecutionError),
     #[error(transparent)]
     DeclareTransactionError(#[from] DeclareTransactionError),
     #[error(transparent)]
     EntryPointExecutionError(#[from] EntryPointExecutionError),
+    #[error(transparent)]
+    ExecutionError(#[from] ExecuteTransactionError),
     #[error(transparent)]
     FeeTransferError(#[from] FeeTransferError),
     #[error("Invalid transaction nonce. Expected: {expected_nonce:?}; got: {actual_nonce:?}.")]
@@ -49,4 +71,6 @@ pub enum TransactionExecutionError {
     UnauthorizedInnerCall { entry_point_kind: String },
     #[error("Unknown chain ID '{chain_id:?}'.")]
     UnknownChainId { chain_id: String },
+    #[error(transparent)]
+    ValidateTransactionError(#[from] ValidateTransactionError),
 }

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib"]
 blockifier = { path = "../blockifier" }
 hex = { version = "0.4.3" }
 indexmap = { version = "1.9.2" }
+log = { version = "0.4" }
 num-bigint = { version = "0.4" }
 ouroboros = { version = "0.15.6" }
 papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "14a7f0f", features = [
@@ -26,6 +27,8 @@ pyo3 = { version = "0.17.3", features = [
     "num-bigint",
     "hashbrown",
 ] }
+pyo3-log = { version = "0.8.1" }
+# We need this rev to be the same as in both `blockifier` and `papyrus_storage`.
 serde_json = { version = "1.0.81", features = ["arbitrary_precision"] }
 # Should match the commit `papyrus_storage` is using.
 starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "482a359", features = [

--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -20,6 +20,10 @@ use crate::py_utils::raise_error_for_testing;
 
 #[pymodule]
 fn native_blockifier(py: Python<'_>, py_module: &PyModule) -> PyResult<()> {
+    // Initialize Rust-to-Python logging.
+    // Usage: just create a Python logger as usual, and it'll capture Rust prints.
+    pyo3_log::init();
+
     py_module.add_class::<PyCallInfo>()?;
     py_module.add_class::<PyExecutionResources>()?;
     py_module.add_class::<PyOrderedEvent>()?;

--- a/crates/native_blockifier/src/py_transaction.rs
+++ b/crates/native_blockifier/src/py_transaction.rs
@@ -245,12 +245,17 @@ impl PyTransactionExecutor {
         max_size: usize,
         latest_block_id: BigInt,
     ) -> NativeBlockifierResult<Self> {
+        log::debug!("Initializing Transaction Executor...");
+
         // TODO(Elin,01/04/2023): think of how to decouple the args needed to instantiate
         // executor and storage - (storage_path, max_size).
         let storage = Storage::new(storage_path, max_size)?;
         storage.validate_aligned(latest_block_id)?;
         let block_context = py_block_context(general_config, block_info)?;
-        build_tx_executor(block_context, storage.reader)
+        let build_result = build_tx_executor(block_context, storage.reader);
+        log::debug!("Initialized Transaction Executor.");
+
+        build_result
     }
 
     #[args(tx, raw_contract_class, enough_room_for_tx)]
@@ -294,6 +299,10 @@ impl PyTransactionExecutor {
 
     /// Returns the state diff resulting in executing transactions.
     pub fn finalize(&mut self) -> PyStateDiff {
-        PyStateDiff::from(self.borrow_state().to_state_diff())
+        log::debug!("Finalizing execution...");
+        let state_diff = PyStateDiff::from(self.borrow_state().to_state_diff());
+        log::debug!("Finalized execution.");
+
+        state_diff
     }
 }

--- a/crates/native_blockifier/src/storage.rs
+++ b/crates/native_blockifier/src/storage.rs
@@ -31,8 +31,11 @@ impl Storage {
     #[new]
     #[args(path, max_size)]
     pub fn new(path: String, max_size: usize) -> NativeBlockifierResult<Storage> {
+        log::debug!("Initializing Blockifier storage...");
         let db_config = papyrus_storage::db::DbConfig { path, max_size };
         let (reader, writer) = papyrus_storage::open_storage(db_config)?;
+        log::debug!("Initialized Blockifier storage.");
+
         Ok(Storage { reader, writer })
     }
 
@@ -56,6 +59,7 @@ impl Storage {
 
     #[args(block_number)]
     pub fn revert_state_diff(&mut self, block_number: u64) -> NativeBlockifierResult<()> {
+        log::debug!("Reverting state diff for {block_number:?}.");
         let block_number = BlockNumber(block_number);
         let revert_txn = self.writer.begin_rw_txn()?;
         let (revert_txn, _) = revert_txn.revert_state_diff(block_number)?;
@@ -75,6 +79,10 @@ impl Storage {
         py_state_diff: PyStateDiff,
         declared_class_hash_to_class: HashMap<PyFelt, String>,
     ) -> NativeBlockifierResult<()> {
+        log::debug!(
+            "Appending state diff with {block_id:?} for block_number: {}.",
+            py_block_info.block_number
+        );
         let block_number = BlockNumber(py_block_info.block_number);
 
         // Deserialize contract classes.


### PR DESCRIPTION
Since Blockifier is a Lib crate, it suffices to put log statements where necessary, and let the binary user decide on log levels and configs.

In our case, the current user is the Python client, and the above decisions are delegated to it via `Pyo3-log`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/324)
<!-- Reviewable:end -->
