### PR TITLE
Add ` segment_arena_builtin ` to the program builtins.

### DIFF
--- a/crates/blockifier/src/execution/cairo1_execution.rs
+++ b/crates/blockifier/src/execution/cairo1_execution.rs
@@ -1,4 +1,5 @@
 use cairo_felt::Felt252;
+use cairo_vm::serde::deserialize_program::BuiltinName;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
 use cairo_vm::vm::runners::builtin_runner::SEGMENT_ARENA_BUILTIN_NAME;
@@ -107,8 +108,18 @@ pub fn initialize_execution_context<'a>(
     let trace_enabled = true;
     let mut vm = VirtualMachine::new(trace_enabled);
 
-    runner.initialize_builtins(&mut vm)?;
-    runner.initialize_segments(&mut vm, None);
+    // Initialize program with all builtins.
+    let program_builtins = [
+        BuiltinName::bitwise,
+        BuiltinName::ec_op,
+        BuiltinName::ecdsa,
+        BuiltinName::output,
+        BuiltinName::pedersen,
+        BuiltinName::poseidon,
+        BuiltinName::range_check,
+        BuiltinName::segment_arena,
+    ];
+    runner.initialize_function_runner_cairo_1(&mut vm, &program_builtins)?;
     let mut read_only_segments = ReadOnlySegments::default();
     let program_segment_size =
         prepare_builtin_costs(&mut vm, contract_class, &mut read_only_segments)?;

--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -7,7 +7,7 @@ use cairo_lang_casm;
 use cairo_lang_casm::hints::Hint;
 use cairo_lang_starknet::casm_contract_class::{CasmContractClass, CasmContractEntryPoint};
 use cairo_vm::serde::deserialize_program::{
-    ApTracking, BuiltinName, FlowTrackingData, HintParams, ReferenceManager,
+    ApTracking, FlowTrackingData, HintParams, ReferenceManager,
 };
 use cairo_vm::types::errors::program_errors::ProgramError;
 use cairo_vm::types::program::Program;
@@ -234,16 +234,7 @@ impl TryFrom<CasmContractClass> for ContractClassV1 {
             }
         }
 
-        // Initialize program with all builtins.
-        let builtins = vec![
-            BuiltinName::output,
-            BuiltinName::pedersen,
-            BuiltinName::range_check,
-            BuiltinName::ecdsa,
-            BuiltinName::bitwise,
-            BuiltinName::ec_op,
-            BuiltinName::poseidon,
-        ];
+        let builtins = vec![]; // The builtins are initialize later.
         let main = Some(0);
         let reference_manager = ReferenceManager { references: Vec::new() };
         let identifiers = HashMap::new();

--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use cairo_vm::serde::deserialize_program::BuiltinName;
 use num_bigint::BigInt;
 use pretty_assertions::assert_eq;
 use starknet_api::core::{EntryPointSelector, PatriciaKey};
@@ -493,7 +494,14 @@ fn test_cairo1_entry_point_segment_arena() {
         ..trivial_external_entry_point()
     };
 
-    entry_point_call.execute_directly(&mut state).unwrap();
+    assert!(
+        entry_point_call
+            .execute_directly(&mut state)
+            .unwrap()
+            .vm_resources
+            .builtin_instance_counter
+            .contains_key(BuiltinName::segment_arena.name())
+    );
 }
 
 #[test]

--- a/crates/blockifier/src/transaction/transaction_utils.rs
+++ b/crates/blockifier/src/transaction/transaction_utils.rs
@@ -65,6 +65,7 @@ pub fn calculate_tx_resources<S: StateReader>(
     let mut total_vm_usage = total_vm_usage.filter_unused_builtins();
     // "segment_arena" built-in is not a SHARP built-in - i.e., it is not part of any proof layout.
     // Each instance requires approximately 10 steps in the OS.
+    // TODO(Noa, 01/07/23): Verify the removal of the segmen_arena builtin.
     let n_steps = total_vm_usage.n_steps
         + 10 * total_vm_usage
             .builtin_instance_counter


### PR DESCRIPTION
Use `initialize_function_runner_cairo_1` (which uses `initialize_all_builtins`. It is based on [CairoFunctionRunner](https://github.com/starkware-industries/starkware/blob/2753bc84eb0b98a31f9f27d73d33fc3116c0185f/src/starkware/cairo/common/cairo_function_runner.py#L31)).
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/652)
<!-- Reviewable:end -->
