### PR TITLE
Cleanup in testing and fmt

### DIFF
--- a/crates/blockifier/src/lib.rs
+++ b/crates/blockifier/src/lib.rs
@@ -4,6 +4,7 @@ pub mod block_execution;
 pub mod execution;
 pub mod fee;
 pub mod state;
+#[cfg(any(feature = "testing", test))]
 pub mod test_utils;
 pub mod transaction;
 pub mod utils;

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -21,7 +21,7 @@ pub type ContractClassMapping = HashMap<ClassHash, ContractClass>;
 ///
 /// Writer functionality is builtin, whereas Reader functionality is injected through
 /// initialization.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct CachedState<S: StateReader> {
     pub state: S,
     // Invariant: read/write access is managed by CachedState.
@@ -248,6 +248,17 @@ impl<S: StateReader> State for CachedState<S> {
             storage_updates: StorageDiff::from(StorageView(storage_diffs)),
             class_hash_to_compiled_class_hash: IndexMap::from_iter(declared_classes),
             address_to_nonce: IndexMap::from_iter(nonces),
+        }
+    }
+}
+
+#[cfg(any(feature = "testing", test))]
+impl Default for CachedState<crate::test_utils::DictStateReader> {
+    fn default() -> Self {
+        Self {
+            state: Default::default(),
+            cache: Default::default(),
+            class_hash_to_class: Default::default(),
         }
     }
 }

--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod errors;
 pub mod papyrus_state;
 pub mod py_state_diff;
+#[cfg(any(feature = "testing", test))]
 pub mod py_test_utils;
 pub mod py_transaction;
 pub mod py_transaction_execution_info;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 edition = "2021"
-newline_style = "unix"
+newline_style = "Unix"
 use_field_init_shorthand = true
 use_small_heuristics = "Max"
 use_try_shorthand = true


### PR DESCRIPTION
- `CachedState` doesn't impl Default really (since `S` isn't doesn't necessarily), this only worked probably due to it working with the testing `DictStateReader`, which is its only user, which might have tricked the compiler. This change makes everything explicit.
- Hide test_utils behind `testing` feature.
- Unrelated: apparent typo in rustfmt (maybe due to breaking change on rustfmt?)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/671)
<!-- Reviewable:end -->
