### PR TITLE
Convert hints to string using ` serde_json::to_string ` (as opposed to ` to_string() `).

### DIFF
--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -217,21 +217,22 @@ impl TryFrom<CasmContractClass> for ContractClassV1 {
             .into_iter()
             .map(|x| MaybeRelocatable::from(Felt252::from(x.value)))
             .collect();
-        let hints: HashMap<usize, Vec<HintParams>> = class
-            .hints
-            .iter()
-            .map(|(i, hints)| (*i, hints.iter().map(hint_to_hint_params).collect()))
-            .collect();
+
+        let mut hints: HashMap<usize, Vec<HintParams>> = HashMap::new();
+        for (i, hint_list) in class.hints.iter() {
+            let hint_params: Result<Vec<HintParams>, ProgramError> =
+                hint_list.iter().map(hint_to_hint_params).collect();
+            hints.insert(*i, hint_params?);
+        }
 
         // Collect a sting to hint map so that the hint processor can fetch the correct [Hint]
         // for each instruction.
-        let string_to_hint: HashMap<String, Hint> = class
-            .hints
-            .into_iter()
-            .flat_map(|(_, hints)| {
-                hints.iter().map(|hint| (hint.to_string(), hint.clone())).collect::<Vec<_>>()
-            })
-            .collect();
+        let mut string_to_hint: HashMap<String, Hint> = HashMap::new();
+        for (_, hint_list) in class.hints.iter() {
+            for hint in hint_list.iter() {
+                string_to_hint.insert(serde_json::to_string(hint)?, hint.clone());
+            }
+        }
 
         // Initialize program with all builtins.
         let builtins = vec![
@@ -296,15 +297,15 @@ pub fn deserialize_program<'de, D: Deserializer<'de>>(
 // V1 utilities.
 
 // TODO(spapini): Share with cairo-lang-runner.
-fn hint_to_hint_params(hint: &cairo_lang_casm::hints::Hint) -> HintParams {
-    HintParams {
-        code: hint.to_string(),
+fn hint_to_hint_params(hint: &cairo_lang_casm::hints::Hint) -> Result<HintParams, ProgramError> {
+    Ok(HintParams {
+        code: serde_json::to_string(hint)?,
         accessible_scopes: vec![],
         flow_tracking_data: FlowTrackingData {
             ap_tracking: ApTracking::new(),
             reference_ids: HashMap::new(),
         },
-    }
+    })
 }
 
 fn convert_entry_points_v1(


### PR DESCRIPTION
(to handle the case of reaching `unreachable!("Deprecated hints do not have a pythonic version.")` when hitting `CoreHintBase::Deprecated`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/642)
<!-- Reviewable:end -->
