### PR TITLE
Don't close executor inside finalize

### DIFF
--- a/crates/native_blockifier/src/py_transaction.rs
+++ b/crates/native_blockifier/src/py_transaction.rs
@@ -312,7 +312,6 @@ impl PyTransactionExecutor {
     pub fn finalize(&mut self) -> PyStateDiff {
         log::debug!("Finalizing execution...");
         let state_diff = self.executor().finalize();
-        self.close();
         log::debug!("Finalized execution.");
 
         state_diff


### PR DESCRIPTION
Move responsibility to caller.
Rationale: finalize isn't guaranteed to be run, which might leave dangling read transactions.

Python side: https://reviewable.io/reviews/starkware-industries/starkware/30472


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/630)
<!-- Reviewable:end -->
