### PR TITLE
Remove duplicated error structs

### DIFF
--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -19,9 +19,7 @@ use crate::execution::entry_point::{
 use crate::state::cached_state::TransactionalState;
 use crate::state::state_api::{State, StateReader};
 use crate::transaction::constants;
-use crate::transaction::errors::{
-    FeeTransferError, TransactionExecutionError, ValidateTransactionError,
-};
+use crate::transaction::errors::TransactionExecutionError;
 use crate::transaction::objects::{
     AccountTransactionContext, TransactionExecutionInfo, TransactionExecutionResult,
 };
@@ -180,7 +178,7 @@ impl AccountTransaction {
                 block_context,
                 account_tx_context,
             )
-            .map_err(ValidateTransactionError::ValidateExecutionFailed)?;
+            .map_err(TransactionExecutionError::ValidateTransactionError)?;
         verify_no_calls_to_other_contracts(
             &validate_call_info,
             String::from(constants::VALIDATE_ENTRY_POINT_NAME),
@@ -221,7 +219,7 @@ impl AccountTransaction {
     ) -> TransactionExecutionResult<CallInfo> {
         let max_fee = account_tx_context.max_fee;
         if actual_fee > max_fee {
-            return Err(FeeTransferError::MaxFeeExceeded { max_fee, actual_fee })?;
+            return Err(TransactionExecutionError::FeeTransferError { max_fee, actual_fee });
         }
 
         // The least significant 128 bits of the amount transferred.

--- a/crates/blockifier/src/transaction/errors.rs
+++ b/crates/blockifier/src/transaction/errors.rs
@@ -7,49 +7,19 @@ use crate::execution::errors::EntryPointExecutionError;
 use crate::state::errors::StateError;
 
 #[derive(Debug, Error)]
-pub enum FeeTransferError {
-    #[error("Actual fee ({actual_fee:?}) exceeded max fee ({max_fee:?}).")]
-    MaxFeeExceeded { max_fee: Fee, actual_fee: Fee },
-}
-
-#[derive(Debug, Error)]
-pub enum DeclareTransactionError {
-    #[error("Class with hash {class_hash:?} is already declared.")]
-    ClassAlreadyDeclared { class_hash: ClassHash },
-}
-
-#[derive(Debug, Error)]
-pub enum ContractConstructorExecutionError {
-    #[error("Contract constructor execution has failed.")]
-    ContractConstructorExecutionFailed(#[from] EntryPointExecutionError),
-}
-
-#[derive(Debug, Error)]
-pub enum ValidateTransactionError {
-    #[error("Transaction validation has failed.")]
-    ValidateExecutionFailed(#[from] EntryPointExecutionError),
-}
-
-#[derive(Debug, Error)]
-pub enum ExecuteTransactionError {
-    #[error("Transaction execution has failed.")]
-    ExecutionError(#[from] EntryPointExecutionError),
-}
-
-#[derive(Debug, Error)]
 pub enum TransactionExecutionError {
     #[error("Cairo resource names must be contained in fee weights dict.")]
     CairoResourcesNotContainedInFeeWeights,
-    #[error(transparent)]
-    ContractConstructorExecutionFailed(#[from] ContractConstructorExecutionError),
-    #[error(transparent)]
-    DeclareTransactionError(#[from] DeclareTransactionError),
+    #[error("Contract constructor execution has failed.")]
+    ContractConstructorExecutionFailed(#[source] EntryPointExecutionError),
+    #[error("Class with hash {class_hash:?} is already declared.")]
+    DeclareTransactionError { class_hash: ClassHash },
     #[error(transparent)]
     EntryPointExecutionError(#[from] EntryPointExecutionError),
-    #[error(transparent)]
-    ExecutionError(#[from] ExecuteTransactionError),
-    #[error(transparent)]
-    FeeTransferError(#[from] FeeTransferError),
+    #[error("Transaction execution has failed.")]
+    ExecutionError(#[source] EntryPointExecutionError),
+    #[error("Actual fee ({actual_fee:?}) exceeded max fee ({max_fee:?}).")]
+    FeeTransferError { max_fee: Fee, actual_fee: Fee },
     #[error(
         "Invalid transaction nonce of contract at address {address:?}. Expected: \
          {expected_nonce:?}; got: {actual_nonce:?}."
@@ -70,6 +40,6 @@ pub enum TransactionExecutionError {
     UnexpectedHoles { object: String, order: usize },
     #[error("Unknown chain ID '{chain_id:?}'.")]
     UnknownChainId { chain_id: String },
-    #[error(transparent)]
-    ValidateTransactionError(#[from] ValidateTransactionError),
+    #[error("Transaction validation has failed.")]
+    ValidateTransactionError(#[source] EntryPointExecutionError),
 }

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -37,7 +37,7 @@ use crate::test_utils::{
 };
 use crate::transaction::account_transaction::AccountTransaction;
 use crate::transaction::constants;
-use crate::transaction::errors::{FeeTransferError, TransactionExecutionError};
+use crate::transaction::errors::TransactionExecutionError;
 use crate::transaction::objects::{ResourcesMapping, TransactionExecutionInfo};
 use crate::transaction::transactions::ExecutableTransaction;
 
@@ -362,10 +362,7 @@ fn test_negative_invoke_tx_flows() {
     let expected_actual_fee = actual_fee();
     assert_matches!(
         execution_error,
-        TransactionExecutionError::FeeTransferError(FeeTransferError::MaxFeeExceeded {
-            max_fee,
-            actual_fee,
-        })
+        TransactionExecutionError::FeeTransferError{ max_fee, actual_fee }
         if (max_fee, actual_fee) == (invalid_max_fee, expected_actual_fee)
     );
 


### PR DESCRIPTION
- Since we're using `map_err` anyway as part of our logic, making a transparent error doesn't benefit really. 
Most of the change is just moving the error message from the singleton error structs into the big struct.
- Fixes a duplication in the way errors are display, for example `ContractConstructorExecutionError<ContractConstructorExecutionError<...>>`
- Small refactor for returning `Result<Option<call_info>>`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/414)
<!-- Reviewable:end -->
