### PR TITLE
Switch to call info slice in  `calculate_tx_resources`

### DIFF
--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -335,16 +335,13 @@ impl<S: StateReader> ExecutableTransaction<S> for AccountTransaction {
                 )?;
             }
         };
-
+        let call_infos = vec![validate_call_info.as_ref(), execute_call_info.as_ref()]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<&CallInfo>>();
         //  Handle fee.
-        let actual_resources = calculate_tx_resources(
-            execution_resources,
-            validate_call_info.as_ref(),
-            execute_call_info.as_ref(),
-            tx_type,
-            state,
-            None,
-        )?;
+        let actual_resources =
+            calculate_tx_resources(execution_resources, &call_infos, tx_type, state, None)?;
 
         // Charge fee.
         let (actual_fee, fee_transfer_call_info) =

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -38,13 +38,14 @@ impl<S: StateReader> ExecutableTransaction<S> for L1HandlerTransaction {
         let execute_call_info =
             self.run_execute(state, &mut execution_resources, block_context, &tx_context, None)?;
 
-        let validate_call_info = None;
+        let call_infos =
+            if let Some(call_info) = execute_call_info.as_ref() { vec![call_info] } else { vec![] };
+
         // The calldata includes the "from" field, which is not a part of the payload.
         let l1_handler_payload_size = Some(self.calldata.0.len() - 1);
         let actual_resources = calculate_tx_resources(
             execution_resources,
-            validate_call_info,
-            execute_call_info.as_ref(),
+            &call_infos,
             TransactionType::L1Handler,
             state,
             l1_handler_payload_size,

--- a/crates/blockifier/src/transaction/transaction_utils.rs
+++ b/crates/blockifier/src/transaction/transaction_utils.rs
@@ -36,8 +36,7 @@ pub fn verify_no_calls_to_other_contracts(
 /// I.e., L1 gas usage and Cairo VM execution resources.
 pub fn calculate_tx_resources<S: StateReader>(
     execution_resources: ExecutionResources,
-    validate_call_info: Option<&CallInfo>,
-    execute_call_info: Option<&CallInfo>,
+    call_infos: &[&CallInfo],
     tx_type: TransactionType,
     state: &mut TransactionalState<'_, S>,
     l1_handler_payload_size: Option<usize>,
@@ -45,13 +44,8 @@ pub fn calculate_tx_resources<S: StateReader>(
     let (n_storage_changes, n_modified_contracts, n_class_updates) =
         state.count_actual_state_changes();
 
-    let non_optional_call_infos: Vec<&CallInfo> = vec![execute_call_info, validate_call_info]
-        .iter()
-        .flat_map(|&optional_call_info| optional_call_info)
-        .collect();
-
     let mut l2_to_l1_payloads_length = vec![];
-    for call_info in non_optional_call_infos {
+    for call_info in call_infos {
         l2_to_l1_payloads_length.extend(call_info.get_sorted_l2_to_l1_payloads_length()?);
     }
 


### PR DESCRIPTION
* Order of the `CallInfo` objects don't matter so switch the 2 args to `&[&CallInfo]`