### PR TITLE
Convert u64->u128, and not u128->u64

### DIFF
--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -81,10 +81,10 @@ pub fn test_erc20_faulty_account_balance_key() -> StorageKey {
 }
 
 // The max_fee used for txs in this test.
-pub const MAX_FEE: u64 = 1000000 * 100000000000; // 1000000 * min_gas_price.
+pub const MAX_FEE: u128 = 1000000 * 100000000000; // 1000000 * min_gas_price.
 
 // The amount of test-token allocated to the account in this test.
-pub const BALANCE: u64 = 10 * MAX_FEE;
+pub const BALANCE: u128 = 10 * MAX_FEE;
 
 pub const DEFAULT_GAS_PRICE: u128 = 100 * u128::pow(10, 9); // Given in units of wei.
 

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -207,7 +207,7 @@ impl AccountTransaction {
         }
 
         // The least significant 128 bits of the amount transferred.
-        let lsb_amount = StarkFelt::from(actual_fee.0 as u64);
+        let lsb_amount = StarkFelt::from(actual_fee.0);
         // The most significant 128 bits of the amount transferred.
         let msb_amount = StarkFelt::from(0_u8);
 

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -45,7 +45,7 @@ fn create_state() -> CachedState<DictStateReader> {
 fn test_account_flow_test() {
     let state = &mut create_state();
     let block_context = &BlockContext::create_for_account_testing();
-    let max_fee = Fee(u128::from(MAX_FEE));
+    let max_fee = Fee(MAX_FEE);
 
     // Deploy an account contract.
     let deploy_account_tx =
@@ -59,7 +59,7 @@ fn test_account_flow_test() {
     state.set_storage_at(
         block_context.fee_token_address,
         deployed_account_balance_key,
-        stark_felt!(Fee(u128::from(BALANCE)).0 as u64),
+        stark_felt!(BALANCE),
     );
 
     let account_tx = AccountTransaction::DeployAccount(deploy_account_tx);

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -55,7 +55,7 @@ fn create_account_tx_test_state(
     account_address: &str,
     account_path: &str,
     erc20_account_balance_key: StorageKey,
-    initial_account_balance: u64,
+    initial_account_balance: u128,
 ) -> CachedState<DictStateReader> {
     let block_context = BlockContext::create_for_testing();
 
@@ -134,7 +134,7 @@ fn expected_fee_transfer_call_info(
     let expected_fee_token_class_hash = ClassHash(stark_felt!(TEST_ERC20_CONTRACT_CLASS_HASH));
     let expected_sequencer_address = *block_context.sequencer_address.0.key();
     // The least significant 128 bits of the expected amount transferred.
-    let lsb_expected_amount = stark_felt!(actual_fee.0 as u64);
+    let lsb_expected_amount = stark_felt!(actual_fee.0);
     // The most significant 128 bits of the expected amount transferred.
     let msb_expected_amount = stark_felt!(0_u8);
     let storage_address = block_context.fee_token_address;
@@ -183,7 +183,7 @@ fn validate_final_balances(
     block_context: &BlockContext,
     expected_sequencer_balance: StarkFelt,
     erc20_account_balance_key: StorageKey,
-    expected_account_balance: u64,
+    expected_account_balance: u128,
 ) {
     let account_balance =
         state.get_storage_at(block_context.fee_token_address, erc20_account_balance_key).unwrap();
@@ -209,7 +209,7 @@ fn invoke_tx() -> InvokeTransactionV1 {
     crate::test_utils::invoke_tx(
         execute_calldata,
         ContractAddress(patricia_key!(TEST_ACCOUNT_CONTRACT_ADDRESS)),
-        Fee(u128::from(MAX_FEE)),
+        Fee(MAX_FEE),
         None,
     )
 }
@@ -337,8 +337,8 @@ fn test_invoke_tx() {
     assert_eq!(nonce_from_state, Nonce(stark_felt!(1_u8)));
 
     // Test final balances.
-    let expected_sequencer_balance = stark_felt!(expected_actual_fee.0 as u64);
-    let expected_account_balance = BALANCE - expected_actual_fee.0 as u64;
+    let expected_sequencer_balance = stark_felt!(expected_actual_fee.0);
+    let expected_account_balance = BALANCE - expected_actual_fee.0;
     validate_final_balances(
         state,
         block_context,
@@ -397,7 +397,7 @@ fn declare_tx(
     crate::test_utils::declare_tx(
         class_hash,
         ContractAddress(patricia_key!(sender_address)),
-        Fee(u128::from(MAX_FEE)),
+        Fee(MAX_FEE),
         signature,
     )
 }
@@ -476,8 +476,8 @@ fn test_declare_tx() {
     assert_eq!(nonce_from_state, Nonce(stark_felt!(1_u8)));
 
     // Test final balances.
-    let expected_sequencer_balance = stark_felt!(expected_actual_fee.0 as u64);
-    let expected_account_balance = BALANCE - expected_actual_fee.0 as u64;
+    let expected_sequencer_balance = stark_felt!(expected_actual_fee.0);
+    let expected_account_balance = BALANCE - expected_actual_fee.0;
     validate_final_balances(
         state,
         block_context,
@@ -498,7 +498,7 @@ fn deploy_account_tx(
 ) -> DeployAccountTransaction {
     crate::test_utils::deploy_account_tx(
         account_class_hash,
-        Fee(u128::from(MAX_FEE)),
+        Fee(MAX_FEE),
         constructor_calldata,
         signature,
     )
@@ -592,8 +592,8 @@ fn test_deploy_account_tx() {
     assert_eq!(nonce_from_state, Nonce(stark_felt!(1_u8)));
 
     // Test final balances.
-    let expected_sequencer_balance = stark_felt!(expected_actual_fee.0 as u64);
-    let expected_account_balance = BALANCE - expected_actual_fee.0 as u64;
+    let expected_sequencer_balance = stark_felt!(expected_actual_fee.0);
+    let expected_account_balance = BALANCE - expected_actual_fee.0;
     validate_final_balances(
         state,
         block_context,


### PR DESCRIPTION
Recently, `From<u128> for StarkFelt` was implemented, so no need to cast u128 integers (`Fee` is `Fee(pub u128)`) to u64 before constructing a felt.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/500)
<!-- Reviewable:end -->
