### PR TITLE
Fix compiled class hash retrieval

### DIFF
--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -185,13 +185,18 @@ pub struct CallInfo {
 
 impl CallInfo {
     /// Returns the set of class hashes that were executed during this call execution.
+    // TODO: Add unit test for this method
     pub fn get_executed_class_hashes(&self) -> HashSet<ClassHash> {
         let mut class_hashes = HashSet::<ClassHash>::from([self
             .call
             .class_hash
             .expect("Class hash must be set after execution.")]);
 
-        for call in self.into_iter() {
+        // The first call in the iterator is self (it follows a pre-order traversal),
+        // which is added separately as the base case for the recursion.
+        let inner_calls = self.into_iter().skip(1);
+
+        for call in inner_calls {
             class_hashes.extend(call.get_executed_class_hashes());
         }
 

--- a/crates/native_blockifier/src/py_transaction.rs
+++ b/crates/native_blockifier/src/py_transaction.rs
@@ -430,7 +430,6 @@ pub fn into_py_executed_compiled_class_hashes(
     for _class_hash in executed_class_hashes {
         // TODO: understand if this is a Sierra hash; if so, add the corresponding compiled class
         // hash to set.
-        todo!();
     }
 
     executed_compiled_class_hashes.iter().map(|class_hash| PyFelt::from(*class_hash)).collect()


### PR DESCRIPTION
- `get_executed_class_hashes` hit infinite recursion.
- Remove `todo!` from python cast, it panics in Python tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/512)
<!-- Reviewable:end -->
