### PR TITLE
Add initial gas to the execution of an entry point.

### DIFF
--- a/crates/blockifier/src/abi/abi_utils_test.rs
+++ b/crates/blockifier/src/abi/abi_utils_test.rs
@@ -3,17 +3,20 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::stark_felt;
 
 use crate::abi::abi_utils::selector_from_name;
-use crate::abi::constants;
+use crate::abi::constants as abi_constants;
 use crate::transaction::constants as transaction_constants;
 
 #[test]
 fn test_selector_from_name() {
     // Test default EP.
     let expected_default_selector =
-        EntryPointSelector(stark_felt!(constants::DEFAULT_ENTRY_POINT_SELECTOR));
-    assert_eq!(selector_from_name(constants::DEFAULT_ENTRY_POINT_NAME), expected_default_selector);
+        EntryPointSelector(stark_felt!(abi_constants::DEFAULT_ENTRY_POINT_SELECTOR));
     assert_eq!(
-        selector_from_name(constants::DEFAULT_L1_ENTRY_POINT_NAME),
+        selector_from_name(abi_constants::DEFAULT_ENTRY_POINT_NAME),
+        expected_default_selector
+    );
+    assert_eq!(
+        selector_from_name(abi_constants::DEFAULT_L1_ENTRY_POINT_NAME),
         expected_default_selector
     );
 

--- a/crates/blockifier/src/abi/constants.rs
+++ b/crates/blockifier/src/abi/constants.rs
@@ -36,6 +36,9 @@ pub const N_STEPS_PER_PEDERSEN: usize = 8;
 // Gas Cost.
 // See documentation in core/os/constants.cairo.
 pub const STEP_GAS_COST: u64 = 100;
+// An estimation of the initial gas for a transaction to run with. This solution is temporary and
+// this value will become a field of the transaction.
+pub const INITIAL_GAS_COST: u64 = 10_u64.pow(8) * STEP_GAS_COST;
 // Compiler gas costs.
 pub const ENTRY_POINT_INITIAL_BUDGET: u64 = 100 * STEP_GAS_COST;
 // OS gas costs.

--- a/crates/blockifier/src/execution/cairo1_execution.rs
+++ b/crates/blockifier/src/execution/cairo1_execution.rs
@@ -182,9 +182,8 @@ pub fn prepare_call_arguments(
         }
         return Err(PreExecutionError::InvalidBuiltin(builtin_name.clone()));
     }
-    // TODO(spapini): Use the correct gas counter.
     // Push gas counter.
-    args.push(CairoArg::Single(10000000000.into()));
+    args.push(CairoArg::Single((&call.initial_gas).into()));
     // Push syscall ptr.
     args.push(CairoArg::Single(initial_syscall_ptr.into()));
 

--- a/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
@@ -111,7 +111,7 @@ fn test_nested_library_call() {
     };
     let storage_entry_point = CallEntryPoint {
         calldata: calldata![stark_felt!(key), stark_felt!(value)],
-        ..nested_storage_entry_point
+        ..nested_storage_entry_point.clone()
     };
     let storage_entry_point_vm_resources =
         VmExecutionResources { n_steps: 41, ..Default::default() };

--- a/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
@@ -22,6 +22,7 @@ use starknet_api::transaction::Calldata;
 use starknet_api::StarknetApiError;
 use thiserror::Error;
 
