### PR TITLE
Newtype `ContractClass` to make sure it is never cloned.

### DIFF
--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use cairo_vm::types::errors::program_errors::ProgramError;
 use cairo_vm::types::program::Program;
@@ -15,21 +16,24 @@ use crate::execution::execution_utils::sn_api_to_cairo_vm_program;
 // Note: when deserializing from a SN API class JSON string, the ABI field is ignored
 // by serde, since it is not required for execution.
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize)]
-pub struct ContractClass {
-    #[serde(deserialize_with = "deserialize_program")]
-    pub program: Program,
-    pub entry_points_by_type: HashMap<EntryPointType, Vec<EntryPoint>>,
-}
+pub struct ContractClass(pub Arc<ContractClassInner>);
 
 impl TryFrom<DeprecatedContractClass> for ContractClass {
     type Error = ProgramError;
 
     fn try_from(class: DeprecatedContractClass) -> Result<Self, Self::Error> {
-        Ok(Self {
+        Ok(Self(Arc::new(ContractClassInner {
             program: sn_api_to_cairo_vm_program(class.program)?,
             entry_points_by_type: class.entry_points_by_type,
-        })
+        })))
     }
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize)]
+pub struct ContractClassInner {
+    #[serde(deserialize_with = "deserialize_program")]
+    pub program: Program,
+    pub entry_points_by_type: HashMap<EntryPointType, Vec<EntryPoint>>,
 }
 
 /// Converts the program type from SN API into a Cairo VM-compatible type.

