### PR TITLE
Enable Papyrus reader

### DIFF
--- a/crates/native_blockifier/src/papyrus_state.rs
+++ b/crates/native_blockifier/src/papyrus_state.rs
@@ -129,58 +129,6 @@ impl<'env> PapyrusStateReader<'env> {
         &self.latest_block
     }
 }
-
-impl<'env> StateReader for PapyrusStateReader<'env> {
-    fn get_storage_at(
-        &mut self,
-        contract_address: ContractAddress,
-        key: StorageKey,
-    ) -> StateResult<StarkFelt> {
-        let state_number = StateNumber(*self.latest_block());
-        self.reader
-            .get_storage_at(state_number, &contract_address, &key)
-            .map_err(|err| StateError::StateReadError(err.to_string()))
-    }
-
-    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
-        let state_number = StateNumber(*self.latest_block());
-        match self.reader.get_nonce_at(state_number, &contract_address) {
-            Ok(Some(nonce)) => Ok(nonce),
-            Ok(None) => Ok(Nonce::default()),
-            Err(error) => Err(StateError::StateReadError(error.to_string())),
-        }
-    }
-
-    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
-        let state_number = StateNumber(*self.latest_block());
-        match self.reader.get_class_hash_at(state_number, &contract_address) {
-            Ok(Some(class_hash)) => Ok(class_hash),
-            Ok(None) => Ok(ClassHash::default()),
-            Err(error) => Err(StateError::StateReadError(error.to_string())),
-        }
-    }
-
-    fn get_compiled_contract_class(
-        &mut self,
-        class_hash: &ClassHash,
-    ) -> StateResult<ContractClass> {
-        let state_number = StateNumber(*self.latest_block());
-        match self.reader.get_deprecated_class_definition_at(state_number, class_hash) {
-            Ok(Some(starknet_api_contract_class)) => {
-                Ok(ContractClassV0::try_from(starknet_api_contract_class)?.into())
-            }
-            Ok(None) => Err(StateError::UndeclaredClassHash(*class_hash)),
-            Err(error) => Err(StateError::StateReadError(error.to_string())),
-        }
-    }
-
-    fn get_compiled_class_hash(
-        &mut self,
-        _class_hash: ClassHash,
-    ) -> StateResult<CompiledClassHash> {
-        todo!()
-    }
-}
 pub struct PapyrusExecutableClassReader<'env> {
     txn: &'env papyrus_storage::StorageTxn<'env, RO>,
 }

--- a/crates/native_blockifier/src/papyrus_state_test.rs
+++ b/crates/native_blockifier/src/papyrus_state_test.rs
@@ -16,7 +16,7 @@ use starknet_api::state::{StateDiff, StorageKey};
 use starknet_api::transaction::Calldata;
 use starknet_api::{calldata, patricia_key, stark_felt};
 
-use crate::papyrus_state::PapyrusStateReader;
+use crate::papyrus_state::{PapyrusReader, PapyrusStateReader};
 
 #[test]
 fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
@@ -42,7 +42,8 @@ fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
 
     // BlockNumber is 1 due to the initialization step above.
     let block_number = BlockNumber(1);
-    let papyrus_reader = PapyrusStateReader::new(state_reader, block_number);
+    let state_reader = PapyrusStateReader::new(state_reader, block_number);
+    let papyrus_reader = PapyrusReader::new(&storage_tx, state_reader);
     let mut state = CachedState::new(papyrus_reader);
 
     // Call entrypoint that want to write to storage, which updates the cached state's write cache.

--- a/crates/native_blockifier/src/py_transaction.rs
+++ b/crates/native_blockifier/src/py_transaction.rs
@@ -31,7 +31,7 @@ use starknet_api::transaction::{
 };
 
 use crate::errors::{NativeBlockifierError, NativeBlockifierInputError, NativeBlockifierResult};
-use crate::papyrus_state::PapyrusStateReader;
+use crate::papyrus_state::{PapyrusReader, PapyrusStateReader};
 use crate::py_state_diff::PyStateDiff;
 use crate::py_transaction_execution_info::PyTransactionExecutionInfo;
 use crate::py_utils::{biguint_to_felt, to_chain_id_enum, PyFelt};
@@ -335,7 +335,7 @@ pub struct PyTransactionExecutorInner {
     pub storage_tx: papyrus_storage::StorageTxn<'this, RO>,
     #[borrows(storage_tx)]
     #[covariant]
-    pub state: CachedState<PapyrusStateReader<'this>>,
+    pub state: CachedState<PapyrusReader<'this>>,
 }
 
 impl PyTransactionExecutorInner {
@@ -445,9 +445,10 @@ pub fn build_tx_executor(
     fn state_builder<'a>(
         storage_tx: &'a papyrus_storage::StorageTxn<'a, RO>,
         block_number: BlockNumber,
-    ) -> NativeBlockifierResult<CachedState<PapyrusStateReader<'a>>> {
+    ) -> NativeBlockifierResult<CachedState<PapyrusReader<'a>>> {
         let state_reader = storage_tx.get_state_reader()?;
-        let papyrus_reader = PapyrusStateReader::new(state_reader, block_number);
+        let state_reader = PapyrusStateReader::new(state_reader, block_number);
+        let papyrus_reader = PapyrusReader::new(storage_tx, state_reader);
         Ok(CachedState::new(papyrus_reader))
     }
 
@@ -480,7 +481,7 @@ fn unexpected_callback_error(error: &PyErr) -> bool {
 
 /// Maps Sierra class hashes to their corresponding compiled class hash.
 pub fn into_py_contract_class_sizes_mapping(
-    state: &mut CachedState<PapyrusStateReader<'_>>,
+    state: &mut CachedState<PapyrusReader<'_>>,
     executed_class_hashes: HashSet<ClassHash>,
 ) -> NativeBlockifierResult<HashMap<PyFelt, PyContractClassSizes>> {
     let mut executed_compiled_class_sizes = HashMap::<PyFelt, PyContractClassSizes>::new();


### PR DESCRIPTION
Was previously added an left unused.
It is similar to the `PapyrusReader` but with added support for cairo1 contracts (and has a casm contract reader).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/603)
<!-- Reviewable:end -->
