### PR TITLE
Hardcode `MODE = RO` in papyrus reader

### DIFF
--- a/crates/native_blockifier/src/papyrus_state.rs
+++ b/crates/native_blockifier/src/papyrus_state.rs
@@ -1,7 +1,7 @@
 use blockifier::execution::contract_class::ContractClass;
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::{StateReader, StateResult};
-use papyrus_storage::db::TransactionKind;
+use papyrus_storage::db::RO;
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
@@ -11,16 +11,16 @@ use starknet_api::state::{StateNumber, StorageKey};
 #[path = "papyrus_state_test.rs"]
 mod test;
 
-type RawPapyrusStateReader<'env, Mode> = papyrus_storage::state::StateReader<'env, Mode>;
+type RawPapyrusStateReader<'env> = papyrus_storage::state::StateReader<'env, RO>;
 
-pub struct PapyrusStateReader<'env, Mode: TransactionKind> {
-    pub reader: RawPapyrusStateReader<'env, Mode>,
+pub struct PapyrusStateReader<'env> {
+    pub reader: RawPapyrusStateReader<'env>,
     // Invariant: Read-Only.
     latest_block: BlockNumber,
 }
 
-impl<'env, Mode: TransactionKind> PapyrusStateReader<'env, Mode> {
-    pub fn new(reader: RawPapyrusStateReader<'env, Mode>, latest_block: BlockNumber) -> Self {
+impl<'env> PapyrusStateReader<'env> {
+    pub fn new(reader: RawPapyrusStateReader<'env>, latest_block: BlockNumber) -> Self {
         Self { reader, latest_block }
     }
 
@@ -29,7 +29,7 @@ impl<'env, Mode: TransactionKind> PapyrusStateReader<'env, Mode> {
     }
 }
 
-impl<'env, Mode: TransactionKind> StateReader for PapyrusStateReader<'env, Mode> {
+impl<'env> StateReader for PapyrusStateReader<'env> {
     fn get_storage_at(
         &mut self,
         contract_address: ContractAddress,

--- a/crates/native_blockifier/src/py_transaction.rs
+++ b/crates/native_blockifier/src/py_transaction.rs
@@ -231,7 +231,7 @@ pub struct PyTransactionExecutor {
     pub storage_tx: papyrus_storage::StorageTxn<'this, RO>,
     #[borrows(storage_tx)]
     #[covariant]
-    pub state: CachedState<PapyrusStateReader<'this, RO>>,
+    pub state: CachedState<PapyrusStateReader<'this>>,
 }
 
 pub fn build_tx_executor(
@@ -248,7 +248,7 @@ pub fn build_tx_executor(
     fn state_builder<'a>(
         storage_tx: &'a papyrus_storage::StorageTxn<'a, RO>,
         block_number: BlockNumber,
-    ) -> NativeBlockifierResult<CachedState<PapyrusStateReader<'a, RO>>> {
+    ) -> NativeBlockifierResult<CachedState<PapyrusStateReader<'a>>> {
         let state_reader = storage_tx.get_state_reader()?;
         let papyrus_reader = PapyrusStateReader::new(state_reader, block_number);
         Ok(CachedState::new(papyrus_reader))


### PR DESCRIPTION
No reason for the generic, it should always be Read-Only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/454)
<!-- Reviewable:end -->
