### PR TITLE
ContractClass deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,13 +529,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1060,13 +1060,13 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1140,9 +1140,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libloading"
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
+checksum = "43a558e3d911bc3c7bfc8c78bc580b404d6e51c1cefbf656e176a94b49b0df40"
 dependencies = [
  "cc",
  "libc",
@@ -1249,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
+checksum = "3d88dad3f985ec267a3fcb7a1726f5cb1a7e8cad8b646e70a84f967210df23da"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -1391,9 +1391,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.49"
+version = "0.10.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2f106ab837a24e03672c59b1239669a0596406ff657c3c0835b6b7f0f35a33"
+checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1423,9 +1423,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.84"
+version = "0.9.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
+checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
 dependencies = [
  "cc",
  "libc",
@@ -1468,7 +1468,7 @@ dependencies = [
 [[package]]
 name = "papyrus_storage"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/papyrus?rev=1d791aa#1d791aaa9b97abe7140c6601f89c1a2bbf0d0f9e"
+source = "git+https://github.com/starkware-libs/papyrus?rev=c1e564c#c1e564c473936b61d25ec53720850adcf241cc8e"
 dependencies = [
  "byteorder",
  "flate2",
@@ -1947,16 +1947,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.7"
+version = "0.37.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2346,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/starknet-api?rev=783885b#783885b137d70b3a4f105fc87b4a72221c6701ce"
+source = "git+https://github.com/starkware-libs/starknet-api?rev=8a7067e#8a7067ef5173fb7a2d916c2bc83793c476b34556"
 dependencies = [
  "derive_more",
  "hex",
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "test_utils"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/papyrus?rev=1d791aa#1d791aaa9b97abe7140c6601f89c1a2bbf0d0f9e"
+source = "git+https://github.com/starkware-libs/papyrus?rev=c1e564c#c1e564c473936b61d25ec53720850adcf241cc8e"
 dependencies = [
  "indexmap",
  "rand",
@@ -2923,13 +2923,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2938,7 +2938,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -2947,13 +2956,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -2963,10 +2987,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2975,10 +3011,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2987,16 +3035,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 members = ["crates/blockifier", "crates/native_blockifier"]
 
 [workspace.dependencies]
-cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git" , rev = "bc52e17"}
+cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "bc52e17" }
 cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "bc52e17" }
 derive_more = { version = "0.99.17" }
 hex = { version = "0.4.3" }
@@ -18,11 +18,11 @@ num-integer = { version = "0.1.45" }
 num-traits = { version = "0.2" }
 ouroboros = { version = "0.15.6" }
 once_cell = { version = "1.16.0" }
-papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "1d791aa" }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "c1e564c" }
 serde = { version = "1.0.130" }
 serde_json = { version = "1.0.81" }
-sha3 = { version = "0.10.6" } # Should match the commit `papyrus_storage` is using.
-starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "783885b" }
+sha3 = { version = "0.10.6" }
+starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "8a7067e" }
 strum = { version = "0.24.1" }
 strum_macros = { version = "0.24.3" }
 thiserror = { version = "1.0.37" }

--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
-use std::io::Read;
+use std::fs;
 
 use cairo_vm::types::errors::program_errors::ProgramError;
 use cairo_vm::types::program::Program;
