### PR TITLE
Add `CasmContractClass`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,6 +2199,7 @@ name = "native_blockifier"
 version = "0.1.0"
 dependencies = [
  "blockifier",
+ "cairo-lang-starknet",
  "cairo-vm",
  "hex",
  "indexmap",

--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -32,6 +32,7 @@ pub enum ContractClass {
     V0(ContractClassV0),
     V1(ContractClassV1),
 }
+
 impl ContractClass {
     pub fn constructor_selector(&self) -> Option<EntryPointSelector> {
         match self {
@@ -214,6 +215,12 @@ impl TryFrom<CasmContractClass> for ContractClassV1 {
 }
 
 // V0 utilities.
+
+impl From<ContractClassV0Inner> for ContractClassV0 {
+    fn from(class: ContractClassV0Inner) -> Self {
+        Self(Arc::new(class))
+    }
+}
 
 /// Converts the program type from SN API into a Cairo VM-compatible type.
 pub fn deserialize_program<'de, D: Deserializer<'de>>(

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -14,6 +14,7 @@ use crate::utils::subtract_mappings;
 #[cfg(test)]
 #[path = "cached_state_test.rs"]
 mod test;
+type ContractClassMapping = HashMap<ClassHash, ContractClass>;
 
 /// Holds uncommitted changes induced on StarkNet contracts.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -27,7 +28,6 @@ pub struct CommitmentStateDiff {
     pub class_hash_to_compiled_class_hash: IndexMap<ClassHash, CompiledClassHash>,
 }
 
-type ContractClassMapping = HashMap<ClassHash, ContractClass>;
 pub type TransactionalState<'a, S> = CachedState<MutRefState<'a, CachedState<S>>>;
 
 /// Caches read and write requests.
@@ -120,7 +120,7 @@ impl<S: StateReader> StateReader for CachedState<S> {
             .class_hash_to_class
             .get(class_hash)
             .expect("The class hash must appear in the cache.");
-        Ok(contract_class.clone())
+        Ok(contract_class).cloned()
     }
 
     fn get_compiled_class_hash(&mut self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -9,8 +9,8 @@ use starknet_api::{patricia_key, stark_felt};
 
 use super::*;
 use crate::test_utils::{
-    create_test_state, get_test_contract_class, DictStateReader, TEST_CLASS_HASH,
-    TEST_EMPTY_CONTRACT_CLASS_HASH,
+    create_test_state, get_contract_class_for_testing, DictStateReader, TEST_CLASS_HASH,
+    TEST_CONTRACT_PATH, TEST_EMPTY_CONTRACT_CLASS_HASH,
 };
 
 fn set_initial_state_values(
@@ -134,14 +134,13 @@ fn get_and_increment_nonce() {
 }
 
 #[test]
-fn get_contract_class() {
+fn get_contract_class_v0() {
     // Positive flow.
     let existing_class_hash = ClassHash(stark_felt!(TEST_CLASS_HASH));
     let mut state = create_test_state();
-    assert_eq!(
-        state.get_compiled_contract_class(&existing_class_hash).unwrap(),
-        get_test_contract_class()
-    );
+
+    let contract_class = state.get_compiled_contract_class(&existing_class_hash).unwrap();
+    assert_eq!(contract_class, get_contract_class_for_testing(TEST_CONTRACT_PATH));
 
     // Negative flow.
     let missing_class_hash = ClassHash(stark_felt!("0x101"));
@@ -186,7 +185,8 @@ fn cached_state_state_diff_conversion() {
     // This will not appear in the diff, since this mapping is immutable for the current version we
     // are aligned with.
     let test_class_hash = ClassHash(stark_felt!(TEST_CLASS_HASH));
-    let class_hash_to_class = HashMap::from([(test_class_hash, get_test_contract_class())]);
+    let class_hash_to_class =
+        HashMap::from([(test_class_hash, get_contract_class_for_testing(TEST_CONTRACT_PATH))]);
 
     let nonce_initial_values = HashMap::new();
 

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -22,7 +22,9 @@ use starknet_api::{calldata, patricia_key, stark_felt};
 
 use crate::abi::abi_utils::get_storage_var_address;
 use crate::block_context::BlockContext;
-use crate::execution::contract_class::{ContractClass, ContractClassV0, ContractClassV1};
+use crate::execution::contract_class::{
+    ContractClass, ContractClassV0, ContractClassV0Inner, ContractClassV1,
+};
 use crate::execution::entry_point::{
     CallEntryPoint, CallExecution, CallInfo, CallType, EntryPointExecutionResult, ExecutionContext,
     Retdata,
@@ -118,11 +120,10 @@ impl StateReader for DictStateReader {
         &mut self,
         class_hash: &ClassHash,
     ) -> StateResult<ContractClass> {
-        let contract_class = self.class_hash_to_class.get(class_hash).cloned();
-        match contract_class {
-            Some(contract_class) => Ok(contract_class),
-            _ => Err(StateError::UndeclaredClassHash(*class_hash)),
-        }
+        self.class_hash_to_class
+            .get(class_hash)
+            .cloned()
+            .ok_or(StateError::UndeclaredClassHash(*class_hash))
     }
 
     fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
@@ -146,17 +147,24 @@ pub fn pad_address_to_64(address: &str) -> String {
     String::from("0x") + format!("{trimmed_address:0>64}").as_str()
 }
 
-pub fn get_contract_class_v1(contract_path: &str) -> ContractClassV1 {
+pub fn get_contract_class_v1(contract_path: &str) -> Option<ContractClassV1> {
     let path: PathBuf = [env!("CARGO_MANIFEST_DIR"), contract_path].iter().collect();
     let raw_contract_class = fs::read_to_string(path).unwrap();
-    let casm_contract_class: CasmContractClass = serde_json::from_str(&raw_contract_class).unwrap();
-    casm_contract_class.try_into().unwrap()
+    serde_json::from_str(&raw_contract_class)
+        .ok()
+        .map(|casm_contract_class: CasmContractClass| casm_contract_class.try_into().unwrap())
 }
 
 pub fn get_contract_class_v0(contract_path: &str) -> ContractClassV0 {
     let path: PathBuf = [env!("CARGO_MANIFEST_DIR"), contract_path].iter().collect();
     let raw_contract_class = fs::read_to_string(path).unwrap();
-    serde_json::from_str(&raw_contract_class).unwrap()
+    let contract_class: ContractClassV0Inner = serde_json::from_str(&raw_contract_class).unwrap();
+    contract_class.into()
+}
+
+pub fn get_contract_class_for_testing(contract_path: &str) -> ContractClass {
+    get_contract_class_v1(contract_path)
+        .map_or_else(|| get_contract_class_v0(contract_path).into(), Into::into)
 }
 
 pub fn get_deprecated_contract_class(contract_path: &str) -> DeprecatedContractClass {
@@ -171,10 +179,6 @@ pub fn get_deprecated_contract_class(contract_path: &str) -> DeprecatedContractC
         .remove("abi");
 
     serde_json::from_value(raw_contract_class).unwrap()
-}
-
-pub fn get_test_contract_class() -> ContractClass {
-    get_contract_class_v0(TEST_CONTRACT_PATH).into()
 }
 
 pub fn trivial_external_entry_point() -> CallEntryPoint {
@@ -200,10 +204,13 @@ pub fn trivial_external_entry_point_security_test() -> CallEntryPoint {
 
 pub fn create_test_state() -> CachedState<DictStateReader> {
     let class_hash_to_class = HashMap::from([
-        (ClassHash(stark_felt!(TEST_CLASS_HASH)), get_contract_class_v0(TEST_CONTRACT_PATH).into()),
+        (
+            ClassHash(stark_felt!(TEST_CLASS_HASH)),
+            get_contract_class_for_testing(TEST_CONTRACT_PATH),
+        ),
         (
             ClassHash(stark_felt!(SECURITY_TEST_CLASS_HASH)),
-            get_contract_class_v0(SECURITY_TEST_CONTRACT_PATH).into(),
+            get_contract_class_for_testing(SECURITY_TEST_CONTRACT_PATH),
         ),
     ]);
 
@@ -233,7 +240,7 @@ pub fn create_test_state() -> CachedState<DictStateReader> {
 pub fn create_test_cairo1_state() -> CachedState<DictStateReader> {
     let class_hash_to_class = HashMap::from([(
         ClassHash(stark_felt!(TEST_CLASS_HASH)),
-        get_contract_class_v1(TEST_CONTRACT_CAIRO1_PATH).into(),
+        get_contract_class_v1(TEST_CONTRACT_CAIRO1_PATH).unwrap().into(),
     )]);
 
     // Two instances of a test contract and one instance of another (different) test contract.
@@ -270,8 +277,8 @@ pub fn create_deploy_test_state() -> CachedState<DictStateReader> {
     )
     .unwrap();
     let class_hash_to_class = HashMap::from([
-        (class_hash, get_contract_class_v0(TEST_CONTRACT_PATH).into()),
-        (empty_contract_class_hash, get_contract_class_v0(TEST_EMPTY_CONTRACT_PATH).into()),
+        (class_hash, get_contract_class_for_testing(TEST_CONTRACT_PATH)),
+        (empty_contract_class_hash, get_contract_class_for_testing(TEST_EMPTY_CONTRACT_PATH)),
     ]);
     let address_to_class_hash =
         HashMap::from([(contract_address, class_hash), (another_contract_address, class_hash)]);

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -13,7 +13,7 @@ use crate::block_context::BlockContext;
 use crate::state::cached_state::CachedState;
 use crate::state::state_api::State;
 use crate::test_utils::{
-    declare_tx, deploy_account_tx, get_contract_class_v0, invoke_tx, DictStateReader,
+    declare_tx, deploy_account_tx, get_contract_class_for_testing, invoke_tx, DictStateReader,
     ACCOUNT_CONTRACT_PATH, BALANCE, ERC20_CONTRACT_PATH, MAX_FEE, TEST_ACCOUNT_CONTRACT_CLASS_HASH,
     TEST_CLASS_HASH, TEST_CONTRACT_PATH, TEST_ERC20_CONTRACT_CLASS_HASH,
 };
@@ -27,8 +27,8 @@ fn create_state() -> CachedState<DictStateReader> {
     let test_account_class_hash = ClassHash(stark_felt!(TEST_ACCOUNT_CONTRACT_CLASS_HASH));
     let test_erc20_class_hash = ClassHash(stark_felt!(TEST_ERC20_CONTRACT_CLASS_HASH));
     let class_hash_to_class = HashMap::from([
-        (test_account_class_hash, get_contract_class_v0(ACCOUNT_CONTRACT_PATH).into()),
-        (test_erc20_class_hash, get_contract_class_v0(ERC20_CONTRACT_PATH).into()),
+        (test_account_class_hash, get_contract_class_for_testing(ACCOUNT_CONTRACT_PATH)),
+        (test_erc20_class_hash, get_contract_class_for_testing(ERC20_CONTRACT_PATH)),
     ]);
     // Deploy the erc20 contract.
     let test_erc20_address = block_context.fee_token_address;
@@ -66,7 +66,7 @@ fn test_account_flow_test() {
     account_tx.execute(state, block_context).unwrap();
 
     // Declare a contract.
-    let contract_class = get_contract_class_v0(TEST_CONTRACT_PATH).into();
+    let contract_class = get_contract_class_for_testing(TEST_CONTRACT_PATH);
     let declare_tx = declare_tx(TEST_CLASS_HASH, deployed_account_address, max_fee, None);
     let account_tx = AccountTransaction::Declare(DeclareTransaction {
         tx: starknet_api::transaction::DeclareTransaction::V1(DeclareTransactionV0V1 {

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -41,7 +41,7 @@ impl Transaction {
                 Self::AccountTransaction(AccountTransaction::Declare(DeclareTransaction {
                     tx: declare,
                     contract_class: contract_class
-                        .expect("Declare should be created with a ContractClass"),
+                        .expect("Declare should be created with a contract class"),
                 }))
             }
             StarknetApiTransaction::DeployAccount(deploy_account) => {

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -30,13 +30,13 @@ use crate::state::cached_state::CachedState;
 use crate::state::errors::StateError;
 use crate::state::state_api::{State, StateReader};
 use crate::test_utils::{
-    get_contract_class_v0, test_erc20_account_balance_key, test_erc20_faulty_account_balance_key,
-    test_erc20_sequencer_balance_key, validate_tx_execution_info, DictStateReader,
-    ACCOUNT_CONTRACT_PATH, BALANCE, ERC20_CONTRACT_PATH, MAX_FEE, TEST_ACCOUNT_CONTRACT_ADDRESS,
-    TEST_ACCOUNT_CONTRACT_CLASS_HASH, TEST_CLASS_HASH, TEST_CONTRACT_ADDRESS, TEST_CONTRACT_PATH,
-    TEST_EMPTY_CONTRACT_CLASS_HASH, TEST_EMPTY_CONTRACT_PATH, TEST_ERC20_CONTRACT_CLASS_HASH,
-    TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS, TEST_FAULTY_ACCOUNT_CONTRACT_CLASS_HASH,
-    TEST_FAULTY_ACCOUNT_CONTRACT_PATH,
+    get_contract_class_for_testing, get_contract_class_v0, test_erc20_account_balance_key,
+    test_erc20_faulty_account_balance_key, test_erc20_sequencer_balance_key,
+    validate_tx_execution_info, DictStateReader, ACCOUNT_CONTRACT_PATH, BALANCE,
+    ERC20_CONTRACT_PATH, MAX_FEE, TEST_ACCOUNT_CONTRACT_ADDRESS, TEST_ACCOUNT_CONTRACT_CLASS_HASH,
+    TEST_CLASS_HASH, TEST_CONTRACT_ADDRESS, TEST_CONTRACT_PATH, TEST_EMPTY_CONTRACT_CLASS_HASH,
+    TEST_EMPTY_CONTRACT_PATH, TEST_ERC20_CONTRACT_CLASS_HASH, TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS,
+    TEST_FAULTY_ACCOUNT_CONTRACT_CLASS_HASH, TEST_FAULTY_ACCOUNT_CONTRACT_PATH,
 };
 use crate::transaction::account_transaction::AccountTransaction;
 use crate::transaction::constants;
@@ -63,9 +63,9 @@ fn create_account_tx_test_state(
     let test_account_class_hash = ClassHash(stark_felt!(account_class_hash));
     let test_erc20_class_hash = ClassHash(stark_felt!(TEST_ERC20_CONTRACT_CLASS_HASH));
     let class_hash_to_class = HashMap::from([
-        (test_account_class_hash, get_contract_class_v0(account_path).into()),
-        (test_contract_class_hash, get_contract_class_v0(TEST_CONTRACT_PATH).into()),
-        (test_erc20_class_hash, get_contract_class_v0(ERC20_CONTRACT_PATH).into()),
+        (test_account_class_hash, get_contract_class_for_testing(account_path)),
+        (test_contract_class_hash, get_contract_class_for_testing(TEST_CONTRACT_PATH)),
+        (test_erc20_class_hash, get_contract_class_for_testing(ERC20_CONTRACT_PATH)),
     ]);
     let test_contract_address = ContractAddress(patricia_key!(TEST_CONTRACT_ADDRESS));
     // A random address that is unlikely to equal the result of the calculation of a contract
@@ -635,7 +635,8 @@ fn create_account_tx_for_validate_test(
 
     match tx_type {
         TransactionType::Declare => {
-            let contract_class = get_contract_class_v0(TEST_FAULTY_ACCOUNT_CONTRACT_PATH).into();
+            let contract_class =
+                ContractClass::V0(get_contract_class_v0(TEST_FAULTY_ACCOUNT_CONTRACT_PATH));
             let declare_tx = crate::test_utils::declare_tx(
                 TEST_ACCOUNT_CONTRACT_CLASS_HASH,
                 ContractAddress(patricia_key!(TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS)),

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 blockifier = { path = "../blockifier", features = ["testing"] }
+cairo-lang-starknet.workspace = true
 cairo-vm.workspace = true
 hex.workspace = true
 indexmap.workspace = true

--- a/crates/native_blockifier/src/papyrus_state.rs
+++ b/crates/native_blockifier/src/papyrus_state.rs
@@ -1,7 +1,11 @@
-use blockifier::execution::contract_class::{ContractClass, ContractClassV0};
+use blockifier::execution::contract_class::{ContractClass, ContractClassV0, ContractClassV1};
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::{StateReader, StateResult};
+use cairo_lang_starknet::casm_contract_class::CasmContractClass;
+use papyrus_storage::compiled_class::CasmStorageReader;
 use papyrus_storage::db::RO;
+use papyrus_storage::state::StateStorageReader;
+use papyrus_storage::StorageResult;
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
@@ -12,6 +16,24 @@ use starknet_api::state::{StateNumber, StorageKey};
 mod test;
 
 type RawPapyrusStateReader<'env> = papyrus_storage::state::StateReader<'env, RO>;
+
+pub struct PapyrusReader<'env> {
+    state: PapyrusStateReader<'env>,
+    contracts: PapyrusExecutableClassReader<'env>,
+}
+
+impl<'env> PapyrusReader<'env> {
+    pub fn new(
+        storage_tx: &'env papyrus_storage::StorageTxn<'env, RO>,
+        block_number: BlockNumber,
+    ) -> Self {
+        let state_reader =
+            storage_tx.get_state_reader().expect("Should be able to initialize a state reader./");
+        let state = PapyrusStateReader::new(state_reader, block_number);
+        let contracts = PapyrusExecutableClassReader::new(storage_tx);
+        Self { state, contracts }
+    }
+}
 
 pub struct PapyrusStateReader<'env> {
     pub reader: RawPapyrusStateReader<'env>,
@@ -29,21 +51,22 @@ impl<'env> PapyrusStateReader<'env> {
     }
 }
 
-impl<'env> StateReader for PapyrusStateReader<'env> {
+impl<'env> StateReader for PapyrusReader<'env> {
     fn get_storage_at(
         &mut self,
         contract_address: ContractAddress,
         key: StorageKey,
     ) -> StateResult<StarkFelt> {
-        let state_number = StateNumber(*self.latest_block());
-        self.reader
+        let state_number = StateNumber(*self.state.latest_block());
+        self.state
+            .reader
             .get_storage_at(state_number, &contract_address, &key)
             .map_err(|err| StateError::StateReadError(err.to_string()))
     }
 
     fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
-        let state_number = StateNumber(*self.latest_block());
-        match self.reader.get_nonce_at(state_number, &contract_address) {
+        let state_number = StateNumber(*self.state.latest_block());
+        match self.state.reader.get_nonce_at(state_number, &contract_address) {
             Ok(Some(nonce)) => Ok(nonce),
             Ok(None) => Ok(Nonce::default()),
             Err(err) => Err(StateError::StateReadError(err.to_string())),
@@ -51,25 +74,55 @@ impl<'env> StateReader for PapyrusStateReader<'env> {
     }
 
     fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
-        let state_number = StateNumber(*self.latest_block());
-        match self.reader.get_class_hash_at(state_number, &contract_address) {
+        let state_number = StateNumber(*self.state.latest_block());
+        match self.state.reader.get_class_hash_at(state_number, &contract_address) {
             Ok(Some(class_hash)) => Ok(class_hash),
             Ok(None) => Ok(ClassHash::default()),
             Err(err) => Err(StateError::StateReadError(err.to_string())),
         }
     }
 
+    /// Returns a V1 contract if found, or a V0 contract if a V1 contract is not
+    /// found, or an `Error` otherwise.
     fn get_compiled_contract_class(
         &mut self,
         class_hash: &ClassHash,
     ) -> StateResult<ContractClass> {
-        let state_number = StateNumber(*self.latest_block());
-        match self.reader.get_deprecated_class_definition_at(state_number, class_hash) {
-            Ok(Some(starknet_api_contract_class)) => {
+        let state_number = StateNumber(*self.state.latest_block());
+
+        // FIXME: Check that the casm contract exists and is defined before the current state
+        // number, if it is, return it.
+        // The extra call to `get_class_definition_at` is inefficient, and returns a large object
+        // that we don't use.
+        let class_definition = &self
+            .state
+            .reader
+            .get_class_definition_at(state_number, class_hash)
+            .map_err(|err| StateError::StateReadError(err.to_string()))?;
+        if class_definition.is_some() {
+            let casm_contract_class = self
+                .contracts
+                .get_casm(*class_hash)
+                .map_err(|err| StateError::StateReadError(err.to_string()))?
+                .expect(
+                    "Should be able to fetch a casm class if its definition exists, database is \
+                     inconsistent.",
+                );
+
+            return Ok(ContractClass::V1(ContractClassV1::try_from(casm_contract_class)?));
+        }
+
+        let v0_contract_class = self
+            .state
+            .reader
+            .get_deprecated_class_definition_at(state_number, class_hash)
+            .map_err(|err| StateError::StateReadError(err.to_string()))?;
+
+        match v0_contract_class {
+            Some(starknet_api_contract_class) => {
                 Ok(ContractClassV0::try_from(starknet_api_contract_class)?.into())
             }
-            Ok(None) => Err(StateError::UndeclaredClassHash(*class_hash)),
-            Err(err) => Err(StateError::StateReadError(err.to_string())),
+            None => Err(StateError::UndeclaredClassHash(*class_hash)),
         }
     }
 
@@ -78,5 +131,19 @@ impl<'env> StateReader for PapyrusStateReader<'env> {
         _class_hash: ClassHash,
     ) -> StateResult<CompiledClassHash> {
         todo!()
+    }
+}
+
+pub struct PapyrusExecutableClassReader<'env> {
+    txn: &'env papyrus_storage::StorageTxn<'env, RO>,
+}
+
+impl<'env> PapyrusExecutableClassReader<'env> {
+    pub fn new(txn: &'env papyrus_storage::StorageTxn<'env, RO>) -> Self {
+        Self { txn }
+    }
+
+    fn get_casm(&self, class_hash: ClassHash) -> StorageResult<Option<CasmContractClass>> {
+        self.txn.get_casm(class_hash)
     }
 }

--- a/crates/native_blockifier/src/papyrus_state_test.rs
+++ b/crates/native_blockifier/src/papyrus_state_test.rs
@@ -8,7 +8,7 @@ use blockifier::test_utils::{
     TEST_CONTRACT_ADDRESS, TEST_CONTRACT_PATH,
 };
 use indexmap::IndexMap;
-use papyrus_storage::state::{StateStorageReader, StateStorageWriter};
+use papyrus_storage::state::StateStorageWriter;
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{ClassHash, ContractAddress, PatriciaKey};
 use starknet_api::hash::{StarkFelt, StarkHash};
@@ -16,7 +16,7 @@ use starknet_api::state::{StateDiff, StorageKey};
 use starknet_api::transaction::Calldata;
 use starknet_api::{calldata, patricia_key, stark_felt};
 
-use crate::papyrus_state::PapyrusStateReader;
+use crate::papyrus_state::PapyrusReader;
 
 #[test]
 fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
@@ -38,11 +38,10 @@ fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
         .commit()?;
 
     let storage_tx = storage_reader.begin_ro_txn()?;
-    let state_reader = storage_tx.get_state_reader()?;
-
     // BlockNumber is 1 due to the initialization step above.
     let block_number = BlockNumber(1);
-    let papyrus_reader = PapyrusStateReader::new(state_reader, block_number);
+    let papyrus_reader = PapyrusReader::new(&storage_tx, block_number);
+
     let mut state = CachedState::new(papyrus_reader);
 
     // Call entrypoint that want to write to storage, which updates the cached state's write cache.

--- a/crates/native_blockifier/src/py_test_utils.rs
+++ b/crates/native_blockifier/src/py_test_utils.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use blockifier::state::cached_state::CachedState;
-use blockifier::test_utils::{get_contract_class_v0, DictStateReader};
+use blockifier::test_utils::{get_contract_class_for_testing, DictStateReader};
 use starknet_api::core::ClassHash;
 use starknet_api::hash::StarkFelt;
 use starknet_api::stark_felt;
@@ -16,7 +16,7 @@ pub const TOKEN_FOR_TESTING_CONTRACT_PATH: &str =
 pub fn create_py_test_state() -> CachedState<DictStateReader> {
     let class_hash_to_class = HashMap::from([(
         ClassHash(stark_felt!(TOKEN_FOR_TESTING_CLASS_HASH)),
-        get_contract_class_v0(TOKEN_FOR_TESTING_CONTRACT_PATH).into(),
+        get_contract_class_for_testing(TOKEN_FOR_TESTING_CONTRACT_PATH),
     )]);
     CachedState::new(DictStateReader { class_hash_to_class, ..Default::default() })
 }


### PR DESCRIPTION
Continues the closed #445, which needed a bunch of changes after the Casm reader was made available.

- Add `PapyrusReader` which encapsulates the previous PapyrusStateReader, and also a Casm contract reader.
- Added minimal logic to get papyrus's `get_compiled_contract_class` to work with Casm contracts, setter and CachedState logic still unimplemented.
- Getter logic tries looking up a hash as a V1 contract class, then V0, and then raises an error.
- Hoisted contract getter logic from `initialize_execution_context` into `CallEntryPoint.execute`.
- test utils modified to assume V0 for now, will be generalized later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/455)
<!-- Reviewable:end -->
