### PR TITLE
Bump Papyrus storage to `1d791aa`; SN API to `783885b`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,9 +354,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
@@ -529,13 +529,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -665,9 +665,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -680,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -690,15 +690,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -707,32 +707,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-timer"
@@ -742,9 +742,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1192,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -1391,9 +1391,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.48"
+version = "0.10.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
+checksum = "4d2f106ab837a24e03672c59b1239669a0596406ff657c3c0835b6b7f0f35a33"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1406,13 +1406,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1423,11 +1423,10 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.83"
+version = "0.9.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
+checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -1469,7 +1468,7 @@ dependencies = [
 [[package]]
 name = "papyrus_storage"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/papyrus?rev=14a7f0f#14a7f0fa90b9f01c00c57f68278f98e3978e49ae"
+source = "git+https://github.com/starkware-libs/papyrus?rev=1d791aa#1d791aaa9b97abe7140c6601f89c1a2bbf0d0f9e"
 dependencies = [
  "byteorder",
  "flate2",
@@ -1537,7 +1536,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -1570,9 +1569,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
+checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1683,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -1824,6 +1823,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.37.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
 dependencies = [
  "bitflags",
  "errno",
@@ -2069,7 +2077,7 @@ checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2338,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/starknet-api?rev=482a359#482a35996357f1a7abce39150f4e0687bb8958c1"
+source = "git+https://github.com/starkware-libs/starknet-api?rev=783885b#783885b137d70b3a4f105fc87b4a72221c6701ce"
 dependencies = [
  "derive_more",
  "hex",
@@ -2395,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2418,15 +2426,15 @@ checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2454,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "test_utils"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/papyrus?rev=14a7f0f#14a7f0fa90b9f01c00c57f68278f98e3978e49ae"
+source = "git+https://github.com/starkware-libs/papyrus?rev=1d791aa#1d791aaa9b97abe7140c6601f89c1a2bbf0d0f9e"
 dependencies = [
  "indexmap",
  "rand",
@@ -2484,7 +2492,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2558,7 +2566,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -3040,11 +3048,11 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25588073e5216b50bca71d61cb8595cdb9745e87032a58c199730def2862c934"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.13",
 ]

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -19,12 +19,12 @@ num-bigint = { version = "0.4" }
 num-integer = { version = "0.1.45" }
 num-traits = { version = "0.2" }
 once_cell = { version = "1.16.0" }
-papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "14a7f0f" }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "1d791aa" }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0.81", features = ["arbitrary_precision"] }
 sha3 = { version = "0.10.6" }
 # Should match the commit `papyrus_storage` is using.
-starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "482a359", features = [
+starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "783885b", features = [
     "testing",
 ] }
 strum = { version = "0.24.1" }
@@ -33,7 +33,7 @@ thiserror = { version = "1.0.37" }
 
 [dev-dependencies]
 assert_matches = { version = "1.5.0" }
-papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "14a7f0f", features = [
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "1d791aa", features = [
     "testing",
 ] }
 pretty_assertions = { version = "1.2.1" }

--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -5,7 +5,9 @@ use std::io::BufReader;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use starknet_api::state::{EntryPoint, EntryPointType, Program};
+use starknet_api::deprecated_contract_class::{
+    ContractClass as DeprecatedContractClass, EntryPoint, EntryPointType, Program,
+};
 
 /// Represents a StarkNet contract class.
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
@@ -17,7 +19,7 @@ pub struct ContractClass {
     pub abi: Option<serde_json::Value>,
 }
 
-impl From<ContractClass> for starknet_api::state::ContractClass {
+impl From<ContractClass> for DeprecatedContractClass {
     fn from(contract_class: ContractClass) -> Self {
         Self {
             program: contract_class.program,
@@ -28,8 +30,8 @@ impl From<ContractClass> for starknet_api::state::ContractClass {
     }
 }
 
-impl From<starknet_api::state::ContractClass> for ContractClass {
-    fn from(contract_class: starknet_api::state::ContractClass) -> Self {
+impl From<DeprecatedContractClass> for ContractClass {
+    fn from(contract_class: DeprecatedContractClass) -> Self {
         Self {
             program: contract_class.program,
             entry_points_by_type: contract_class.entry_points_by_type,

--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -2,8 +2,9 @@ use std::collections::HashSet;
 
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResources;
 use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector};
+use starknet_api::deprecated_contract_class::{EntryPoint, EntryPointType};
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::{EntryPoint, EntryPointType, StorageKey};
+use starknet_api::state::StorageKey;
 use starknet_api::transaction::{Calldata, EthAddress, EventContent, L2ToL1Payload};
 
 use crate::abi::abi_utils::selector_from_name;

--- a/crates/blockifier/src/execution/execution_utils.rs
+++ b/crates/blockifier/src/execution/execution_utils.rs
@@ -15,8 +15,8 @@ use cairo_vm::vm::runners::cairo_runner::{
 };
 use cairo_vm::vm::vm_core::VirtualMachine;
 use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector};
+use starknet_api::deprecated_contract_class::{EntryPointType, Program as DeprecatedProgram};
 use starknet_api::hash::StarkFelt;
-use starknet_api::state::EntryPointType;
 use starknet_api::transaction::Calldata;
 
 use crate::block_context::BlockContext;
@@ -327,7 +327,7 @@ pub fn felt_range_from_ptr(
 }
 
 pub fn convert_program_to_cairo_runner_format(
-    program: &starknet_api::state::Program,
+    program: &DeprecatedProgram,
 ) -> Result<Program, ProgramError> {
     let program = program.clone();
     let identifiers = serde_json::from_value::<HashMap<String, Identifier>>(program.identifiers)?;

--- a/crates/blockifier/src/execution/syscalls.rs
+++ b/crates/blockifier/src/execution/syscalls.rs
@@ -6,8 +6,9 @@ use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::core::{
     calculate_contract_address, ClassHash, ContractAddress, EntryPointSelector,
 };
+use starknet_api::deprecated_contract_class::EntryPointType;
 use starknet_api::hash::StarkFelt;
-use starknet_api::state::{EntryPointType, StorageKey};
+use starknet_api::state::StorageKey;
 use starknet_api::transaction::{
     Calldata, ContractAddressSalt, EthAddress, EventContent, EventData, EventKey, L2ToL1Payload,
 };

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -168,13 +168,13 @@ impl<S: StateReader> State for CachedState<S> {
         let nonces =
             subtract_mappings(&state_cache.nonce_writes, &state_cache.nonce_initial_values);
 
-        let declared_classes = IndexMap::new();
-
         StateDiff {
             deployed_contracts: IndexMap::from_iter(deployed_contracts),
             storage_diffs: StorageDiff::from(StorageView(storage_diffs)),
-            declared_classes,
+            declared_classes: IndexMap::new(),
+            deprecated_declared_classes: IndexMap::new(),
             nonces: IndexMap::from_iter(nonces),
+            replaced_classes: IndexMap::new(),
         }
     }
 }

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -257,10 +257,12 @@ fn cached_state_state_diff_conversion() {
     // Only changes to contract_address2 should be shown, since contract_address_0 wasn't changed
     // and contract_address_1 was changed but ended up with the original values.
     let expected_state_diff = StateDiff {
-        declared_classes: IndexMap::new(),
-        storage_diffs: IndexMap::from_iter([(contract_address2, indexmap! {key_y => new_value})]),
-        nonces: IndexMap::from_iter([(contract_address2, Nonce(StarkFelt::from(1_u64)))]),
         deployed_contracts: IndexMap::from_iter([(contract_address2, new_class_hash)]),
+        storage_diffs: IndexMap::from_iter([(contract_address2, indexmap! {key_y => new_value})]),
+        declared_classes: IndexMap::new(),
+        deprecated_declared_classes: IndexMap::new(),
+        nonces: IndexMap::from_iter([(contract_address2, Nonce(StarkFelt::from(1_u64)))]),
+        replaced_classes: IndexMap::new(),
     };
 
     assert_eq!(expected_state_diff, state.to_state_diff());

--- a/crates/blockifier/src/state/papyrus_state.rs
+++ b/crates/blockifier/src/state/papyrus_state.rs
@@ -67,7 +67,7 @@ impl<'env, Mode: TransactionKind> StateReader for PapyrusStateReader<'env, Mode>
         class_hash: &starknet_api::core::ClassHash,
     ) -> StateResult<Arc<ContractClass>> {
         let state_number = StateNumber(*self.latest_block());
-        match self.reader.get_class_definition_at(state_number, class_hash) {
+        match self.reader.get_deprecated_class_definition_at(state_number, class_hash) {
             Ok(Some(starknet_api_contract_class)) => {
                 Ok(Arc::from(ContractClass::from(starknet_api_contract_class)))
             }

--- a/crates/blockifier/src/state/papyrus_state_test.rs
+++ b/crates/blockifier/src/state/papyrus_state_test.rs
@@ -2,6 +2,7 @@ use indexmap::IndexMap;
 use papyrus_storage::state::{StateStorageReader, StateStorageWriter};
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{ClassHash, ContractAddress, PatriciaKey};
+use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::state::{StateDiff, StorageKey};
 use starknet_api::transaction::Calldata;
@@ -27,13 +28,13 @@ fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
         ClassHash(stark_felt!(TEST_CLASS_HASH)),
     )]);
     let state_diff = StateDiff { deployed_contracts, ..Default::default() };
-    let declared_classes = IndexMap::from([(
+    let deprecated_declared_classes = IndexMap::from([(
         ClassHash(stark_felt!(TEST_CLASS_HASH)),
-        starknet_api::state::ContractClass::from(get_test_contract_class()),
+        DeprecatedContractClass::from(get_test_contract_class()),
     )]);
     storage_writer
         .begin_rw_txn()?
-        .append_state_diff(BlockNumber::default(), state_diff, declared_classes)?
+        .append_state_diff(BlockNumber::default(), state_diff, deprecated_declared_classes)?
         .commit()?;
 
     let storage_tx = storage_reader.begin_ro_txn()?;

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use starknet_api::core::{calculate_contract_address, ClassHash, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::{
-    Calldata, ContractAddressSalt, DeclareTransaction, Fee, InvokeTransaction,
+    Calldata, ContractAddressSalt, DeclareTransactionV0V1, Fee, InvokeTransactionV1,
 };
 use starknet_api::{calldata, stark_felt};
 
@@ -69,8 +69,8 @@ fn test_account_flow_test() {
     // Declare a contract.
     let contract_class = get_contract_class(TEST_CONTRACT_PATH);
     let declare_tx = declare_tx(TEST_CLASS_HASH, deployed_account_address, max_fee);
-    let account_tx = AccountTransaction::Declare(
-        DeclareTransaction { nonce: Nonce(stark_felt!(1)), ..declare_tx },
+    let account_tx = AccountTransaction::create_declare_tx_v1(
+        DeclareTransactionV0V1 { nonce: Nonce(stark_felt!(1)), ..declare_tx },
         contract_class,
     );
     account_tx.execute(state, block_context).unwrap();
@@ -91,7 +91,7 @@ fn test_account_flow_test() {
     ];
     let tx = invoke_tx(execute_calldata, deployed_account_address, max_fee);
     let account_tx =
-        AccountTransaction::Invoke(InvokeTransaction { nonce: Nonce(stark_felt!(2)), ..tx });
+        AccountTransaction::Invoke(InvokeTransactionV1 { nonce: Nonce(stark_felt!(2)), ..tx });
     account_tx.execute(state, block_context).unwrap();
 
     // Calculate the newly deployed contract address
@@ -113,6 +113,6 @@ fn test_account_flow_test() {
     ];
     let tx = invoke_tx(execute_calldata, deployed_account_address, max_fee);
     let account_tx =
-        AccountTransaction::Invoke(InvokeTransaction { nonce: Nonce(stark_felt!(3)), ..tx });
+        AccountTransaction::Invoke(InvokeTransactionV1 { nonce: Nonce(stark_felt!(3)), ..tx });
     account_tx.execute(state, block_context).unwrap();
 }

--- a/crates/blockifier/src/transaction/errors.rs
+++ b/crates/blockifier/src/transaction/errors.rs
@@ -13,12 +13,6 @@ pub enum FeeTransferError {
 }
 
 #[derive(Debug, Error)]
-pub enum InvokeTransactionError {
-    #[error("Entry point selector must not be specified for an invoke transaction.")]
-    SpecifiedEntryPoint,
-}
-
-#[derive(Debug, Error)]
 pub enum DeclareTransactionError {
     #[error("Class with hash {class_hash:?} is already declared.")]
     ClassAlreadyDeclared { class_hash: ClassHash },
@@ -61,8 +55,6 @@ pub enum TransactionExecutionError {
          {allowed_versions:?}."
     )]
     InvalidVersion { version: TransactionVersion, allowed_versions: Vec<TransactionVersion> },
-    #[error(transparent)]
-    InvokeTransactionError(#[from] InvokeTransactionError),
     #[error(transparent)]
     StarknetApiError(#[from] StarknetApiError),
     #[error(transparent)]

--- a/crates/blockifier/src/transaction/transactions.rs
+++ b/crates/blockifier/src/transaction/transactions.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
 use starknet_api::core::ContractAddress;
-use starknet_api::state::EntryPointType;
+use starknet_api::deprecated_contract_class::EntryPointType;
 use starknet_api::transaction::{
-    Calldata, DeclareTransaction, DeployAccountTransaction, InvokeTransaction, L1HandlerTransaction,
+    Calldata, DeclareTransaction, DeployAccountTransaction, InvokeTransactionV1,
+    L1HandlerTransaction,
 };
 
 use crate::abi::abi_utils::selector_from_name;
@@ -72,7 +73,7 @@ pub trait Executable<S: State> {
         execution_resources: &mut ExecutionResources,
         block_context: &BlockContext,
         account_tx_context: &AccountTransactionContext,
-        // Only used for `DeclareTransaction`.
+        // Only used for declare transaction.
         contract_class: Option<ContractClass>,
     ) -> TransactionExecutionResult<Option<CallInfo>>;
 }
@@ -86,11 +87,13 @@ impl<S: State> Executable<S> for DeclareTransaction {
         _account_tx_context: &AccountTransactionContext,
         contract_class: Option<ContractClass>,
     ) -> TransactionExecutionResult<Option<CallInfo>> {
-        match state.get_contract_class(&self.class_hash) {
+        let class_hash = self.class_hash();
+
+        match state.get_contract_class(&class_hash) {
             Err(StateError::UndeclaredClassHash(_)) => {
                 // Class is undeclared; declare it.
                 state.set_contract_class(
-                    &self.class_hash,
+                    &class_hash,
                     contract_class.expect("Declare transaction must have a contract_class"),
                 )?;
 
@@ -99,7 +102,7 @@ impl<S: State> Executable<S> for DeclareTransaction {
             Err(error) => Err(error).map_err(TransactionExecutionError::from),
             Ok(_) => {
                 // Class is already declared; cannot redeclare.
-                Err(DeclareTransactionError::ClassAlreadyDeclared { class_hash: self.class_hash })?
+                Err(DeclareTransactionError::ClassAlreadyDeclared { class_hash })?
             }
         }
     }
@@ -134,7 +137,7 @@ impl<S: State> Executable<S> for DeployAccountTransaction {
     }
 }
 
-impl<S: State> Executable<S> for InvokeTransaction {
+impl<S: State> Executable<S> for InvokeTransactionV1 {
     fn run_execute(
         &self,
         state: &mut S,

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -6,12 +6,13 @@ use cairo_vm::vm::runners::builtin_runner::{HASH_BUILTIN_NAME, RANGE_CHECK_BUILT
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResources;
 use itertools::concat;
 use pretty_assertions::assert_eq;
-use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce, PatriciaKey};
+use starknet_api::core::{ClassHash, ContractAddress, Nonce, PatriciaKey};
+use starknet_api::deprecated_contract_class::EntryPointType;
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::{EntryPointType, StorageKey};
+use starknet_api::state::StorageKey;
 use starknet_api::transaction::{
-    Calldata, DeclareTransaction, DeployAccountTransaction, EventContent, EventData, EventKey, Fee,
-    InvokeTransaction, TransactionVersion,
+    Calldata, DeclareTransaction, DeclareTransactionV0V1, DeployAccountTransaction, EventContent,
+    EventData, EventKey, Fee, InvokeTransactionV1,
 };
 use starknet_api::{calldata, patricia_key, stark_felt};
 
@@ -34,9 +35,7 @@ use crate::test_utils::{
 };
 use crate::transaction::account_transaction::AccountTransaction;
 use crate::transaction::constants;
-use crate::transaction::errors::{
-    FeeTransferError, InvokeTransactionError, TransactionExecutionError,
-};
+use crate::transaction::errors::{FeeTransferError, TransactionExecutionError};
 use crate::transaction::objects::{ResourcesMapping, TransactionExecutionInfo};
 use crate::transaction::transactions::ExecutableTransaction;
 
@@ -184,7 +183,7 @@ fn validate_final_balances(
     );
 }
 
-fn invoke_tx() -> InvokeTransaction {
+fn invoke_tx() -> InvokeTransactionV1 {
     let entry_point_selector = selector_from_name("return_result");
     let execute_calldata = calldata![
         stark_felt!(TEST_CONTRACT_ADDRESS), // Contract address.
@@ -311,26 +310,9 @@ fn test_negative_invoke_tx_flows() {
     let block_context = &BlockContext::create_for_testing();
     let valid_invoke_tx = invoke_tx();
 
-    // Invalid version.
-    // Note: there is no need to test for a negative version, as it cannot be constructed.
-    let invalid_tx_version = TransactionVersion(stark_felt!(0));
-    let invalid_tx = AccountTransaction::Invoke(InvokeTransaction {
-        version: invalid_tx_version,
-        ..valid_invoke_tx.clone()
-    });
-    let execution_error = invalid_tx.execute(state, block_context).unwrap_err();
-
-    // Test error.
-    let expected_allowed_versions = vec![TransactionVersion(stark_felt!(1))];
-    assert_matches!(
-        execution_error,
-        TransactionExecutionError::InvalidVersion { version, allowed_versions }
-        if (version, &allowed_versions) == (invalid_tx_version, &expected_allowed_versions)
-    );
-
     // Insufficient fee.
     let invalid_max_fee = Fee(1);
-    let invalid_tx = AccountTransaction::Invoke(InvokeTransaction {
+    let invalid_tx = AccountTransaction::Invoke(InvokeTransactionV1 {
         max_fee: invalid_max_fee,
         ..valid_invoke_tx.clone()
     });
@@ -347,28 +329,11 @@ fn test_negative_invoke_tx_flows() {
         if (max_fee, actual_fee) == (invalid_max_fee, expected_actual_fee)
     );
 
-    // Invalid selector.
-    let invalid_selector = Some(EntryPointSelector::default());
-    let invalid_tx = AccountTransaction::Invoke(InvokeTransaction {
-        entry_point_selector: invalid_selector,
-        ..valid_invoke_tx.clone()
-    });
-    let execution_error =
-        invalid_tx.execute(&mut create_account_tx_test_state(), block_context).unwrap_err();
-
-    // Test error.
-    assert_matches!(
-        execution_error,
-        TransactionExecutionError::InvokeTransactionError(
-            InvokeTransactionError::SpecifiedEntryPoint
-        )
-    );
-
     // Invalid nonce.
     // Use a fresh state to facilitate testing.
     let invalid_nonce = Nonce(stark_felt!(1));
     let invalid_tx =
-        AccountTransaction::Invoke(InvokeTransaction { nonce: invalid_nonce, ..valid_invoke_tx });
+        AccountTransaction::Invoke(InvokeTransactionV1 { nonce: invalid_nonce, ..valid_invoke_tx });
     let execution_error =
         invalid_tx.execute(&mut create_account_tx_test_state(), block_context).unwrap_err();
 
@@ -380,7 +345,7 @@ fn test_negative_invoke_tx_flows() {
     );
 }
 
-fn declare_tx() -> DeclareTransaction {
+fn declare_tx() -> DeclareTransactionV0V1 {
     crate::test_utils::declare_tx(
         TEST_EMPTY_CONTRACT_CLASS_HASH,
         ContractAddress(patricia_key!(TEST_ACCOUNT_CONTRACT_ADDRESS)),
@@ -400,7 +365,10 @@ fn test_declare_tx() {
     let class_hash = declare_tx.class_hash;
 
     let contract_class = get_contract_class(TEST_EMPTY_CONTRACT_PATH);
-    let account_tx = AccountTransaction::Declare(declare_tx.clone(), contract_class.clone());
+    let account_tx = AccountTransaction::Declare(
+        DeclareTransaction::V1(declare_tx.clone()),
+        contract_class.clone(),
+    );
 
     // Check state before transaction application.
     assert_matches!(
@@ -468,8 +436,8 @@ fn test_declare_tx() {
     assert_eq!(contract_class_from_state, Arc::from(contract_class.clone()));
 
     // Negative flow: check that the same class hash cannot be declared twice.
-    let invalid_declare_tx = AccountTransaction::Declare(
-        DeclareTransaction { nonce: Nonce(stark_felt!(1)), ..declare_tx },
+    let invalid_declare_tx = AccountTransaction::create_declare_tx_v1(
+        DeclareTransactionV0V1 { nonce: Nonce(stark_felt!(1)), ..declare_tx },
         contract_class,
     );
     let error = invalid_declare_tx.execute(state, block_context).unwrap_err();

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -20,7 +20,7 @@ indexmap = { version = "1.9.2" }
 log = { version = "0.4" }
 num-bigint = { version = "0.4" }
 ouroboros = { version = "0.15.6" }
-papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "14a7f0f", features = [
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "1d791aa", features = [
     "testing",
 ] }
 pyo3 = { version = "0.17.3", features = [
@@ -32,7 +32,7 @@ pyo3-log = { version = "0.8.1" }
 # We need this rev to be the same as in both `blockifier` and `papyrus_storage`.
 serde_json = { version = "1.0.81", features = ["arbitrary_precision"] }
 # Should match the commit `papyrus_storage` is using.
-starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "482a359", features = [
+starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "783885b", features = [
     "testing",
 ] }
 

--- a/crates/native_blockifier/src/py_state_diff.rs
+++ b/crates/native_blockifier/src/py_state_diff.rs
@@ -11,7 +11,7 @@ use crate::py_utils::PyFelt;
 
 #[pyclass]
 #[derive(FromPyObject)]
-// TODO: Add support for returning the declared_classes to python.
+// TODO: Add support for returning the `declared_classes` to python.
 pub struct PyStateDiff {
     #[pyo3(get)]
     pub address_to_class_hash: HashMap<PyFelt, PyFelt>,
@@ -46,7 +46,6 @@ impl TryFrom<PyStateDiff> for StateDiff {
             }
         }
 
-        let declared_classes = IndexMap::new();
         let mut nonces = IndexMap::new();
         for (address, nonce) in state_diff.address_to_nonce {
             let address = ContractAddress::try_from(address.0)?;
@@ -54,7 +53,14 @@ impl TryFrom<PyStateDiff> for StateDiff {
             nonces.insert(address, nonce);
         }
 
-        Ok(Self { deployed_contracts, storage_diffs, declared_classes, nonces })
+        Ok(Self {
+            deployed_contracts,
+            storage_diffs,
+            declared_classes: IndexMap::new(),
+            deprecated_declared_classes: IndexMap::new(),
+            nonces,
+            replaced_classes: IndexMap::new(),
+        })
     }
 }
 


### PR DESCRIPTION
Main changes:
- Fields changed in SN API `StateDiff` (previously `declared_classes` now appear in `deprecated_declared_classes`; rest new fields are currently unused).
- `DeclareTransaction` is now an enum; `InvokeTransaction` changed to `InvokeTransactionV1`.
- Many location changes in SN API (especially to `deprecated_contract_class.rs`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/384)
<!-- Reviewable:end -->
