### PR TITLE
Change `u64` to `usize`.

### DIFF
--- a/crates/blockifier/src/abi/constants.rs
+++ b/crates/blockifier/src/abi/constants.rs
@@ -9,16 +9,16 @@ pub const L1_HANDLER_VERSION: u64 = 0;
 // OS-related constants.
 pub const L1_TO_L2_MSG_HEADER_SIZE: usize = 5;
 pub const L2_TO_L1_MSG_HEADER_SIZE: usize = 3;
-pub const CLASS_UPDATE_SIZE: u64 = 1;
+pub const CLASS_UPDATE_SIZE: usize = 1;
 
 // StarkNet solidity contract-related constants.
-pub const N_DEFAULT_TOPICS: u64 = 1; // Events have one default topic.
+pub const N_DEFAULT_TOPICS: usize = 1; // Events have one default topic.
 
 // Excluding the default topic.
-pub const LOG_MSG_TO_L1_N_TOPICS: u64 = 2;
-pub const CONSUMED_MSG_TO_L2_N_TOPICS: u64 = 3;
+pub const LOG_MSG_TO_L1_N_TOPICS: usize = 2;
+pub const CONSUMED_MSG_TO_L2_N_TOPICS: usize = 3;
 
 // The headers include the payload size, so we need to add +1 since arrays are encoded with two
 // additional parameters (offset and length) in solidity.
-pub const LOG_MSG_TO_L1_ENCODED_DATA_SIZE: u64 =
-    (L2_TO_L1_MSG_HEADER_SIZE as u64 + 1) - LOG_MSG_TO_L1_N_TOPICS;
+pub const LOG_MSG_TO_L1_ENCODED_DATA_SIZE: usize =
+    (L2_TO_L1_MSG_HEADER_SIZE + 1) - LOG_MSG_TO_L1_N_TOPICS;

--- a/crates/blockifier/src/fee/eth_gas_constants.rs
+++ b/crates/blockifier/src/fee/eth_gas_constants.rs
@@ -1,5 +1,5 @@
-pub const WORD_WIDTH: u64 = 32;
-pub const GAS_PER_LOG: u64 = 375;
-pub const GAS_PER_LOG_DATA_BYTE: u64 = 8;
-pub const GAS_PER_LOG_DATA_WORD: u64 = GAS_PER_LOG_DATA_BYTE * WORD_WIDTH;
-pub const GAS_PER_LOG_TOPIC: u64 = 375;
+pub const WORD_WIDTH: usize = 32;
+pub const GAS_PER_LOG: usize = 375;
+pub const GAS_PER_LOG_DATA_BYTE: usize = 8;
+pub const GAS_PER_LOG_DATA_WORD: usize = GAS_PER_LOG_DATA_BYTE * WORD_WIDTH;
+pub const GAS_PER_LOG_TOPIC: usize = 375;

--- a/crates/blockifier/src/fee/fee_utils.rs
+++ b/crates/blockifier/src/fee/fee_utils.rs
@@ -6,9 +6,9 @@ pub fn extract_l1_gas_and_cairo_usage(
     resources: &ResourcesMapping,
 ) -> (usize, HashMap<String, usize>) {
     let mut cairo_resource_usage = resources.0.clone();
-    let l1_gas_usage = match cairo_resource_usage.remove("l1_gas_usage") {
-        Some(l1_gas_usage) => l1_gas_usage,
-        None => panic!("ResourcesMapping does not have the key l1_gas_usage."),
-    };
+    let l1_gas_usage = cairo_resource_usage
+        .remove("l1_gas_usage")
+        .expect("`ResourcesMapping` does not have the key `l1_gas_usage`.");
+
     (l1_gas_usage, cairo_resource_usage)
 }

--- a/crates/blockifier/src/fee/gas_usage.rs
+++ b/crates/blockifier/src/fee/gas_usage.rs
@@ -7,10 +7,10 @@ use crate::fee::eth_gas_constants;
 /// This segment consists of deployment info (of contracts deployed by the transaction) and
 /// storage updates.
 pub fn get_onchain_data_segment_length(
-    n_modified_contracts: u64,
-    n_storage_changes: u64,
-    n_class_updates: u64,
-) -> u64 {
+    n_modified_contracts: usize,
+    n_storage_changes: usize,
+    n_class_updates: usize,
+) -> usize {
     // For each newly modified contract: contract address, number of modified storage cells.
     let mut onchain_data_segment_length = n_modified_contracts * 2;
     // For each class updated (through a deploy or a class replacement).
@@ -25,12 +25,12 @@ pub fn get_onchain_data_segment_length(
 /// a transaction with the given parameters to a batch. Note that constant cells - such as the one
 /// that holds the segment size - are not counted.
 pub fn get_message_segment_length(
-    payload_lengths: &[usize],
+    l2_to_l1_payloads_length: &[usize],
     l1_handler_payload_size: Option<usize>,
 ) -> usize {
     // Add L2-to-L1 message segment length; for each message, the OS outputs the following:
     // to_address, from_address, payload_size, payload.
-    let mut message_segment_length = payload_lengths
+    let mut message_segment_length = l2_to_l1_payloads_length
         .iter()
         .map(|payload_length| constants::L2_TO_L1_MSG_HEADER_SIZE + payload_length)
         .sum();
@@ -46,21 +46,21 @@ pub fn get_message_segment_length(
     message_segment_length
 }
 
-/// Returns the cost of LogMessageToL1 event emissions caused by the given messages.
-pub fn get_log_message_to_l1_emissions_cost(l2_to_l1_payload_lengths: &[usize]) -> u64 {
-    l2_to_l1_payload_lengths
+/// Returns the cost of LogMessageToL1 event emissions caused by the given messages payload length.
+pub fn get_log_message_to_l1_emissions_cost(l2_to_l1_payloads_length: &[usize]) -> usize {
+    l2_to_l1_payloads_length
         .iter()
         .map(|length| {
             get_event_emission_cost(
                 constants::LOG_MSG_TO_L1_N_TOPICS,
                 // We're assuming the existence of one (not indexed) payload array.
-                constants::LOG_MSG_TO_L1_ENCODED_DATA_SIZE + (*length as u64),
+                constants::LOG_MSG_TO_L1_ENCODED_DATA_SIZE + *length,
             )
         })
         .sum()
 }
 
-fn get_event_emission_cost(n_topics: u64, data_length: u64) -> u64 {
+fn get_event_emission_cost(n_topics: usize, data_length: usize) -> usize {
     eth_gas_constants::GAS_PER_LOG
         + (n_topics + constants::N_DEFAULT_TOPICS) * eth_gas_constants::GAS_PER_LOG_TOPIC
         + data_length * eth_gas_constants::GAS_PER_LOG_DATA_WORD


### PR DESCRIPTION
Whenever we refer to amounts - use `usize`.  `u64` should be used for ids - or if rust enforces us to use it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/376)
<!-- Reviewable:end -->
