### PR TITLE
Limit recursion depth for entrypoint calls

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,14 @@
 [build]
 # Configuration for these lints should be placed in `.clippy.toml` at the crate root.
-rustflags = ["-Dwarnings", "-Dfuture-incompatible", "-Dnonstandard-style", "-Drust-2018-idioms", "-Dunused"]
+rustflags = [
+    "-Dwarnings",
+    "-Dfuture-incompatible",
+    "-Dnonstandard-style",
+    "-Drust-2018-idioms",
+    "-Dunused",
+]
+
+[env]
+# Increase Rust stack size.
+# This should be large enough for `MAX_ENTRY_POINT_RECURSION_DEPTH` recursive entry point calls.
+RUST_MIN_STACK = "4194304" #  4 MiB

--- a/crates/blockifier/src/abi/constants.rs
+++ b/crates/blockifier/src/abi/constants.rs
@@ -58,6 +58,10 @@ pub const SEND_MESSAGE_TO_L1_GAS_COST: u64 = 50 * STEP_GAS_COST;
 pub const STORAGE_READ_GAS_COST: u64 = 50 * STEP_GAS_COST;
 pub const STORAGE_WRITE_GAS_COST: u64 = 50 * STEP_GAS_COST;
 
+// Max number of recursions allows in an EntryPoint.
+// Compatible with CPython's max recursion depth.
+pub const MAX_ENTRY_POINT_RECURSION_DEPTH: usize = 100;
+
 // OS reserved contract addresses.
 
 // This contract stores the block number -> block hash mapping.

--- a/crates/blockifier/src/execution/errors.rs
+++ b/crates/blockifier/src/execution/errors.rs
@@ -137,4 +137,6 @@ pub enum EntryPointExecutionError {
         #[source]
         source: VirtualMachineExecutionError,
     },
+    #[error("Execution failed due to recursion depth exceeded.")]
+    RecursionDepthExceeded,
 }


### PR DESCRIPTION
Currently too many recursions hit stack-overflow panic, we don't want that.

Increasing the stack size to 72MB is required in order to have the same recursion depth as in CPython, 3000.
This is X36 times the 2MB default, is there a better way?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/612)
<!-- Reviewable:end -->
