### PR TITLE
Don't commit transactions before checking if they can be added

### DIFF
--- a/crates/native_blockifier/setup.py
+++ b/crates/native_blockifier/setup.py
@@ -3,7 +3,7 @@ from setuptools_rust import Binding, RustExtension
 
 setup(
     name="native_blockifier",
-    version="0.15.2",
+    version="0.16.0",
     rust_extensions=[RustExtension("native_blockifier.native_blockifier", binding=Binding.PyO3)],
     author="Starkware",
     author_email="info@starkware.co",


### PR DESCRIPTION
Previously, transactions were committed onto the state if they succeeded, which is incorrect in cases where the transaction weight is too big.

Now accepting a python callback, which is given the `tx_weights` and raises an exception if they cannot be added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/343)
<!-- Reviewable:end -->
