### PR TITLE
Run CI in PRs for main-v* type branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - main-v[0-9].**
     tags:
       - v[0-9].**
 


### PR DESCRIPTION
Currently PRs to main-v0.12.0 don't run CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/532)
<!-- Reviewable:end -->
