### PR TITLE
Fix feature tests and lock cairo version for it

### DIFF
--- a/crates/blockifier/feature_contracts/cairo0/compiled/account_faulty_compiled.json
+++ b/crates/blockifier/feature_contracts/cairo0/compiled/account_faulty_compiled.json
@@ -131,7 +131,7 @@
             "pedersen",
             "range_check"
         ],
-        "compiler_version": "0.11.0.2",
+        "compiler_version": "0.11.1.1",
         "data": [
             "0x40780017fff7fff",
             "0x1",

--- a/crates/blockifier/feature_contracts/cairo0/compiled/account_without_validations_compiled.json
+++ b/crates/blockifier/feature_contracts/cairo0/compiled/account_without_validations_compiled.json
@@ -153,7 +153,7 @@
             "pedersen",
             "range_check"
         ],
-        "compiler_version": "0.11.0.2",
+        "compiler_version": "0.11.1.1",
         "data": [
             "0x480680017fff8000",
             "0x43616c6c436f6e7472616374",

--- a/crates/blockifier/feature_contracts/cairo0/compiled/empty_contract_compiled.json
+++ b/crates/blockifier/feature_contracts/cairo0/compiled/empty_contract_compiled.json
@@ -10,7 +10,7 @@
         "builtins": [
             "range_check"
         ],
-        "compiler_version": "0.11.0.2",
+        "compiler_version": "0.11.1.1",
         "data": [],
         "debug_info": null,
         "hints": {},

--- a/crates/blockifier/feature_contracts/cairo0/compiled/security_tests_contract_compiled.json
+++ b/crates/blockifier/feature_contracts/cairo0/compiled/security_tests_contract_compiled.json
@@ -410,7 +410,7 @@
             "ecdsa",
             "ec_op"
         ],
-        "compiler_version": "0.11.0.2",
+        "compiler_version": "0.11.1.1",
         "data": [
             "0x40780017fff7fff",
             "0x1",

--- a/crates/blockifier/feature_contracts/cairo0/compiled/test_contract_compiled.json
+++ b/crates/blockifier/feature_contracts/cairo0/compiled/test_contract_compiled.json
@@ -383,7 +383,7 @@
             "range_check",
             "bitwise"
         ],
-        "compiler_version": "0.11.0.2",
+        "compiler_version": "0.11.1.1",
         "data": [
             "0x400380007ffb7ffc",
             "0x400380017ffb7ffd",

--- a/crates/blockifier/tests/requirements.txt
+++ b/crates/blockifier/tests/requirements.txt
@@ -1,1 +1,2 @@
-cairo-lang
+# Locked for the stake of CI stability, bump this version as needed.
+cairo-lang=="0.11.1.1"


### PR DESCRIPTION
Fixing the version is to prevent frequent CI failures. Nothing special about this version, make sure to update this as needed when new versions come up.

Note: Without this locked version, the CI automatically takes the latest version, which means this test would crash after every cairo release without the lock.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/484)
<!-- Reviewable:end -->
