### PR TITLE
Start implementing `StateReader` for `PapyrusReader`

### DIFF
--- a/crates/native_blockifier/src/papyrus_state.rs
+++ b/crates/native_blockifier/src/papyrus_state.rs
@@ -37,6 +37,35 @@ impl<'env> PapyrusReader<'env> {
 
 // Currently unused - will soon replace the same `impl` for `PapyrusStateReader`.
 impl<'env> StateReader for PapyrusReader<'env> {
+    fn get_storage_at(
+        &mut self,
+        contract_address: ContractAddress,
+        key: StorageKey,
+    ) -> StateResult<StarkFelt> {
+        let state_number = StateNumber(*self.state.latest_block());
+        self.state_reader()
+            .get_storage_at(state_number, &contract_address, &key)
+            .map_err(|err| StateError::StateReadError(err.to_string()))
+    }
+
+    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
+        let state_number = StateNumber(*self.state.latest_block());
+        match self.state_reader().get_nonce_at(state_number, &contract_address) {
+            Ok(Some(nonce)) => Ok(nonce),
+            Ok(None) => Ok(Nonce::default()),
+            Err(err) => Err(StateError::StateReadError(err.to_string())),
+        }
+    }
+
+    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
+        let state_number = StateNumber(*self.state.latest_block());
+        match self.state_reader().get_class_hash_at(state_number, &contract_address) {
+            Ok(Some(class_hash)) => Ok(class_hash),
+            Ok(None) => Ok(ClassHash::default()),
+            Err(err) => Err(StateError::StateReadError(err.to_string())),
+        }
+    }
+
     /// Returns a V1 contract if found, or a V0 contract if a V1 contract is not
     /// found, or an `Error` otherwise.
     fn get_compiled_contract_class(
@@ -44,14 +73,14 @@ impl<'env> StateReader for PapyrusReader<'env> {
         class_hash: &ClassHash,
     ) -> StateResult<ContractClass> {
         let state_number = StateNumber(*self.state.latest_block());
-
-        let contract_class_definition_block_number = self
+        let class_declaration_block_number = self
             .state_reader()
             .get_class_definition_block_number(class_hash)
             .map_err(|err| StateError::StateReadError(err.to_string()))?;
-        if matches!(contract_class_definition_block_number,
-                    Some(block_number) if block_number < state_number.0)
-        {
+        let class_is_declared: bool = matches!(class_declaration_block_number,
+                    Some(block_number) if block_number <= state_number.0);
+
+        if class_is_declared {
             let casm_contract_class = self
                 .contract_classes
                 .get_casm(*class_hash)
@@ -81,22 +110,6 @@ impl<'env> StateReader for PapyrusReader<'env> {
         &mut self,
         _class_hash: ClassHash,
     ) -> StateResult<CompiledClassHash> {
-        todo!()
-    }
-
-    fn get_storage_at(
-        &mut self,
-        _contract_address: ContractAddress,
-        _key: StorageKey,
-    ) -> StateResult<StarkFelt> {
-        todo!()
-    }
-
-    fn get_nonce_at(&mut self, _contract_address: ContractAddress) -> StateResult<Nonce> {
-        todo!()
-    }
-
-    fn get_class_hash_at(&mut self, _contract_address: ContractAddress) -> StateResult<ClassHash> {
         todo!()
     }
 }

--- a/crates/native_blockifier/src/papyrus_state.rs
+++ b/crates/native_blockifier/src/papyrus_state.rs
@@ -1,4 +1,4 @@
-use blockifier::execution::contract_class::{ContractClass, ContractClassV0};
+use blockifier::execution::contract_class::{ContractClass, ContractClassV0, ContractClassV1};
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::{StateReader, StateResult};
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
@@ -18,7 +18,7 @@ type RawPapyrusStateReader<'env> = papyrus_storage::state::StateReader<'env, RO>
 
 pub struct PapyrusReader<'env> {
     state: PapyrusStateReader<'env>,
-    _contract_classes: PapyrusExecutableClassReader<'env>,
+    contract_classes: PapyrusExecutableClassReader<'env>,
 }
 
 impl<'env> PapyrusReader<'env> {
@@ -26,12 +26,78 @@ impl<'env> PapyrusReader<'env> {
         storage_tx: &'env papyrus_storage::StorageTxn<'env, RO>,
         state_reader: PapyrusStateReader<'env>,
     ) -> Self {
-        let _contract_classes = PapyrusExecutableClassReader::new(storage_tx);
-        Self { state: state_reader, _contract_classes }
+        let contract_classes = PapyrusExecutableClassReader::new(storage_tx);
+        Self { state: state_reader, contract_classes }
     }
 
     pub fn state_reader(&mut self) -> &RawPapyrusStateReader<'env> {
         &self.state.reader
+    }
+}
+
+// Currently unused - will soon replace the same `impl` for `PapyrusStateReader`.
+impl<'env> StateReader for PapyrusReader<'env> {
+    /// Returns a V1 contract if found, or a V0 contract if a V1 contract is not
+    /// found, or an `Error` otherwise.
+    fn get_compiled_contract_class(
+        &mut self,
+        class_hash: &ClassHash,
+    ) -> StateResult<ContractClass> {
+        let state_number = StateNumber(*self.state.latest_block());
+
+        let contract_class_definition_block_number = self
+            .state_reader()
+            .get_class_definition_block_number(class_hash)
+            .map_err(|err| StateError::StateReadError(err.to_string()))?;
+        if matches!(contract_class_definition_block_number,
+                    Some(block_number) if block_number < state_number.0)
+        {
+            let casm_contract_class = self
+                .contract_classes
+                .get_casm(*class_hash)
+                .map_err(|err| StateError::StateReadError(err.to_string()))?
+                .expect(
+                    "Should be able to fetch a Casm class if its definition exists, database is \
+                     inconsistent.",
+                );
+
+            return Ok(ContractClass::V1(ContractClassV1::try_from(casm_contract_class)?));
+        }
+
+        let v0_contract_class = self
+            .state_reader()
+            .get_deprecated_class_definition_at(state_number, class_hash)
+            .map_err(|err| StateError::StateReadError(err.to_string()))?;
+
+        match v0_contract_class {
+            Some(starknet_api_contract_class) => {
+                Ok(ContractClassV0::try_from(starknet_api_contract_class)?.into())
+            }
+            None => Err(StateError::UndeclaredClassHash(*class_hash)),
+        }
+    }
+
+    fn get_compiled_class_hash(
+        &mut self,
+        _class_hash: ClassHash,
+    ) -> StateResult<CompiledClassHash> {
+        todo!()
+    }
+
+    fn get_storage_at(
+        &mut self,
+        _contract_address: ContractAddress,
+        _key: StorageKey,
+    ) -> StateResult<StarkFelt> {
+        todo!()
+    }
+
+    fn get_nonce_at(&mut self, _contract_address: ContractAddress) -> StateResult<Nonce> {
+        todo!()
+    }
+
+    fn get_class_hash_at(&mut self, _contract_address: ContractAddress) -> StateResult<ClassHash> {
+        todo!()
     }
 }
 
@@ -103,15 +169,15 @@ impl<'env> StateReader for PapyrusStateReader<'env> {
     }
 }
 pub struct PapyrusExecutableClassReader<'env> {