-use serde::{Deserialize, Serialize};
+use serde::de::Error as DeserializationError;
+use serde::{Deserialize, Deserializer, Serialize};
 use starknet_api::deprecated_contract_class::{
     ContractClass as DeprecatedContractClass, EntryPoint, EntryPointType,
     Program as DeprecatedProgram,
@@ -12,8 +13,11 @@ use starknet_api::deprecated_contract_class::{
 use crate::execution::execution_utils::sn_api_to_cairo_vm_program;
 
 /// Represents a runnable StarkNet contract class (meaning, the program is runnable by the VM).
+/// Is equivalent of SN API's struct, without ABI which is not required for execution).
+//  Note: when deserializing from a SN API JSON string, the ABI field is ignored by serde.
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ContractClass {
+    #[serde(deserialize_with = "deserialize_program")]
     pub program: Program,
     pub entry_points_by_type: HashMap<EntryPointType, Vec<EntryPoint>>,
 }
@@ -22,18 +26,6 @@ impl TryFrom<DeprecatedContractClass> for ContractClass {
     type Error = ProgramError;
 
     fn try_from(class: DeprecatedContractClass) -> Result<Self, Self::Error> {
-        let class = DeprecatedContractClassWithoutAbi {
-            program: class.program,
-            entry_points_by_type: class.entry_points_by_type,
-        };
-        ContractClass::try_from(class)
-    }
-}
-
-impl TryFrom<DeprecatedContractClassWithoutAbi> for ContractClass {
-    type Error = ProgramError;
-
-    fn try_from(class: DeprecatedContractClassWithoutAbi) -> Result<Self, Self::Error> {
         Ok(Self {
             program: sn_api_to_cairo_vm_program(class.program)?,
             entry_points_by_type: class.entry_points_by_type,
@@ -41,71 +33,11 @@ impl TryFrom<DeprecatedContractClassWithoutAbi> for ContractClass {
     }
 }
 
-impl TryFrom<&str> for ContractClass {
-    type Error = ProgramError;
-
-    fn try_from(raw_contract_class: &str) -> Result<Self, Self::Error> {
-        let deprecated_contract_class =
-            DeprecatedContractClassWithoutAbi::try_from(raw_contract_class)?;
-        ContractClass::try_from(deprecated_contract_class)
-    }
-}
-
-#[cfg(any(feature = "testing", test))]
-impl TryFrom<std::path::PathBuf> for ContractClass {
-    type Error = ProgramError;
-
-    fn try_from(path: std::path::PathBuf) -> Result<Self, Self::Error> {
-        let deprecated_contract_class = DeprecatedContractClassWithoutAbi::from(path);
-        ContractClass::try_from(deprecated_contract_class)
-    }
-}
-
-/// Represents a raw StarkNet contract class (non-runnable;
-/// the equivalent of SN API's struct, without ABI which is not required for execution).
-#[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
-pub struct DeprecatedContractClassWithoutAbi {
-    pub program: DeprecatedProgram,
-    pub entry_points_by_type: HashMap<EntryPointType, Vec<EntryPoint>>,
-}
-
-impl From<DeprecatedContractClassWithoutAbi> for DeprecatedContractClass {
-    fn from(contract_class: DeprecatedContractClassWithoutAbi) -> Self {
-        Self {
-            program: contract_class.program,
-            entry_points_by_type: contract_class.entry_points_by_type,
-            abi: None,
-        }
-    }
-}
-
-impl TryFrom<&str> for DeprecatedContractClassWithoutAbi {
-    type Error = serde_json::Error;
-
-    fn try_from(raw_contract_class: &str) -> Result<Self, Self::Error> {
-        let mut raw_contract_class: serde_json::Value = serde_json::from_str(raw_contract_class)?;
-
-        // ABI is not required for execution.
-        raw_contract_class
-            .as_object_mut()
-            .expect("A compiled contract must be a JSON object.")
-            .insert("abi".to_string(), serde_json::Value::Null);
-
-        let deprecated_contract_class: DeprecatedContractClassWithoutAbi =
-            serde_json::from_value(raw_contract_class)?;
-        Ok(deprecated_contract_class)
-    }
-}
-
-#[cfg(any(feature = "testing", test))]
-impl From<std::path::PathBuf> for DeprecatedContractClassWithoutAbi {
-    fn from(path: std::path::PathBuf) -> Self {
-        let mut file =
-            std::fs::File::open(&path).unwrap_or_else(|_| panic!("File {path:?} does not exist."));
-        let mut raw_contract_class = String::new();
-        file.read_to_string(&mut raw_contract_class).expect("Malformed class JSON.");
-
-        DeprecatedContractClassWithoutAbi::try_from(raw_contract_class.as_str())
-            .expect("Malformed class JSON.")
-    }
+/// Convert the program type from SN API into a Cairo VM compatible type.
+pub fn deserialize_program<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Program, D::Error> {
+    let deprecated_program = DeprecatedProgram::deserialize(deserializer)?;
+    sn_api_to_cairo_vm_program(deprecated_program)
+        .map_err(|err| DeserializationError::custom(err.to_string()))
 }

--- a/crates/blockifier/src/state/papyrus_state_test.rs
+++ b/crates/blockifier/src/state/papyrus_state_test.rs
@@ -1,24 +1,21 @@
-use std::path::PathBuf;
-
 use indexmap::IndexMap;
 use papyrus_storage::state::{StateStorageReader, StateStorageWriter};
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{ClassHash, ContractAddress, PatriciaKey};
-use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::state::{StateDiff, StorageKey};
 use starknet_api::transaction::Calldata;
 use starknet_api::{calldata, patricia_key, stark_felt};
 
 use crate::abi::abi_utils::selector_from_name;
-use crate::execution::contract_class::DeprecatedContractClassWithoutAbi;
 use crate::execution::entry_point::{CallEntryPoint, CallExecution, Retdata};
 use crate::retdata;
 use crate::state::cached_state::CachedState;
 use crate::state::papyrus_state::PapyrusStateReader;
 use crate::state::state_api::StateReader;
 use crate::test_utils::{
-    trivial_external_entry_point, TEST_CLASS_HASH, TEST_CONTRACT_ADDRESS, TEST_CONTRACT_PATH,
+    get_deprecated_contract_class, trivial_external_entry_point, TEST_CLASS_HASH,
+    TEST_CONTRACT_ADDRESS, TEST_CONTRACT_PATH,
 };
 
 #[test]
@@ -32,10 +29,7 @@ fn test_entry_point_with_papyrus_state() {
     )]);
     let state_diff = StateDiff { deployed_contracts, ..Default::default() };
 
-    let test_contract_path = PathBuf::from(TEST_CONTRACT_PATH);
-    let test_contract = DeprecatedContractClass::from(
-        DeprecatedContractClassWithoutAbi::try_from(test_contract_path).unwrap(),
-    );
+    let test_contract = get_deprecated_contract_class(TEST_CONTRACT_PATH);
     let deprecated_declared_classes =
         IndexMap::from([(ClassHash(stark_felt!(TEST_CLASS_HASH)), test_contract)]);
     storage_writer

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
+use std::fs;
 use std::iter::zip;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use once_cell::sync::Lazy;
@@ -9,7 +9,9 @@ use starknet_api::core::{
     calculate_contract_address, ChainId, ClassHash, ContractAddress, EntryPointSelector, Nonce,
     PatriciaKey,
 };
-use starknet_api::deprecated_contract_class::EntryPointType;
+use starknet_api::deprecated_contract_class::{
+    ContractClass as DeprecatedContractClass, EntryPointType,
+};
 use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::{
@@ -115,8 +117,21 @@ impl StateReader for DictStateReader {
 }
 
 pub fn get_contract_class(contract_path: &str) -> ContractClass {
-    let path = PathBuf::from(contract_path);
-    ContractClass::try_from(path).expect("File must contain the content of a compiled contract.")
+    let raw_contract = fs::read_to_string(contract_path).unwrap();
+    serde_json::from_str(&raw_contract).unwrap()
+}
+
+pub fn get_deprecated_contract_class(contract_path: &str) -> DeprecatedContractClass {
+    let contract = fs::read_to_string(contract_path).unwrap();
+    let mut raw_contract_class: serde_json::Value = serde_json::from_str(&contract).unwrap();
+
+    // ABI is not required for execution.
+    raw_contract_class
+        .as_object_mut()
+        .expect("A compiled contract must be a JSON object.")
+        .remove("abi");
+
+    serde_json::from_value(raw_contract_class).unwrap()
 }
 
 pub fn get_test_contract_class() -> ContractClass {

--- a/crates/native_blockifier/src/py_transaction.rs
+++ b/crates/native_blockifier/src/py_transaction.rs
@@ -176,9 +176,7 @@ pub fn py_tx(
         "DECLARE" => {
             let raw_contract_class: &str = raw_contract_class
                 .expect("A contract class must be passed in a Declare transaction.");
-            let contract_class = ContractClass::try_from(raw_contract_class).map_err(|err| {
-                NativeBlockifierError::from(NativeBlockifierInputError::from(err))
-            })?;
+            let contract_class: ContractClass = serde_json::from_str(raw_contract_class)?;
             let declare_tx = AccountTransaction::Declare(py_declare(tx)?, contract_class);
             Ok(Transaction::AccountTransaction(declare_tx))
         }

--- a/crates/native_blockifier/src/storage.rs
+++ b/crates/native_blockifier/src/storage.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::path::PathBuf;
 
-use blockifier::execution::contract_class::DeprecatedContractClassWithoutAbi;
 use indexmap::IndexMap;
 use papyrus_storage::header::{HeaderStorageReader, HeaderStorageWriter};
 use papyrus_storage::state::{StateStorageReader, StateStorageWriter};
@@ -104,9 +103,7 @@ impl Storage {
         let mut deprecated_declared_classes: IndexMap<ClassHash, DeprecatedContractClass> =
             IndexMap::new();
         for (class_hash, raw_class) in declared_class_hash_to_class {
-            let deprecated_contract_class = DeprecatedContractClass::from(
-                DeprecatedContractClassWithoutAbi::try_from(raw_class.as_str())?,
-            );
+            let deprecated_contract_class = serde_json::from_str(&raw_class)?;
             deprecated_declared_classes.insert(ClassHash(class_hash.0), deprecated_contract_class);
         }
 


### PR DESCRIPTION
- Using a new version of SN API, which contains default deserialization of `ContractClass` fields.
- When deserialzing from json, map the SN program into a cairo vm one.