### PR TITLE
Bump rust edition in native-blockifier

### DIFF
--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "native_blockifier"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "native_blockifier"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2018"
+edition = "2021"
 newline_style = "unix"
 use_field_init_shorthand = true
 use_small_heuristics = "Max"


### PR DESCRIPTION
No real reason for it to be 2018 (blockifier is already 2021).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/394)
<!-- Reviewable:end -->
