### PR TITLE
cherry-pick: Missing `deprecated_declared_class_hash_to_class` in `append_block` d…

### DIFF
--- a/crates/native_blockifier/src/storage.rs
+++ b/crates/native_blockifier/src/storage.rs
@@ -94,7 +94,14 @@ impl Storage {
         Ok(())
     }
 
-    #[args(block_id, previous_block_id, py_block_info, py_state_diff, declared_class_hash_to_class)]
+    #[args(
+        block_id,
+        previous_block_id,
+        py_block_info,
+        py_state_diff,
+        declared_class_hash_to_class,
+        deprecated_declared_class_hash_to_class
+    )]
     /// Appends state diff and block header into Papyrus storage.
     // Previous block ID can either be a block hash (starting from a Papyrus snapshot), or a
     // sequential ID (throughout sequencing).


### PR DESCRIPTION
…efinition (#513)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/522)
<!-- Reviewable:end -->