-    _txn: &'env papyrus_storage::StorageTxn<'env, RO>,
+    txn: &'env papyrus_storage::StorageTxn<'env, RO>,
 }
 
 impl<'env> PapyrusExecutableClassReader<'env> {
-    pub fn new(_txn: &'env papyrus_storage::StorageTxn<'env, RO>) -> Self {
-        Self { _txn }
+    pub fn new(txn: &'env papyrus_storage::StorageTxn<'env, RO>) -> Self {
+        Self { txn }
     }
 
-    fn _get_casm(&self, class_hash: ClassHash) -> StorageResult<Option<CasmContractClass>> {
-        self._txn.get_casm(class_hash)
+    fn get_casm(&self, class_hash: ClassHash) -> StorageResult<Option<CasmContractClass>> {
+        self.txn.get_casm(class_hash)
     }
 }


### PR DESCRIPTION
Currently unused, will replace the impl on `PapyrusStateReader` soon. The impl is copy-pasted from `PapyrusStateReader`, with the following differences:
* `get_compiled_contract_class` also looks for V1 contract classes, before looking for V0 ones.
* getter for the state_reader now uses the getter method (since the reader is now a field inside PapyrusReader)

Too see exact diff, compare with https://reviewable.io/reviews/starkware-libs/blockifier/455#, which is almost the same (changes are after addressing comments there)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/508)
<!-- Reviewable:end -->
