### PR TITLE
Add `PyContractClass`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,6 +2210,7 @@ dependencies = [
  "papyrus_storage",
  "pyo3",
  "pyo3-log",
+ "serde",
  "serde_json",
  "starknet_api",
  "thiserror",

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -28,6 +28,7 @@ pyo3 = { version = "0.17.3", features = [
     "hashbrown",
 ] }
 pyo3-log = "0.8.1"
+serde = { workspace = true, features = ["derive"] }
 # We need this rev to be the same as in both `blockifier` and `papyrus_storage`.
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 # Should match the commit `papyrus_storage` is using.

--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod errors;
 pub mod papyrus_state;
+pub mod py_contract_class;
 pub mod py_state_diff;
 pub mod py_test_utils;
 pub mod py_transaction;

--- a/crates/native_blockifier/src/py_contract_class.rs
+++ b/crates/native_blockifier/src/py_contract_class.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use starknet_api::hash::StarkFelt;
+use starknet_api::state::{ContractClass, EntryPoint, EntryPointType};
+
+// A contract class as represented in Python, which is represented slightly different than
+// in Starknet API.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+pub struct PyContractClass {
+    pub sierra_program: Vec<StarkFelt>,
+    pub entry_points_by_type: HashMap<EntryPointType, Vec<EntryPoint>>,
+    pub abi: String,
+}
+
+impl From<PyContractClass> for ContractClass {
+    fn from(contract_class: PyContractClass) -> Self {
+        Self {
+            sierra_program: contract_class.sierra_program,
+            // Only different is here, mapping "*_points_*" to "*_point_*".
+            entry_point_by_type: contract_class.entry_points_by_type,
+            abi: contract_class.abi,
+        }
+    }
+}

--- a/crates/native_blockifier/src/storage.rs
+++ b/crates/native_blockifier/src/storage.rs
@@ -13,6 +13,7 @@ use starknet_api::hash::StarkHash;
 use starknet_api::state::{ContractClass, StateDiff, StateNumber};
 
 use crate::errors::NativeBlockifierResult;
+use crate::py_contract_class::PyContractClass;
 use crate::py_state_diff::PyBlockInfo;
 use crate::py_utils::PyFelt;
 use crate::PyStateDiff;
@@ -141,8 +142,8 @@ impl Storage {
         let mut declared_classes: IndexMap<ClassHash, (CompiledClassHash, ContractClass)> =
             IndexMap::new();
         for (class_hash, (compiled_class_hash, raw_class)) in declared_class_hash_to_class {
-            let contract_class: starknet_api::state::ContractClass =
-                serde_json::from_str(&raw_class)?;
+            let py_contract_class: PyContractClass = serde_json::from_str(&raw_class)?;
+            let contract_class = ContractClass::from(py_contract_class);
             declared_classes.insert(
                 ClassHash(class_hash.0),
                 (CompiledClassHash(compiled_class_hash.0), contract_class),


### PR DESCRIPTION
Sierra contract class in python has a field called `entry_points_by_type`, whereas in SN API it's called `entry_point_by_type`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/557)
<!-- Reviewable:end -->
