### PR TITLE
Remove unnecessary `mut`

### DIFF
--- a/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
@@ -330,7 +330,7 @@ pub fn emit_event(
     _vm: &mut VirtualMachine,
     syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<EmitEventResponse> {
-    let mut execution_context = &mut syscall_handler.context;
+    let execution_context = &mut syscall_handler.context;
     let ordered_event =
         OrderedEvent { order: execution_context.n_emitted_events, event: request.content };
     syscall_handler.events.push(ordered_event);
@@ -604,7 +604,7 @@ pub fn send_message_to_l1(
     _vm: &mut VirtualMachine,
     syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<SendMessageToL1Response> {
-    let mut execution_context = &mut syscall_handler.context;
+    let execution_context = &mut syscall_handler.context;
     let ordered_message_to_l1 = OrderedL2ToL1Message {
         order: execution_context.n_sent_messages_to_l1,
         message: request.message,

--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -263,7 +263,7 @@ pub fn emit_event(
     _vm: &mut VirtualMachine,
     syscall_handler: &mut SyscallHintProcessor<'_>,
 ) -> SyscallResult<EmitEventResponse> {
-    let mut execution_context = &mut syscall_handler.context;
+    let execution_context = &mut syscall_handler.context;
     let ordered_event =
         OrderedEvent { order: execution_context.n_emitted_events, event: request.content };
     syscall_handler.events.push(ordered_event);
@@ -412,7 +412,7 @@ pub fn send_message_to_l1(
     _vm: &mut VirtualMachine,
     syscall_handler: &mut SyscallHintProcessor<'_>,
 ) -> SyscallResult<SendMessageToL1Response> {
-    let mut execution_context = &mut syscall_handler.context;
+    let execution_context = &mut syscall_handler.context;
     let ordered_message_to_l1 = OrderedL2ToL1Message {
         order: execution_context.n_sent_messages_to_l1,
         message: request.message,


### PR DESCRIPTION
The pointer itself doesn't change so no need to put the pointer as mut.
(Clippy doesn't let me build locally without this change, probably using an old version of clippy on the CI?)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/548)
<!-- Reviewable:end -->
