### PR TITLE
Use the remaining gas in deploy syscall (as the initial gas of the constructor entry point.

### DIFF
--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -227,7 +227,6 @@ pub fn deploy(
         deployer_address_for_calculation,
     )?;
 
-    let initial_gas = constants::INITIAL_GAS_COST.into();
     let ctor_context = ConstructorContext {
         class_hash: request.class_hash,
         code_address: Some(deployed_contract_address),
@@ -240,7 +239,7 @@ pub fn deploy(
         syscall_handler.context,
         ctor_context,
         request.constructor_calldata,
-        initial_gas,
+        remaining_gas.clone(),
     )?;
 
     let constructor_retdata =


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/673)
<!-- Reviewable:end -->
