### PR TITLE
Renaming `ExecutionResources`

### DIFF
--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -1,4 +1,4 @@
-use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResources;
 use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::EntryPointType;
@@ -33,8 +33,8 @@ pub struct CallEntryPoint {
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
-pub struct ExecutionResourcesManager {
-    pub vm_resources: ExecutionResources,
+pub struct ExecutionResources {
+    pub vm_resources: VmExecutionResources,
     pub syscall_counter: SyscallCounter,
 }
 
@@ -42,7 +42,7 @@ impl CallEntryPoint {
     pub fn execute(
         self,
         state: &mut dyn State,
-        resources_manager: &mut ExecutionResourcesManager,
+        execution_resources: &mut ExecutionResources,
         block_context: &BlockContext,
         account_tx_context: &AccountTransactionContext,
     ) -> EntryPointExecutionResult<CallInfo> {
@@ -60,7 +60,7 @@ impl CallEntryPoint {
             self,
             class_hash,
             state,
-            resources_manager,
+            execution_resources,
             block_context,
             account_tx_context,
         )
@@ -144,7 +144,7 @@ impl<'a> IntoIterator for &'a CallInfo {
 #[allow(clippy::too_many_arguments)]
 pub fn execute_constructor_entry_point(
     state: &mut dyn State,
-    resources_manager: &mut ExecutionResourcesManager,
+    execution_resources: &mut ExecutionResources,
     block_context: &BlockContext,
     account_tx_context: &AccountTransactionContext,
     class_hash: ClassHash,
@@ -170,7 +170,7 @@ pub fn execute_constructor_entry_point(
         storage_address,
         caller_address,
     };
-    constructor_call.execute(state, resources_manager, block_context, account_tx_context)
+    constructor_call.execute(state, execution_resources, block_context, account_tx_context)
 }
 
 pub fn handle_empty_constructor(

--- a/crates/blockifier/src/execution/execution_utils.rs
+++ b/crates/blockifier/src/execution/execution_utils.rs
@@ -10,7 +10,9 @@ use cairo_vm::types::program::Program;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_vm::vm::errors::memory_errors::MemoryError;
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
-use cairo_vm::vm::runners::cairo_runner::{CairoArg, CairoRunner, ExecutionResources};
+use cairo_vm::vm::runners::cairo_runner::{
+    CairoArg, CairoRunner, ExecutionResources as VmExecutionResources,
+};
 use cairo_vm::vm::vm_core::VirtualMachine;
 use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector};
 use starknet_api::hash::StarkFelt;
@@ -20,7 +22,7 @@ use starknet_api::transaction::Calldata;
 use crate::block_context::BlockContext;
 use crate::execution::entry_point::{
     execute_constructor_entry_point, CallEntryPoint, CallExecution, CallInfo,
-    EntryPointExecutionResult, Retdata,
+    EntryPointExecutionResult, ExecutionResources, Retdata,
 };
 use crate::execution::errors::{
     PostExecutionError, PreExecutionError, VirtualMachineExecutionError,
@@ -29,8 +31,6 @@ use crate::execution::syscall_handling::{execute_inner_call, SyscallHintProcesso
 use crate::execution::syscalls::SyscallResult;
 use crate::state::state_api::State;
 use crate::transaction::objects::AccountTransactionContext;
-
-use super::entry_point::ExecutionResourcesManager;
 
 pub type Args = Vec<CairoArg>;
 
@@ -59,7 +59,7 @@ pub fn initialize_execution_context<'a>(
     call: &CallEntryPoint,
     class_hash: ClassHash,
     state: &'a mut dyn State,
-    resources_manager: &'a mut ExecutionResourcesManager,
+    execution_resources: &'a mut ExecutionResources,
     block_context: &'a BlockContext,
     account_tx_context: &'a AccountTransactionContext,
 ) -> Result<ExecutionContext<'a>, PreExecutionError> {
@@ -79,7 +79,7 @@ pub fn initialize_execution_context<'a>(
     let initial_syscall_ptr = vm.add_memory_segment();
     let syscall_handler = SyscallHintProcessor::new(
         state,
-        resources_manager,
+        execution_resources,
         block_context,
         account_tx_context,
         initial_syscall_ptr,
@@ -131,17 +131,17 @@ pub fn execute_entry_point_call(
     call: CallEntryPoint,
     class_hash: ClassHash,
     state: &mut dyn State,
-    resources_manager: &mut ExecutionResourcesManager,
+    execution_resources: &mut ExecutionResources,
     block_context: &BlockContext,
     account_tx_context: &AccountTransactionContext,
 ) -> EntryPointExecutionResult<CallInfo> {
-    let previous_vm_resources = resources_manager.vm_resources.clone();
+    let previous_vm_resources = execution_resources.vm_resources.clone();
 
     let mut execution_context = initialize_execution_context(
         &call,
         class_hash,
         state,
-        resources_manager,
+        execution_resources,
         block_context,
         account_tx_context,
     )?;
@@ -188,7 +188,7 @@ pub fn finalize_execution(
     mut vm: VirtualMachine,
     cairo_runner: CairoRunner,
     call: CallEntryPoint,
-    _previous_vm_resources: ExecutionResources,
+    _previous_vm_resources: VmExecutionResources,
     syscall_handler: SyscallHintProcessor<'_>,
     implicit_args: Vec<MaybeRelocatable>,
 ) -> Result<CallInfo, PostExecutionError> {
@@ -405,7 +405,7 @@ impl ReadOnlySegments {
 #[allow(clippy::too_many_arguments)]
 pub fn execute_deployment(
     state: &mut dyn State,
-    resources_manager: &mut ExecutionResourcesManager,
+    execution_resources: &mut ExecutionResources,
     block_context: &BlockContext,
     account_tx_context: &AccountTransactionContext,
     class_hash: ClassHash,
@@ -418,7 +418,7 @@ pub fn execute_deployment(
     state.set_class_hash_at(deployed_contract_address, class_hash)?;
     execute_constructor_entry_point(
         state,
-        resources_manager,
+        execution_resources,
         block_context,
         account_tx_context,
         class_hash,

--- a/crates/blockifier/src/execution/syscall_handling.rs
+++ b/crates/blockifier/src/execution/syscall_handling.rs
@@ -19,7 +19,9 @@ use starknet_api::transaction::Calldata;
 
 use crate::block_context::BlockContext;
 use crate::execution::common_hints::{extended_builtin_hint_processor, HintExecutionResult};
-use crate::execution::entry_point::{CallEntryPoint, CallInfo, OrderedEvent, OrderedL2ToL1Message};
+use crate::execution::entry_point::{
+    CallEntryPoint, CallInfo, ExecutionResources, OrderedEvent, OrderedL2ToL1Message,
+};
 use crate::execution::errors::SyscallExecutionError;
 use crate::execution::execution_utils::{
     felt_from_memory_ptr, felt_range_from_ptr, stark_felt_to_felt, ReadOnlySegment,
@@ -35,8 +37,6 @@ use crate::execution::syscalls::{
 use crate::state::state_api::State;
 use crate::transaction::objects::AccountTransactionContext;
 
-use super::entry_point::ExecutionResourcesManager;
-
 pub type SyscallCounter = HashMap<SyscallSelector, usize>;
 
 /// Executes StarkNet syscalls (stateful protocol hints) during the execution of an entry point
@@ -44,7 +44,7 @@ pub type SyscallCounter = HashMap<SyscallSelector, usize>;
 pub struct SyscallHintProcessor<'a> {
     // Input for execution.
     pub state: &'a mut dyn State,
-    pub resources_manager: &'a mut ExecutionResourcesManager,
+    pub execution_resources: &'a mut ExecutionResources,
     pub block_context: &'a BlockContext,
     pub account_tx_context: &'a AccountTransactionContext,
     pub storage_address: ContractAddress,
@@ -75,7 +75,7 @@ pub struct SyscallHintProcessor<'a> {
 impl<'a> SyscallHintProcessor<'a> {
     pub fn new(
         state: &'a mut dyn State,
-        resources_manager: &'a mut ExecutionResourcesManager,
+        execution_resources: &'a mut ExecutionResources,
         block_context: &'a BlockContext,
         account_tx_context: &'a AccountTransactionContext,
         initial_syscall_ptr: Relocatable,
@@ -84,7 +84,7 @@ impl<'a> SyscallHintProcessor<'a> {
     ) -> Self {
         SyscallHintProcessor {
             state,
-            resources_manager,
+            execution_resources,
             block_context,
             account_tx_context,
             storage_address,
@@ -210,7 +210,7 @@ impl<'a> SyscallHintProcessor<'a> {
     }
 
     fn increment_syscall_count(&mut self, selector: &SyscallSelector) {
-        let syscall_count = self.resources_manager.syscall_counter.entry(*selector).or_default();
+        let syscall_count = self.execution_resources.syscall_counter.entry(*selector).or_default();
         *syscall_count += 1;
     }
 
@@ -309,7 +309,7 @@ pub fn execute_inner_call(
 ) -> SyscallResult<ReadOnlySegment> {
     let call_info = call.execute(
         syscall_handler.state,
-        syscall_handler.resources_manager,
+        syscall_handler.execution_resources,
         syscall_handler.block_context,
         syscall_handler.account_tx_context,
     )?;

--- a/crates/blockifier/src/execution/syscalls.rs
+++ b/crates/blockifier/src/execution/syscalls.rs
@@ -417,7 +417,7 @@ pub fn deploy(
 
     let call_info = execute_deployment(
         syscall_handler.state,
-        syscall_handler.resources_manager,
+        syscall_handler.execution_resources,
         syscall_handler.block_context,
         syscall_handler.account_tx_context,
         request.class_hash,

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -19,8 +19,7 @@ use crate::abi::abi_utils::get_storage_var_address;
 use crate::block_context::BlockContext;
 use crate::execution::contract_class::ContractClass;
 use crate::execution::entry_point::{
-    CallEntryPoint, CallExecution, CallInfo, EntryPointExecutionResult, ExecutionResourcesManager,
-    Retdata,
+    CallEntryPoint, CallExecution, CallInfo, EntryPointExecutionResult, ExecutionResources, Retdata,
 };
 use crate::state::cached_state::{CachedState, ContractClassMapping, ContractStorageKey};
 use crate::state::errors::StateError;
@@ -202,7 +201,7 @@ impl CallEntryPoint {
     pub fn execute_directly(self, state: &mut dyn State) -> EntryPointExecutionResult<CallInfo> {
         self.execute(
             state,
-            &mut ExecutionResourcesManager::default(),
+            &mut ExecutionResources::default(),
             &BlockContext::create_for_testing(),
             &AccountTransactionContext::default(),
         )

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -1,7 +1,7 @@
 use starknet_api::transaction::{Fee, L1HandlerTransaction, TransactionSignature};
 
 use crate::block_context::BlockContext;
-use crate::execution::entry_point::ExecutionResourcesManager;
+use crate::execution::entry_point::ExecutionResources;
 use crate::state::cached_state::TransactionalState;
 use crate::state::state_api::StateReader;
 use crate::transaction::account_transaction::AccountTransaction;
@@ -31,13 +31,13 @@ impl<S: StateReader> ExecutableTransaction<S> for L1HandlerTransaction {
             nonce: self.nonce,
             sender_address: self.contract_address,
         };
-        let resources_manager = &mut ExecutionResourcesManager::default();
+        let execution_resources = &mut ExecutionResources::default();
 
         Ok(TransactionExecutionInfo {
             validate_call_info: None,
             execute_call_info: self.run_execute(
                 state,
-                resources_manager,
+                execution_resources,
                 block_context,
                 &tx_context,
                 None,

--- a/crates/blockifier/src/transaction/transactions.rs
+++ b/crates/blockifier/src/transaction/transactions.rs
@@ -9,7 +9,7 @@ use starknet_api::transaction::{
 use crate::abi::abi_utils::selector_from_name;
 use crate::block_context::BlockContext;
 use crate::execution::contract_class::ContractClass;
-use crate::execution::entry_point::{CallEntryPoint, CallInfo, ExecutionResourcesManager};
+use crate::execution::entry_point::{CallEntryPoint, CallInfo, ExecutionResources};
 use crate::execution::execution_utils::execute_deployment;
 use crate::state::cached_state::{CachedState, MutRefState, TransactionalState};
 use crate::state::errors::StateError;
@@ -61,7 +61,7 @@ pub trait Executable<S: State> {
     fn run_execute(
         &self,
         state: &mut S,
-        resources_manager: &mut ExecutionResourcesManager,
+        execution_resources: &mut ExecutionResources,
         block_context: &BlockContext,
         account_tx_context: &AccountTransactionContext,
         // Only used for `DeclareTransaction`.
@@ -73,7 +73,7 @@ impl<S: State> Executable<S> for DeclareTransaction {
     fn run_execute(
         &self,
         state: &mut S,
-        _resources_manager: &mut ExecutionResourcesManager,
+        _execution_resources: &mut ExecutionResources,
         _block_context: &BlockContext,
         _account_tx_context: &AccountTransactionContext,
         contract_class: Option<ContractClass>,
@@ -102,14 +102,14 @@ impl<S: State> Executable<S> for DeployAccountTransaction {
     fn run_execute(
         &self,
         state: &mut S,
-        resources_manager: &mut ExecutionResourcesManager,
+        execution_resources: &mut ExecutionResources,
         block_context: &BlockContext,
         account_tx_context: &AccountTransactionContext,
         _contract_class: Option<ContractClass>,
     ) -> TransactionExecutionResult<Option<CallInfo>> {
         let call_info = execute_deployment(
             state,
-            resources_manager,
+            execution_resources,
             block_context,
             account_tx_context,
             self.class_hash,
@@ -127,7 +127,7 @@ impl<S: State> Executable<S> for InvokeTransaction {
     fn run_execute(
         &self,
         state: &mut S,
-        resources_manager: &mut ExecutionResourcesManager,
+        execution_resources: &mut ExecutionResources,
         block_context: &BlockContext,
         account_tx_context: &AccountTransactionContext,
         _contract_class: Option<ContractClass>,
@@ -143,7 +143,7 @@ impl<S: State> Executable<S> for InvokeTransaction {
 
         Ok(Some(execute_call.execute(
             state,
-            resources_manager,
+            execution_resources,
             block_context,
             account_tx_context,
         )?))
@@ -154,7 +154,7 @@ impl<S: State> Executable<S> for L1HandlerTransaction {
     fn run_execute(
         &self,
         state: &mut S,
-        resources_manager: &mut ExecutionResourcesManager,
+        execution_resources: &mut ExecutionResources,
         block_context: &BlockContext,
         account_tx_context: &AccountTransactionContext,
         _contract_class: Option<ContractClass>,
@@ -170,7 +170,7 @@ impl<S: State> Executable<S> for L1HandlerTransaction {
 
         Ok(Some(execute_call.execute(
             state,
-            resources_manager,
+            execution_resources,
             block_context,
             account_tx_context,
         )?))


### PR DESCRIPTION
- Import cairo_rs's `ExecutionResources` as `VmExecutionResources`.
- Rename `ExecutionResourcesManager` -> `ExecutionResources`
- Rename `resources_manager` fields into `execution_resources`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/334)
<!-- Reviewable:end -->
