### PR TITLE
Add `get\set_compiled_class_hash`.

### DIFF
--- a/crates/blockifier/src/state/state_api.rs
+++ b/crates/blockifier/src/state/state_api.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::{StateDiff, StorageKey};
 
@@ -33,6 +33,9 @@ pub trait StateReader {
 
     /// Returns the contract class of the given class hash.
     fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<Arc<ContractClass>>;
+
+    /// Returns the compiled class hash of the given class hash.
+    fn get_compiled_class_hash(&mut self, class_hash: ClassHash) -> StateResult<CompiledClassHash>;
 }
 
 /// A class defining the API for writing to StarkNet global state.
@@ -65,6 +68,13 @@ pub trait State: StateReader {
         &mut self,
         class_hash: &ClassHash,
         contract_class: ContractClass,
+    ) -> StateResult<()>;
+
+    /// Sets the given compiled class hash under the given class hash.
+    fn set_compiled_class_hash(
+        &mut self,
+        class_hash: ClassHash,
+        compiled_class_hash: CompiledClassHash,
     ) -> StateResult<()>;
 
     fn to_state_diff(&self) -> StateDiff;

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::core::{
-    calculate_contract_address, ChainId, ClassHash, ContractAddress, EntryPointSelector, Nonce,
-    PatriciaKey,
+    calculate_contract_address, ChainId, ClassHash, CompiledClassHash, ContractAddress,
+    EntryPointSelector, Nonce, PatriciaKey,
 };
 use starknet_api::deprecated_contract_class::{
     ContractClass as DeprecatedContractClass, EntryPointType,
@@ -89,6 +89,7 @@ pub struct DictStateReader {
     pub address_to_nonce: HashMap<ContractAddress, Nonce>,
     pub address_to_class_hash: HashMap<ContractAddress, ClassHash>,
     pub class_hash_to_class: HashMap<ClassHash, ContractClass>,
+    pub class_hash_to_compiled_class_hash: HashMap<ClassHash, CompiledClassHash>,
 }
 
 impl StateReader for DictStateReader {
@@ -119,6 +120,15 @@ impl StateReader for DictStateReader {
         let class_hash =
             self.address_to_class_hash.get(&contract_address).copied().unwrap_or_default();
         Ok(class_hash)
+    }
+
+    fn get_compiled_class_hash(
+        &mut self,
+        class_hash: ClassHash,
+    ) -> StateResult<starknet_api::core::CompiledClassHash> {
+        let compiled_class_hash =
+            self.class_hash_to_compiled_class_hash.get(&class_hash).copied().unwrap_or_default();
+        Ok(compiled_class_hash)
     }
 }
 

--- a/crates/native_blockifier/src/papyrus_state.rs
+++ b/crates/native_blockifier/src/papyrus_state.rs
@@ -5,7 +5,7 @@ use blockifier::state::errors::StateError;
 use blockifier::state::state_api::{StateReader, StateResult};
 use papyrus_storage::db::TransactionKind;
 use starknet_api::block::BlockNumber;
-use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::{StateNumber, StorageKey};
 
@@ -61,10 +61,7 @@ impl<'env, Mode: TransactionKind> StateReader for PapyrusStateReader<'env, Mode>
         }
     }
 
-    fn get_contract_class(
-        &mut self,
-        class_hash: &starknet_api::core::ClassHash,
-    ) -> StateResult<Arc<ContractClass>> {
+    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<Arc<ContractClass>> {
         let state_number = StateNumber(*self.latest_block());
         match self.reader.get_deprecated_class_definition_at(state_number, class_hash) {
             Ok(Some(starknet_api_contract_class)) => {
@@ -73,5 +70,12 @@ impl<'env, Mode: TransactionKind> StateReader for PapyrusStateReader<'env, Mode>
             Ok(None) => Err(StateError::UndeclaredClassHash(*class_hash)),
             Err(err) => Err(StateError::StateReadError(err.to_string())),
         }
+    }
+
+    fn get_compiled_class_hash(
+        &mut self,
+        _class_hash: ClassHash,
+    ) -> StateResult<CompiledClassHash> {
+        todo!()
     }
 }


### PR DESCRIPTION
- Will be used in declare version 2: will be use to check that we have not already declared the given class. And if we did not declare it, we will add (using `set`) the relevant mapping.
- Should return `0` in declare version`<2`.
- Will be used in `get_compiled_class_by_class_hash(class_hash)-> CompiledClass` (which is used in deploy and in execute entry point (to initialize the runner)). Reason: given the `class_hash` we need to extract the `compiled_class_hash` and then we can get the compiled class.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/433)
<!-- Reviewable:end -->
