### PR TITLE
Use `PapyrusReader`

### DIFF
--- a/crates/native_blockifier/src/papyrus_state.rs
+++ b/crates/native_blockifier/src/papyrus_state.rs
@@ -130,57 +130,6 @@ impl<'env> PapyrusStateReader<'env> {
     }
 }
 
-impl<'env> StateReader for PapyrusStateReader<'env> {
-    fn get_storage_at(
-        &mut self,
-        contract_address: ContractAddress,
-        key: StorageKey,
-    ) -> StateResult<StarkFelt> {
-        let state_number = StateNumber(*self.latest_block());
-        self.reader
-            .get_storage_at(state_number, &contract_address, &key)
-            .map_err(|err| StateError::StateReadError(err.to_string()))
-    }
-
-    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
-        let state_number = StateNumber(*self.latest_block());
-        match self.reader.get_nonce_at(state_number, &contract_address) {
-            Ok(Some(nonce)) => Ok(nonce),
-            Ok(None) => Ok(Nonce::default()),
-            Err(err) => Err(StateError::StateReadError(err.to_string())),
-        }
-    }
-
-    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
-        let state_number = StateNumber(*self.latest_block());
-        match self.reader.get_class_hash_at(state_number, &contract_address) {
-            Ok(Some(class_hash)) => Ok(class_hash),
-            Ok(None) => Ok(ClassHash::default()),
-            Err(err) => Err(StateError::StateReadError(err.to_string())),
-        }
-    }
-
-    fn get_compiled_contract_class(
-        &mut self,
-        class_hash: &ClassHash,
-    ) -> StateResult<ContractClass> {
-        let state_number = StateNumber(*self.latest_block());
-        match self.reader.get_deprecated_class_definition_at(state_number, class_hash) {
-            Ok(Some(starknet_api_contract_class)) => {
-                Ok(ContractClassV0::try_from(starknet_api_contract_class)?.into())
-            }
-            Ok(None) => Err(StateError::UndeclaredClassHash(*class_hash)),
-            Err(err) => Err(StateError::StateReadError(err.to_string())),
-        }
-    }
-
-    fn get_compiled_class_hash(
-        &mut self,
-        _class_hash: ClassHash,
-    ) -> StateResult<CompiledClassHash> {
-        todo!()
-    }
-}
 pub struct PapyrusExecutableClassReader<'env> {
     txn: &'env papyrus_storage::StorageTxn<'env, RO>,
 }

--- a/crates/native_blockifier/src/papyrus_state_test.rs
+++ b/crates/native_blockifier/src/papyrus_state_test.rs
@@ -16,7 +16,7 @@ use starknet_api::state::{StateDiff, StorageKey};
 use starknet_api::transaction::Calldata;
 use starknet_api::{calldata, patricia_key, stark_felt};
 
-use crate::papyrus_state::PapyrusStateReader;
+use crate::papyrus_state::{PapyrusReader, PapyrusStateReader};
 
 #[test]
 fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
@@ -42,7 +42,8 @@ fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
 
     // BlockNumber is 1 due to the initialization step above.
     let block_number = BlockNumber(1);
-    let papyrus_reader = PapyrusStateReader::new(state_reader, block_number);
+    let state_reader = PapyrusStateReader::new(state_reader, block_number);
+    let papyrus_reader = PapyrusReader::new(&storage_tx, state_reader);
     let mut state = CachedState::new(papyrus_reader);
 
     // Call entrypoint that want to write to storage, which updates the cached state's write cache.


### PR DESCRIPTION
This adds support for `get_compiled_contract_class` in Cairo1.

The old PapyrusStateReader is deleted because its logic has already been
implemented into `PapyrusReader`, which has been disabled thus far.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/549)
<!-- Reviewable:end -->