+use crate::abi::constants;
 use crate::execution::common_hints::{extended_builtin_hint_processor, HintExecutionResult};
 use crate::execution::deprecated_syscalls::{
     call_contract, delegate_call, delegate_l1_handler, deploy, emit_event, get_block_number,
@@ -389,6 +390,7 @@ pub fn execute_library_call(
 ) -> DeprecatedSyscallResult<ReadOnlySegment> {
     let entry_point_type =
         if call_to_external { EntryPointType::External } else { EntryPointType::L1Handler };
+    let initial_gas = constants::INITIAL_GAS_COST.into();
     let entry_point = CallEntryPoint {
         class_hash: Some(class_hash),
         code_address,
@@ -399,6 +401,7 @@ pub fn execute_library_call(
         storage_address: syscall_handler.storage_address,
         caller_address: syscall_handler.caller_address,
         call_type: CallType::Delegate,
+        initial_gas,
     };
 
     execute_inner_call(entry_point, vm, syscall_handler)

--- a/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
@@ -18,6 +18,7 @@ use self::hint_processor::{
     execute_inner_call, execute_library_call, felt_to_bool, read_call_params, read_calldata,
     read_felt_array, DeprecatedSyscallExecutionError, DeprecatedSyscallHintProcessor,
 };
+use crate::abi::constants;
 use crate::execution::entry_point::{
     CallEntryPoint, CallType, MessageToL1, OrderedEvent, OrderedL2ToL1Message,
 };
@@ -161,6 +162,7 @@ pub fn call_contract(
     syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<CallContractResponse> {
     let storage_address = request.contract_address;
+    let initial_gas = constants::INITIAL_GAS_COST.into();
     let entry_point = CallEntryPoint {
         class_hash: None,
         code_address: Some(storage_address),
@@ -170,6 +172,7 @@ pub fn call_contract(
         storage_address,
         caller_address: syscall_handler.storage_address,
         call_type: CallType::Call,
+        initial_gas,
     };
     let retdata_segment = execute_inner_call(entry_point, vm, syscall_handler)?;
 

--- a/crates/blockifier/src/execution/syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/syscalls/hint_processor.rs
@@ -491,6 +491,7 @@ pub fn execute_library_call(
 ) -> SyscallResult<ReadOnlySegment> {
     let entry_point_type =
         if call_to_external { EntryPointType::External } else { EntryPointType::L1Handler };
+    let initial_gas = constants::INITIAL_GAS_COST.into();
     let entry_point = CallEntryPoint {
         class_hash: Some(class_hash),
         code_address,
@@ -501,6 +502,7 @@ pub fn execute_library_call(
         storage_address: syscall_handler.storage_address(),
         caller_address: syscall_handler.caller_address(),
         call_type: CallType::Delegate,
+        initial_gas,
     };
 
     execute_inner_call(entry_point, vm, syscall_handler)

--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -16,6 +16,7 @@ use self::hint_processor::{
     read_call_params, read_calldata, read_felt_array, write_segment, SyscallExecutionError,
     SyscallHintProcessor,
 };
+use crate::abi::constants;
 use crate::execution::contract_class::ContractClass;
 use crate::execution::deprecated_syscalls::DeprecatedSyscallSelector;
 use crate::execution::entry_point::{
@@ -149,6 +150,7 @@ pub fn call_contract(
     syscall_handler: &mut SyscallHintProcessor<'_>,
 ) -> SyscallResult<CallContractResponse> {
     let storage_address = request.contract_address;
+    let initial_gas = constants::INITIAL_GAS_COST.into();
     let entry_point = CallEntryPoint {
         class_hash: None,
         code_address: Some(storage_address),
@@ -158,6 +160,7 @@ pub fn call_contract(
         storage_address,
         caller_address: syscall_handler.storage_address(),
         call_type: CallType::Call,
+        initial_gas,
     };
     let retdata_segment = execute_inner_call(entry_point, vm, syscall_handler)?;
 

--- a/crates/blockifier/src/execution/syscalls/syscalls_test.rs
+++ b/crates/blockifier/src/execution/syscalls/syscalls_test.rs
@@ -203,7 +203,7 @@ fn test_nested_library_call() {
     };
     let storage_entry_point = CallEntryPoint {
         calldata: calldata![stark_felt!(key), stark_felt!(value)],
-        ..nested_storage_entry_point
+        ..nested_storage_entry_point.clone()
     };
     let storage_entry_point_vm_resources = VmExecutionResources {
         n_steps: 148,

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -20,6 +20,7 @@ use starknet_api::transaction::{
 use starknet_api::{calldata, patricia_key, stark_felt};
 
 use crate::abi::abi_utils::get_storage_var_address;
+use crate::abi::constants;
 use crate::block_context::BlockContext;
 use crate::execution::contract_class::{ContractClass, ContractClassV0, ContractClassV1};
 use crate::execution::entry_point::{
@@ -172,6 +173,7 @@ pub fn get_test_contract_class() -> ContractClass {
 
 pub fn trivial_external_entry_point() -> CallEntryPoint {
     let contract_address = ContractAddress(patricia_key!(TEST_CONTRACT_ADDRESS));
+    let initial_gas = constants::INITIAL_GAS_COST.into();
     CallEntryPoint {
         class_hash: None,
         code_address: Some(contract_address),
@@ -181,6 +183,7 @@ pub fn trivial_external_entry_point() -> CallEntryPoint {
         storage_address: contract_address,
         caller_address: ContractAddress::default(),
         call_type: CallType::Call,
+        initial_gas,
     }
 }
 

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -8,6 +8,7 @@ use starknet_api::transaction::{
 };
 
 use crate::abi::abi_utils::selector_from_name;
+use crate::abi::constants as abi_constants;
 use crate::block_context::BlockContext;
 use crate::execution::entry_point::{CallEntryPoint, CallInfo, CallType, ExecutionContext};
 use crate::fee::fee_utils::calculate_tx_fee;
@@ -164,6 +165,7 @@ impl AccountTransaction {
         }
 
         let storage_address = context.account_tx_context.sender_address;
+        let initial_gas = abi_constants::INITIAL_GAS_COST.into();
         let validate_call = CallEntryPoint {
             entry_point_type: EntryPointType::External,
             entry_point_selector: self.validate_entry_point_selector(),
@@ -173,6 +175,7 @@ impl AccountTransaction {
             storage_address,
             caller_address: ContractAddress::default(),
             call_type: CallType::Call,
+            initial_gas,
         };
 
         let validate_call_info = validate_call
@@ -219,6 +222,7 @@ impl AccountTransaction {
         let msb_amount = StarkFelt::from(0_u8);
 
         let storage_address = context.block_context.fee_token_address;
+        let initial_gas = abi_constants::INITIAL_GAS_COST.into();
         let fee_transfer_call = CallEntryPoint {
             class_hash: None,
             code_address: None,
@@ -232,6 +236,7 @@ impl AccountTransaction {
             storage_address,
             caller_address: context.account_tx_context.sender_address,
             call_type: CallType::Call,
+            initial_gas,
         };
 
         Ok(fee_transfer_call.execute(state, context)?)

--- a/crates/blockifier/src/transaction/transactions.rs
+++ b/crates/blockifier/src/transaction/transactions.rs
@@ -5,6 +5,7 @@ use starknet_api::deprecated_contract_class::EntryPointType;
 use starknet_api::transaction::{Calldata, DeployAccountTransaction, Fee, InvokeTransaction};
 
 use crate::abi::abi_utils::selector_from_name;
+use crate::abi::constants as abi_constants;
 use crate::block_context::BlockContext;
 use crate::execution::contract_class::ContractClass;
 use crate::execution::entry_point::{CallEntryPoint, CallInfo, CallType, ExecutionContext};
@@ -194,6 +195,7 @@ impl<S: State> Executable<S> for InvokeTransaction {
             InvokeTransaction::V1(_) => selector_from_name(constants::EXECUTE_ENTRY_POINT_NAME),
         };
         let storage_address = self.sender_address();
+        let initial_gas = abi_constants::INITIAL_GAS_COST.into();
         let execute_call = CallEntryPoint {
             entry_point_type: EntryPointType::External,
             entry_point_selector,
@@ -203,6 +205,7 @@ impl<S: State> Executable<S> for InvokeTransaction {
             storage_address,
             caller_address: ContractAddress::default(),
             call_type: CallType::Call,
+            initial_gas,
         };
 
         execute_call
@@ -226,6 +229,7 @@ impl<S: State> Executable<S> for L1HandlerTransaction {
     ) -> TransactionExecutionResult<Option<CallInfo>> {
         let tx = &self.tx;
         let storage_address = tx.contract_address;
+        let initial_gas = abi_constants::INITIAL_GAS_COST.into();
         let execute_call = CallEntryPoint {
             entry_point_type: EntryPointType::L1Handler,
             entry_point_selector: tx.entry_point_selector,
@@ -235,6 +239,7 @@ impl<S: State> Executable<S> for L1HandlerTransaction {
             storage_address,
             caller_address: ContractAddress::default(),
             call_type: CallType::Call,
+            initial_gas,
         };
 
         execute_call

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -110,6 +110,7 @@ fn expected_validate_call_info(
         )]),
     };
 
+    let initial_gas = abi_constants::INITIAL_GAS_COST.into();
     Some(CallInfo {
         call: CallEntryPoint {
             class_hash: Some(class_hash),
@@ -120,6 +121,7 @@ fn expected_validate_call_info(
             storage_address,
             caller_address: ContractAddress::default(),
             call_type: CallType::Call,
+            initial_gas,
         },
         // The account contract we use for testing has trivial `validate` functions.
         execution: CallExecution::default(),
@@ -141,6 +143,7 @@ fn expected_fee_transfer_call_info(
     // The most significant 128 bits of the expected amount transferred.
     let msb_expected_amount = stark_felt!(0_u8);
     let storage_address = block_context.fee_token_address;
+    let initial_gas = abi_constants::INITIAL_GAS_COST.into();
     let expected_fee_transfer_call = CallEntryPoint {
         class_hash: Some(expected_fee_token_class_hash),
         code_address: None,
@@ -154,6 +157,7 @@ fn expected_fee_transfer_call_info(
         storage_address,
         caller_address: account_address,
         call_type: CallType::Call,
+        initial_gas,
     };
     let expected_fee_sender_address = *account_address.0.key();
     let expected_fee_transfer_event = OrderedEvent {
@@ -266,6 +270,7 @@ fn test_invoke_tx() {
     // Build expected execute call info.
     let expected_return_result_calldata = vec![stark_felt!(2_u8)];
     let storage_address = ContractAddress(patricia_key!(TEST_CONTRACT_ADDRESS));
+    let initial_gas = abi_constants::INITIAL_GAS_COST.into();
     let expected_return_result_call = CallEntryPoint {
         entry_point_selector: selector_from_name("return_result"),
         class_hash: Some(ClassHash(stark_felt!(TEST_CLASS_HASH))),
@@ -275,6 +280,7 @@ fn test_invoke_tx() {
         storage_address,
         caller_address: expected_account_address,
         call_type: CallType::Call,
+        initial_gas,
     };
     let expected_execute_call = CallEntryPoint {
         entry_point_selector: selector_from_name(constants::EXECUTE_ENTRY_POINT_NAME),
@@ -581,6 +587,7 @@ fn test_deploy_account_tx() {
     );
 
     // Build expected execute call info.
+    let initial_gas = abi_constants::INITIAL_GAS_COST.into();
     let expected_execute_call_info = Some(CallInfo {
         call: CallEntryPoint {
             class_hash: Some(expected_account_class_hash),
@@ -588,6 +595,7 @@ fn test_deploy_account_tx() {
             entry_point_type: EntryPointType::Constructor,
             entry_point_selector: selector_from_name(abi_constants::CONSTRUCTOR_ENTRY_POINT_NAME),
             storage_address: deployed_account_address,
+            initial_gas,
             ..Default::default()
         },
         ..Default::default()


### PR DESCRIPTION
Initial gas is the amount of gas allocated to the execution on initiation.
Push this value to the stack when preparing the call arguments.
Based on #515.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/545)
<!-- Reviewable:end -->
