### PR TITLE
Refactor: Add `TransactionalState` constructor

### DIFF
--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -16,19 +16,6 @@ use crate::utils::subtract_mappings;
 mod test;
 
 pub type ContractClassMapping = HashMap<ClassHash, ContractClass>;
-pub type TransactionalState<'a, S> = CachedState<MutRefState<'a, CachedState<S>>>;
-
-/// Holds uncommitted changes induced on StarkNet contracts.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct CommitmentStateDiff {
-    // Contract instance attributes (per address).
-    pub address_to_class_hash: IndexMap<ContractAddress, ClassHash>,
-    pub address_to_nonce: IndexMap<ContractAddress, Nonce>,
-    pub storage_updates: IndexMap<ContractAddress, IndexMap<StorageKey, StarkFelt>>,
-
-    // Global attributes.
-    pub class_hash_to_compiled_class_hash: IndexMap<ClassHash, CompiledClassHash>,
-}
 
 /// Caches read and write requests.
 ///
@@ -45,6 +32,13 @@ pub struct CachedState<S: StateReader> {
 impl<S: StateReader> CachedState<S> {
     pub fn new(state: S) -> Self {
         Self { state, cache: StateCache::default(), class_hash_to_class: HashMap::default() }
+    }
+
+    /// Creates a transactional instance from the given cached state.
+    /// It allows performing buffered modifying actions on the given state, which
+    /// will either all happen (will be committed) or none of them (will be discarded).
+    pub fn create_transactional(state: &mut CachedState<S>) -> TransactionalState<'_, S> {
+        CachedState::new(MutRefState::new(state))
     }
 
     /// Returns the number of storage changes done through this state.
@@ -426,6 +420,8 @@ impl<'a, S: State + ?Sized> State for MutRefState<'a, S> {
     }
 }
 
+pub type TransactionalState<'a, S> = CachedState<MutRefState<'a, CachedState<S>>>;
+
 /// Adds the ability to perform a transactional execution.
 impl<'a, S: StateReader> TransactionalState<'a, S> {
     /// Commits changes in the child (wrapping) state to its parent.
@@ -442,4 +438,16 @@ impl<'a, S: StateReader> TransactionalState<'a, S> {
 
     /// Drops `self`.
     pub fn abort(self) {}
+}
+
+/// Holds uncommitted changes induced on StarkNet contracts.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CommitmentStateDiff {
+    // Contract instance attributes (per address).
+    pub address_to_class_hash: IndexMap<ContractAddress, ClassHash>,
+    pub address_to_nonce: IndexMap<ContractAddress, Nonce>,
+    pub storage_updates: IndexMap<ContractAddress, IndexMap<StorageKey, StarkFelt>>,
+
+    // Global attributes.
+    pub class_hash_to_compiled_class_hash: IndexMap<ClassHash, CompiledClassHash>,
 }

--- a/crates/blockifier/src/transaction/transactions.rs
+++ b/crates/blockifier/src/transaction/transactions.rs
@@ -13,7 +13,7 @@ use crate::execution::entry_point::{
     ExecutionResources,
 };
 use crate::execution::execution_utils::execute_deployment;
-use crate::state::cached_state::{CachedState, MutRefState, TransactionalState};
+use crate::state::cached_state::{CachedState, TransactionalState};
 use crate::state::errors::StateError;
 use crate::state::state_api::{State, StateReader};
 use crate::transaction::constants;
@@ -36,7 +36,7 @@ pub trait ExecutableTransaction<S: StateReader>: Sized {
         block_context: &BlockContext,
     ) -> TransactionExecutionResult<TransactionExecutionInfo> {
         log::debug!("Executing Transaction...");
-        let mut transactional_state = CachedState::new(MutRefState::new(state));
+        let mut transactional_state = CachedState::create_transactional(state);
         let execution_result = self.execute_raw(&mut transactional_state, block_context);
 
         match execution_result {

--- a/crates/native_blockifier/src/py_transaction.rs
+++ b/crates/native_blockifier/src/py_transaction.rs
@@ -6,7 +6,7 @@ use blockifier::abi::constants::L1_HANDLER_VERSION;
 use blockifier::block_context::BlockContext;
 use blockifier::block_execution::pre_process_block;
 use blockifier::execution::contract_class::{ContractClass, ContractClassV0, ContractClassV1};
-use blockifier::state::cached_state::{CachedState, MutRefState};
+use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::{State, StateReader};
 use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::objects::AccountTransactionContext;
@@ -385,7 +385,7 @@ impl PyTransactionExecutorInner {
 
         let mut executed_class_hashes = HashSet::<ClassHash>::new();
         self.with_mut(|executor| {
-            let mut transactional_state = CachedState::new(MutRefState::new(executor.state));
+            let mut transactional_state = CachedState::create_transactional(executor.state);
             let tx_execution_result = tx
                 .execute_raw(&mut transactional_state, executor.block_context)
                 .map_err(NativeBlockifierError::from);


### PR DESCRIPTION
* Constructor will be easier to work with in the upcoming global contract cache feature.
* Reorder: CommitmentStateDiff moved down (importance).
* Moved `TransactionalState` closer to its `impl` (it is a typedef but we treat it like a struct).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/653)
<!-- Reviewable:end -->
