### PR TITLE
Lock dependencies at workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,28 @@
 resolver = "2"
 
 members = ["crates/blockifier", "crates/native_blockifier"]
+
+[workspace.dependencies]
+cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git" , rev = "bc52e17"}
+cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "bc52e17" }
+derive_more = { version = "0.99.17" }
+hex = { version = "0.4.3" }
+indexmap = { version = "1.9.2" }
+itertools = { version = "0.10.3" }
+log = { version = "0.4" }
+num-bigint = { version = "0.4" }
+num-integer = { version = "0.1.45" }
+num-traits = { version = "0.2" }
+ouroboros = { version = "0.15.6" }
+once_cell = { version = "1.16.0" }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "1d791aa" }
+serde = { version = "1.0.130" }
+serde_json = { version = "1.0.81" }
+sha3 = { version = "0.10.6" } # Should match the commit `papyrus_storage` is using.
+starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "783885b" }
+strum = { version = "0.24.1" }
+strum_macros = { version = "0.24.3" }
+thiserror = { version = "1.0.37" }
+assert_matches = { version = "1.5.0" }
+pretty_assertions = { version = "1.2.1" }
+test-case = { version = "2.2.2" }

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -9,32 +9,28 @@ testing = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git" , rev = "bc52e17"}
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "bc52e17" }
-derive_more = { version = "0.99.17" }
-indexmap = { version = "1.9.2" }
-itertools = { version = "0.10.3" }
-log = { version = "0.4" }
-num-bigint = { version = "0.4" }
-num-integer = { version = "0.1.45" }
-num-traits = { version = "0.2" }
-once_cell = { version = "1.16.0" }
-papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "1d791aa" }
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = { version = "1.0.81", features = ["arbitrary_precision"] }
-sha3 = { version = "0.10.6" }
+cairo-felt.workspace = true
+cairo-vm.workspace = true
+derive_more.workspace = true
+indexmap.workspace = true
+itertools.workspace = true
+log.workspace = true
+num-bigint.workspace = true
+num-integer.workspace = true
+num-traits.workspace = true
+once_cell.workspace = true
+papyrus_storage.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true,features = ["arbitrary_precision"] }
+sha3.workspace = true
 # Should match the commit `papyrus_storage` is using.
-starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "783885b", features = [
-    "testing",
-] }
-strum = { version = "0.24.1" }
-strum_macros = { version = "0.24.3" }
-thiserror = { version = "1.0.37" }
+starknet_api = { workspace = true, features = [ "testing", ] }
+strum.workspace = true
+strum_macros.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
-assert_matches = { version = "1.5.0" }
-papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "1d791aa", features = [
-    "testing",
-] }
-pretty_assertions = { version = "1.2.1" }
-test-case = { version = "2.2.2" }
+assert_matches.workspace = true
+papyrus_storage = { workspace = true, features = [ "testing", ] }
+pretty_assertions.workspace = true
+test-case.workspace = true

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -14,15 +14,13 @@ crate-type = ["cdylib"]
 
 [dependencies]
 blockifier = { path = "../blockifier" }
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "bc52e17" }
-hex = { version = "0.4.3" }
-indexmap = { version = "1.9.2" }
-log = { version = "0.4" }
-num-bigint = { version = "0.4" }
-ouroboros = { version = "0.15.6" }
-papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "1d791aa", features = [
-    "testing",
-] }
+cairo-vm.workspace = true
+hex.workspace = true
+indexmap.workspace = true
+log.workspace = true
+num-bigint.workspace = true
+ouroboros.workspace = true
+papyrus_storage = { workspace = true, features = [ "testing", ] }
 pyo3 = { version = "0.17.3", features = [
     "extension-module",
     "num-bigint",
@@ -30,10 +28,8 @@ pyo3 = { version = "0.17.3", features = [
 ] }
 pyo3-log = { version = "0.8.1" }
 # We need this rev to be the same as in both `blockifier` and `papyrus_storage`.
-serde_json = { version = "1.0.81", features = ["arbitrary_precision"] }
+serde_json = { workspace = true, features = ["arbitrary_precision"] }
 # Should match the commit `papyrus_storage` is using.
-starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "783885b", features = [
-    "testing",
-] }
+starknet_api = { workspace = true, features = [ "testing" ] }
 
-thiserror = { version = "1.0.37" }
+thiserror.workspace = true


### PR DESCRIPTION
Prevents having to manually sync between blockifier and native-blockifier deps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/392)
<!-- Reviewable:end -->
