### PR TITLE
Storage cleanup

### DIFF
--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -16,7 +16,7 @@ use py_transaction_execution_info::{
 };
 use py_transaction_executor::PyTransactionExecutor;
 use pyo3::prelude::*;
-use storage::Storage;
+use storage::{Storage, StorageConfig};
 
 use crate::py_state_diff::PyStateDiff;
 use crate::py_utils::raise_error_for_testing;
@@ -35,6 +35,7 @@ fn native_blockifier(py: Python<'_>, py_module: &PyModule) -> PyResult<()> {
     py_module.add_class::<PyTransactionExecutor>()?;
     py_module.add_class::<PyVmExecutionResources>()?;
     py_module.add_class::<Storage>()?;
+    py_module.add_class::<StorageConfig>()?;
     add_py_exceptions(py, py_module)?;
 
     // TODO(Dori, 1/4/2023): If and when supported in the Python build environment, gate this code

--- a/crates/native_blockifier/src/storage.rs
+++ b/crates/native_blockifier/src/storage.rs
@@ -33,18 +33,14 @@ pub struct Storage {
 #[pymethods]
 impl Storage {
     #[new]
-    #[args(path_prefix, chain_id, max_size)]
-    pub fn new(
-        path_prefix: PathBuf,
-        #[pyo3(from_py_with = "int_to_chain_id")] chain_id: ChainId,
-        max_size: usize,
-    ) -> NativeBlockifierResult<Storage> {
+    #[args(config)]
+    pub fn new(config: StorageConfig) -> NativeBlockifierResult<Storage> {
         log::debug!("Initializing Blockifier storage...");
         let db_config = papyrus_storage::db::DbConfig {
-            path_prefix,
-            chain_id,
+            path_prefix: config.path,
+            chain_id: config.chain_id,
             min_size: 1 << 20, // 1MB.
-            max_size,
+            max_size: config.max_size,
             growth_step: 1 << 26, // 64MB.
         };
         let (reader, writer) = papyrus_storage::open_storage(db_config)?;
@@ -223,6 +219,21 @@ impl Storage {
         append_txn.commit()?;
         Ok(())
     }
+
+    #[staticmethod]
+    #[args(path)]
+    pub fn new_for_testing(path: PathBuf) -> Storage {
+        let db_config = papyrus_storage::db::DbConfig {
+            path_prefix: path,
+            chain_id: ChainId("".to_string()),
+            min_size: 1 << 20,    // 1MB
+            max_size: 1 << 35,    // 32GB
+            growth_step: 1 << 26, // 64MB
+        };
+        let (reader, writer) = papyrus_storage::open_storage(db_config).unwrap();
+
+        Storage { reader: Some(reader), writer: Some(writer) }
+    }
 }
 
 // Internal getters, Python should not have access to them, and only use the public API.
@@ -232,5 +243,25 @@ impl Storage {
     }
     pub fn writer(&mut self) -> &mut papyrus_storage::StorageWriter {
         self.writer.as_mut().expect("Storage should be initialized.")
+    }
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub struct StorageConfig {
+    path: PathBuf,
+    chain_id: ChainId,
+    max_size: usize,
+}
+
+#[pymethods]
+impl StorageConfig {
+    #[new]
+    pub fn new(
+        path: PathBuf,
+        #[pyo3(from_py_with = "int_to_chain_id")] chain_id: ChainId,
+        max_size: usize,
+    ) -> Self {
+        Self { path, chain_id, max_size }
     }
 }


### PR DESCRIPTION
- initialize storage using a `StorageConfig` motivation is two-fold: first, `Storage` will soon be internalized into a more general struct (BlockExecutor), so when we initialize it we want to wrap all the storage-relevant arguments up nicely to differentiate from the other arguments it is initialized with; second, there will soon be an additional argument here (chain_id) and three arguments is starting to get verbose.
- Added a testing initializer for Python usage (currently we're doing this in Python, which is wrong cause this is an implementation detail)

python: https://reviewable.io/reviews/starkware-industries/starkware/30775

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/731)
<!-- Reviewable:end -->
