### PR TITLE
Small refactor default constructors

### DIFF
--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -95,7 +95,7 @@ fn cast_between_storage_mapping_types() {
 
 #[test]
 fn get_uninitialized_value() {
-    let mut state = CachedState::new(DictStateReader::default());
+    let mut state: CachedState<DictStateReader> = CachedState::default();
     let contract_address = ContractAddress(patricia_key!("0x1"));
 
     assert_eq!(state.get_nonce_at(contract_address).unwrap(), Nonce::default());
@@ -153,7 +153,7 @@ fn get_contract_class() {
 
 #[test]
 fn get_uninitialized_class_hash_value() {
-    let mut state = CachedState::new(DictStateReader::default());
+    let mut state: CachedState<DictStateReader> = CachedState::default();
     let valid_contract_address = ContractAddress(patricia_key!("0x1"));
 
     assert_eq!(state.get_class_hash_at(valid_contract_address).unwrap(), ClassHash::default());
@@ -162,7 +162,7 @@ fn get_uninitialized_class_hash_value() {
 #[test]
 fn set_and_get_contract_hash() {
     let contract_address = ContractAddress(patricia_key!("0x1"));
-    let mut state = CachedState::new(DictStateReader::default());
+    let mut state: CachedState<DictStateReader> = CachedState::default();
     let class_hash = ClassHash(stark_felt!("0x10"));
 
     assert!(state.set_class_hash_at(contract_address, class_hash).is_ok());
@@ -171,7 +171,7 @@ fn set_and_get_contract_hash() {
 
 #[test]
 fn cannot_set_class_hash_to_uninitialized_contract() {
-    let mut state = CachedState::new(DictStateReader::default());
+    let mut state: CachedState<DictStateReader> = CachedState::default();
 
     let uninitialized_contract_address = ContractAddress::default();
     let class_hash = ClassHash(stark_felt!("0x100"));
@@ -262,7 +262,7 @@ fn count_actual_state_changes() {
     let key = StorageKey(patricia_key!("0x10"));
     let storage_val: StarkFelt = stark_felt!("0x1");
 
-    let mut state = CachedState::new(DictStateReader::default());
+    let mut state: CachedState<DictStateReader> = CachedState::default();
     state.set_class_hash_at(contract_address, class_hash).unwrap();
     state.set_storage_at(contract_address, key, storage_val);
 

--- a/crates/native_blockifier/src/py_transaction.rs
+++ b/crates/native_blockifier/src/py_transaction.rs
@@ -312,10 +312,10 @@ impl PyTransactionExecutor {
 
     pub fn finalize(&mut self) -> PyStateDiff {
         log::debug!("Finalizing execution...");
-        let state_diff = self.executor().finalize();
+        let finalized_state = self.executor().finalize();
         log::debug!("Finalized execution.");
 
-        state_diff
+        finalized_state
     }
 
     pub fn close(&mut self) {


### PR DESCRIPTION
Use default constructor and rename variables, as a setup for the more general construction and finalization when using global cache.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/654)
<!-- Reviewable:end -->
