### PR TITLE
Remove clippy warning

### DIFF
--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -31,8 +31,6 @@ mod test;
 
 /// Represents a paid StarkNet transaction.
 #[derive(Debug)]
-// TODO(Gilad, 15/4/2023): Remove clippy ignore, box large variants.
-#[allow(clippy::large_enum_variant)]
 pub enum AccountTransaction {
     Declare(DeclareTransaction),
     DeployAccount(DeployAccountTransaction),

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -16,8 +16,6 @@ use crate::transaction::transaction_utils::calculate_tx_resources;
 use crate::transaction::transactions::{DeclareTransaction, Executable, ExecutableTransaction};
 
 #[derive(Debug)]
-// TODO(Gilad, 15/4/2023): Remove clippy ignore, box large variants.
-#[allow(clippy::large_enum_variant)]
 pub enum Transaction {
     AccountTransaction(AccountTransaction),
     L1HandlerTransaction(L1HandlerTransaction),


### PR DESCRIPTION
The `ContractClass` inside `AccountTransaction` is now `Arc`ed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/467)
<!-- Reviewable:end -->