--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -133,7 +133,7 @@ impl CallEntryPoint {
         contract_class: &ContractClass,
     ) -> Result<usize, PreExecutionError> {
         let entry_points_of_same_type =
-            &contract_class.entry_points_by_type[&self.entry_point_type];
+            &contract_class.0.entry_points_by_type[&self.entry_point_type];
         let filtered_entry_points: Vec<&EntryPoint> = entry_points_of_same_type
             .iter()
             .filter(|ep| ep.selector == self.entry_point_selector)
@@ -287,7 +287,7 @@ pub fn execute_constructor_entry_point(
     // Ensure the class is declared (by reading it).
     let contract_class = state.get_contract_class(&class_hash)?;
     let constructor_entry_points =
-        &contract_class.entry_points_by_type[&EntryPointType::Constructor];
+        &contract_class.0.entry_points_by_type[&EntryPointType::Constructor];
 
     if constructor_entry_points.is_empty() {
         // Contract has no constructor.

--- a/crates/blockifier/src/execution/execution_utils.rs
+++ b/crates/blockifier/src/execution/execution_utils.rs
@@ -73,7 +73,7 @@ pub fn initialize_execution_context<'a>(
 
     // Instantiate Cairo runner.
     let proof_mode = false;
-    let mut runner = CairoRunner::new(&contract_class.program, "starknet", proof_mode)?;
+    let mut runner = CairoRunner::new(&contract_class.0.program, "starknet", proof_mode)?;
 
     let trace_enabled = true;
     let mut vm = VirtualMachine::new(trace_enabled);

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 
 use derive_more::IntoIterator;
 use indexmap::IndexMap;
@@ -16,7 +15,7 @@ use crate::utils::subtract_mappings;
 #[path = "cached_state_test.rs"]
 mod test;
 
-type ContractClassMapping = HashMap<ClassHash, Arc<ContractClass>>;
+type ContractClassMapping = HashMap<ClassHash, ContractClass>;
 pub type TransactionalState<'a, S> = CachedState<MutRefState<'a, CachedState<S>>>;
 
 /// Caches read and write requests.
@@ -96,7 +95,7 @@ impl<S: StateReader> StateReader for CachedState<S> {
         Ok(*class_hash)
     }
 
-    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<Arc<ContractClass>> {
+    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<ContractClass> {
         if !self.class_hash_to_class.contains_key(class_hash) {
             let contract_class = self.state.get_contract_class(class_hash)?;
             self.class_hash_to_class.insert(*class_hash, contract_class);
@@ -161,7 +160,7 @@ impl<S: StateReader> State for CachedState<S> {
         class_hash: &ClassHash,
         contract_class: ContractClass,
     ) -> StateResult<()> {
-        self.class_hash_to_class.insert(*class_hash, Arc::from(contract_class));
+        self.class_hash_to_class.insert(*class_hash, contract_class);
         Ok(())
     }
 
@@ -359,7 +358,7 @@ impl<'a, S: State> StateReader for MutRefState<'a, S> {
         self.0.get_class_hash_at(contract_address)
     }
 
-    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<Arc<ContractClass>> {
+    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<ContractClass> {
         self.0.get_contract_class(class_hash)
     }
 

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -137,10 +137,7 @@ fn get_contract_class() {
     // Positive flow.
     let existing_class_hash = ClassHash(stark_felt!(TEST_CLASS_HASH));
     let mut state = create_test_state();
-    assert_eq!(
-        state.get_contract_class(&existing_class_hash).unwrap(),
-        Arc::from(get_test_contract_class())
-    );
+    assert_eq!(state.get_contract_class(&existing_class_hash).unwrap(), get_test_contract_class());
 
     // Negative flow.
     let missing_class_hash = ClassHash(stark_felt!("0x101"));
@@ -185,8 +182,7 @@ fn cached_state_state_diff_conversion() {
     // This will not appear in the diff, since this mapping is immutable for the current version we
     // are aligned with.
     let test_class_hash = ClassHash(stark_felt!(TEST_CLASS_HASH));
-    let class_hash_to_class =
-        HashMap::from([(test_class_hash, Arc::from(get_test_contract_class()))]);
+    let class_hash_to_class = HashMap::from([(test_class_hash, get_test_contract_class())]);
 
     let nonce_initial_values = HashMap::new();
 

--- a/crates/blockifier/src/state/state_api.rs
+++ b/crates/blockifier/src/state/state_api.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::{StateDiff, StorageKey};
@@ -32,7 +30,7 @@ pub trait StateReader {
     fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash>;
 
     /// Returns the contract class of the given class hash.
-    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<Arc<ContractClass>>;
+    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<ContractClass>;
 
     /// Returns the compiled class hash of the given class hash.
     fn get_compiled_class_hash(&mut self, class_hash: ClassHash) -> StateResult<CompiledClassHash>;

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::fs;
 use std::iter::zip;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::core::{
@@ -108,10 +107,10 @@ impl StateReader for DictStateReader {
         Ok(nonce)
     }
 
-    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<Arc<ContractClass>> {
+    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<ContractClass> {
         let contract_class = self.class_hash_to_class.get(class_hash).cloned();
         match contract_class {
-            Some(contract_class) => Ok(Arc::from(contract_class)),
+            Some(contract_class) => Ok(contract_class),
             None => Err(StateError::UndeclaredClassHash(*class_hash)),
         }
     }

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -485,7 +485,7 @@ fn test_declare_tx() {
 
     // Verify class declaration.
     let contract_class_from_state = state.get_contract_class(&class_hash).unwrap();
-    assert_eq!(contract_class_from_state, Arc::from(contract_class));
+    assert_eq!(contract_class_from_state, contract_class);
 }
 
 fn deploy_account_tx(

--- a/crates/native_blockifier/src/papyrus_state.rs
+++ b/crates/native_blockifier/src/papyrus_state.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use blockifier::execution::contract_class::ContractClass;
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::{StateReader, StateResult};
@@ -61,11 +59,11 @@ impl<'env, Mode: TransactionKind> StateReader for PapyrusStateReader<'env, Mode>
         }
     }
 
-    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<Arc<ContractClass>> {
+    fn get_contract_class(&mut self, class_hash: &ClassHash) -> StateResult<ContractClass> {
         let state_number = StateNumber(*self.latest_block());
         match self.reader.get_deprecated_class_definition_at(state_number, class_hash) {
             Ok(Some(starknet_api_contract_class)) => {
-                Ok(Arc::from(ContractClass::try_from(starknet_api_contract_class)?))
+                Ok(ContractClass::try_from(starknet_api_contract_class)?)
             }
             Ok(None) => Err(StateError::UndeclaredClassHash(*class_hash)),
             Err(err) => Err(StateError::StateReadError(err.to_string())),


### PR DESCRIPTION
`Arc`ing it from the outside couldn't make sure new usages of it also used `Arc`.

For example, the `ContractClass` in `AccountTransaction didn't clone it (and it came up in benchmarks).
