### PR TITLE
Extract `ChainId` directly from python

### DIFF
--- a/crates/native_blockifier/src/py_transaction_executor.rs
+++ b/crates/native_blockifier/src/py_transaction_executor.rs
@@ -8,20 +8,19 @@ use blockifier::state::state_api::{State, StateReader};
 use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResources;
-use num_bigint::BigUint;
 use ouroboros;
 use papyrus_storage::db::RO;
 use papyrus_storage::state::StateStorageReader;
 use pyo3::prelude::*;
 use starknet_api::block::{BlockHash, BlockNumber, BlockTimestamp};
-use starknet_api::core::{ClassHash, ContractAddress};
+use starknet_api::core::{ChainId, ClassHash, ContractAddress};
 
 use crate::errors::{NativeBlockifierError, NativeBlockifierResult};
 use crate::papyrus_state::{PapyrusReader, PapyrusStateReader};
 use crate::py_state_diff::PyStateDiff;
 use crate::py_transaction::py_tx;
 use crate::py_transaction_execution_info::{PyTransactionExecutionInfo, PyVmExecutionResources};
-use crate::py_utils::{py_attr, py_enum_name, to_chain_id_enum, PyFelt};
+use crate::py_utils::{int_to_chain_id, py_attr, py_enum_name, PyFelt};
 use crate::storage::Storage;
 
 /// Wraps the transaction executor in an optional, to allow an explicit deallocation of it.
@@ -254,7 +253,8 @@ impl FromPyObject<'_> for PyGeneralConfig {
 
 #[derive(FromPyObject)]
 pub struct PyOsConfig {
-    pub chain_id: BigUint,
+    #[pyo3(from_py_with = "int_to_chain_id")]
+    pub chain_id: ChainId,
     pub fee_token_address: PyFelt,
 }
 
@@ -266,7 +266,7 @@ pub fn py_block_context(
     let starknet_os_config = general_config.starknet_os_config;
     let block_number = BlockNumber(py_attr(block_info, "block_number")?);
     let block_context = BlockContext {
-        chain_id: to_chain_id_enum(starknet_os_config.chain_id)?,
+        chain_id: starknet_os_config.chain_id,
         block_number,
         block_timestamp: BlockTimestamp(py_attr(block_info, "block_timestamp")?),
         sequencer_address: ContractAddress::try_from(general_config.sequencer_address.0)?,

--- a/crates/native_blockifier/src/py_utils.rs
+++ b/crates/native_blockifier/src/py_utils.rs
@@ -11,7 +11,7 @@ use starknet_api::transaction::EthAddress;
 use crate::errors::NativeBlockifierResult;
 
 #[derive(Eq, FromPyObject, Hash, PartialEq, Clone, Copy)]
-pub struct PyFelt(#[pyo3(from_py_with = "pyint_to_stark_felt")] pub StarkFelt);
+pub struct PyFelt(#[pyo3(from_py_with = "int_to_stark_felt")] pub StarkFelt);
 
 impl IntoPy<PyObject> for PyFelt {
     fn into_py(self, py: Python<'_>) -> PyObject {
@@ -59,7 +59,7 @@ impl From<CompiledClassHash> for PyFelt {
     }
 }
 
-fn pyint_to_stark_felt(int: &PyAny) -> PyResult<StarkFelt> {
+fn int_to_stark_felt(int: &PyAny) -> PyResult<StarkFelt> {
     let biguint: BigUint = int.extract()?;
     biguint_to_felt(biguint).map_err(|e| PyValueError::new_err(e.to_string()))
 }
@@ -77,8 +77,9 @@ where
     values.into_iter().map(converter).collect()
 }
 
-pub fn to_chain_id_enum(value: BigUint) -> NativeBlockifierResult<ChainId> {
-    Ok(ChainId(String::from_utf8_lossy(&value.to_bytes_be()).to_string()))
+pub fn int_to_chain_id(int: &PyAny) -> PyResult<ChainId> {
+    let biguint: BigUint = int.extract()?;
+    Ok(ChainId(String::from_utf8_lossy(&biguint.to_bytes_be()).into()))
 }
 
 // TODO(Dori, 1/4/2023): If and when supported in the Python build environment, use #[cfg(test)].


### PR DESCRIPTION
Upcoming caching changes will also use `ChainId`, and this will prevent future duplication of logic.

Python: https://reviewable.io/reviews/starkware-industries/starkware/30768

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/728)
<!-- Reviewable:end -->
