### PR TITLE
Make recursion depth configurable

### DIFF
--- a/crates/blockifier/src/abi/constants.rs
+++ b/crates/blockifier/src/abi/constants.rs
@@ -58,10 +58,6 @@ pub const SEND_MESSAGE_TO_L1_GAS_COST: u64 = 50 * STEP_GAS_COST;
 pub const STORAGE_READ_GAS_COST: u64 = 50 * STEP_GAS_COST;
 pub const STORAGE_WRITE_GAS_COST: u64 = 50 * STEP_GAS_COST;
 
-// Max number of recursions allows in an EntryPoint.
-// Compatible with CPython's max recursion depth.
-pub const MAX_ENTRY_POINT_RECURSION_DEPTH: usize = 50;
-
 // OS reserved contract addresses.
 
 // This contract stores the block number -> block hash mapping.

--- a/crates/blockifier/src/block_context.rs
+++ b/crates/blockifier/src/block_context.rs
@@ -18,4 +18,5 @@ pub struct BlockContext {
     // Limits.
     pub invoke_tx_max_n_steps: u32,
     pub validate_max_n_steps: u32,
+    pub max_recursion_depth: usize,
 }

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -356,6 +356,7 @@ impl BlockContext {
             gas_price: DEFAULT_GAS_PRICE,
             invoke_tx_max_n_steps: 1_000_000,
             validate_max_n_steps: 1_000_000,
+            max_recursion_depth: 50,
         }
     }
 


### PR DESCRIPTION
- rename `recursion_depth`->`current_recursion_depth` for clarity.
- Constant for max depth (and stale comment) replaced with value in `BlockContext`.
- Refactor: hoist up papyrus_storage, it should be first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/687)
<!-- Reviewable:end -->
