### PR TITLE
Add papyrus reader class cache

### DIFF
--- a/crates/native_blockifier/src/papyrus_state_test.rs
+++ b/crates/native_blockifier/src/papyrus_state_test.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use blockifier::abi::abi_utils::selector_from_name;
 use blockifier::execution::entry_point::{CallEntryPoint, CallExecution, Retdata};
 use blockifier::retdata;
@@ -42,7 +44,8 @@ fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
 
     // BlockNumber is 1 due to the initialization step above.
     let block_number = BlockNumber(1);
-    let papyrus_reader = PapyrusStateReader::new(state_reader, block_number);
+    let contract_class_cache = HashMap::new();
+    let papyrus_reader = PapyrusStateReader::new(state_reader, block_number, contract_class_cache);
     let mut state = CachedState::new(papyrus_reader);
 
     // Call entrypoint that want to write to storage, which updates the cached state's write cache.

--- a/crates/native_blockifier/src/py_transaction.rs
+++ b/crates/native_blockifier/src/py_transaction.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
@@ -252,7 +253,9 @@ pub fn build_tx_executor(
         block_number: BlockNumber,
     ) -> NativeBlockifierResult<CachedState<PapyrusStateReader<'a>>> {
         let state_reader = storage_tx.get_state_reader()?;
-        let papyrus_reader = PapyrusStateReader::new(state_reader, block_number);
+        let contract_class_cache = HashMap::new();
+        let papyrus_reader =
+            PapyrusStateReader::new(state_reader, block_number, contract_class_cache);
         Ok(CachedState::new(papyrus_reader))
     }
 


### PR DESCRIPTION
While there is already a cache like this in `CachedState`, it cannot persist in between blocks, whereas this cache is saved on the reader, which is currently saved on the transaction executor instance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/478)
<!-- Reviewable:end -->
