### PR TITLE
Remove ouroboros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,12 +38,6 @@ checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "aliasable"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "anyhow"
@@ -1912,7 +1900,6 @@ dependencies = [
  "indexmap",
  "log",
  "num-bigint",
- "ouroboros",
  "papyrus_storage",
  "pyo3",
  "pyo3-log",
@@ -2092,29 +2079,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "ouroboros"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
-dependencies = [
- "aliasable",
- "ouroboros_macro",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
-dependencies = [
- "Inflector",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ log = "0.4"
 num-bigint = "0.4"
 num-integer = "0.1.45"
 num-traits = "0.2"
-ouroboros = "0.15.6"
 rstest = "0.17.0"
 papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "90ad4bc" }
 phf = { version = "0.11", features = ["macros"] }

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -22,7 +22,6 @@ cairo-vm.workspace = true
 indexmap.workspace = true
 log.workspace = true
 num-bigint.workspace = true
-ouroboros.workspace = true
 papyrus_storage = { workspace = true, features = ["testing"] }
 pyo3 = { version = "0.17.3", features = [
     "extension-module",

--- a/crates/native_blockifier/src/papyrus_state_test.rs
+++ b/crates/native_blockifier/src/papyrus_state_test.rs
@@ -8,7 +8,7 @@ use blockifier::test_utils::{
     TEST_CONTRACT_ADDRESS, TEST_CONTRACT_CAIRO0_PATH,
 };
 use indexmap::IndexMap;
-use papyrus_storage::state::{StateStorageReader, StateStorageWriter};
+use papyrus_storage::state::StateStorageWriter;
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{ClassHash, ContractAddress, PatriciaKey};
 use starknet_api::hash::{StarkFelt, StarkHash};
@@ -16,7 +16,7 @@ use starknet_api::state::{StateDiff, StorageKey};
 use starknet_api::transaction::Calldata;
 use starknet_api::{calldata, patricia_key, stark_felt};
 
-use crate::papyrus_state::{PapyrusReader, PapyrusStateReader};
+use crate::papyrus_state::PapyrusReader;
 
 #[test]
 fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
@@ -37,13 +37,9 @@ fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
         .append_state_diff(BlockNumber::default(), state_diff, deprecated_declared_classes)?
         .commit()?;
 
-    let storage_tx = storage_reader.begin_ro_txn()?;
-    let state_reader = storage_tx.get_state_reader()?;
-
     // BlockNumber is 1 due to the initialization step above.
     let block_number = BlockNumber(1);
-    let state_reader = PapyrusStateReader::new(state_reader, block_number);
-    let papyrus_reader = PapyrusReader::new(&storage_tx, state_reader);
+    let papyrus_reader = PapyrusReader::new(storage_reader, block_number);
     let mut state = CachedState::new(papyrus_reader);
 
     // Call entrypoint that want to write to storage, which updates the cached state's write cache.

--- a/crates/native_blockifier/src/py_transaction_executor.rs
+++ b/crates/native_blockifier/src/py_transaction_executor.rs
@@ -8,15 +8,12 @@ use blockifier::state::state_api::{State, StateReader};
 use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResources;
-use ouroboros;
-use papyrus_storage::db::RO;
-use papyrus_storage::state::StateStorageReader;
 use pyo3::prelude::*;
 use starknet_api::block::{BlockHash, BlockNumber, BlockTimestamp};
 use starknet_api::core::{ChainId, ClassHash, ContractAddress};
 
 use crate::errors::{NativeBlockifierError, NativeBlockifierResult};
-use crate::papyrus_state::{PapyrusReader, PapyrusStateReader};
+use crate::papyrus_state::PapyrusReader;
 use crate::py_state_diff::PyStateDiff;
 use crate::py_transaction::py_tx;
 use crate::py_transaction_execution_info::{PyTransactionExecutionInfo, PyVmExecutionResources};
@@ -41,7 +38,7 @@ impl PyTransactionExecutor {
         max_recursion_depth: usize,
     ) -> NativeBlockifierResult<Self> {
         log::debug!("Initializing Transaction Executor...");
-        let executor = TransactionExecutor::create(
+        let executor = TransactionExecutor::new(
             papyrus_storage,
             general_config,
             block_info,
@@ -92,7 +89,6 @@ impl PyTransactionExecutor {
 
 // To access a field you must use `self.borrow_{field_name}()`.
 // Alternately, you can borrow the whole object using `self.with[_mut]()`.
-#[ouroboros::self_referencing]
 pub struct TransactionExecutor {
     pub block_context: BlockContext,
 
@@ -101,17 +97,11 @@ pub struct TransactionExecutor {
 
     // State-related fields.
     // Storage reader and transaction are kept merely for lifetime parameter referencing.
-    pub storage_reader: papyrus_storage::StorageReader,
-    #[borrows(storage_reader)]
-    #[covariant]
-    pub storage_tx: papyrus_storage::StorageTxn<'this, RO>,
-    #[borrows(storage_tx)]
-    #[covariant]
-    pub state: CachedState<PapyrusReader<'this>>,
+    pub state: CachedState<PapyrusReader>,
 }
 
 impl TransactionExecutor {
-    pub fn create(
+    pub fn new(
         papyrus_storage: &Storage,
         general_config: PyGeneralConfig,
         block_info: &PyAny,
@@ -121,7 +111,9 @@ impl TransactionExecutor {
         let reader = papyrus_storage.reader().clone();
 
         let block_context = py_block_context(general_config, block_info, max_recursion_depth)?;
-        build_tx_executor(block_context, reader)
+        let state = CachedState::new(PapyrusReader::new(reader, block_context.block_number));
+        let executed_class_hashes = HashSet::<ClassHash>::new();
+        Ok(Self { block_context, executed_class_hashes, state })
     }
 
     /// Executes the given transaction on the state maintained by the executor.
@@ -138,72 +130,68 @@ impl TransactionExecutor {
         let tx: Transaction = py_tx(&tx_type, tx, raw_contract_class)?;
 
         let mut tx_executed_class_hashes = HashSet::<ClassHash>::new();
-        self.with_mut(|executor| {
-            let mut transactional_state = CachedState::create_transactional(executor.state);
-            let tx_execution_result = tx
-                .execute_raw(&mut transactional_state, executor.block_context)
-                .map_err(NativeBlockifierError::from);
-            let (py_tx_execution_info, py_casm_hash_calculation_resources) =
-                match tx_execution_result {
-                    Ok(tx_execution_info) => {
-                        tx_executed_class_hashes = tx_execution_info.get_executed_class_hashes();
+        let mut transactional_state = CachedState::create_transactional(&mut self.state);
+        let tx_execution_result = tx
+            .execute_raw(&mut transactional_state, &self.block_context)
+            .map_err(NativeBlockifierError::from);
+        let (py_tx_execution_info, py_casm_hash_calculation_resources) = match tx_execution_result {
+            Ok(tx_execution_info) => {
+                tx_executed_class_hashes.extend(tx_execution_info.get_executed_class_hashes());
 
-                        let py_tx_execution_info = Python::with_gil(|py| {
-                            // Allocate this instance on the Python heap.
-                            // This is necessary in order to pass a reference to it to the callback
-                            // (otherwise, if it were allocated on Rust's heap/stack, giving Python
-                            // a reference to the objects will not
-                            // work).
-                            Py::new(py, PyTransactionExecutionInfo::from(tx_execution_info))
-                                .expect("Should be able to allocate on Python heap")
-                        });
+                let py_tx_execution_info = Python::with_gil(|py| {
+                    // Allocate this instance on the Python heap.
+                    // This is necessary in order to pass a reference to it to the callback
+                    // (otherwise, if it were allocated on Rust's heap/stack, giving Python
+                    // a reference to the objects will not
+                    // work).
+                    Py::new(py, PyTransactionExecutionInfo::from(tx_execution_info))
+                        .expect("Should be able to allocate on Python heap")
+                });
 
-                        let py_casm_hash_calculation_resources =
-                            get_casm_hash_calculation_resources(
-                                &mut transactional_state,
-                                executor.executed_class_hashes,
-                                &tx_executed_class_hashes,
-                            )?;
+                let py_casm_hash_calculation_resources = get_casm_hash_calculation_resources(
+                    &mut transactional_state,
+                    &self.executed_class_hashes,
+                    &tx_executed_class_hashes,
+                )?;
 
-                        (py_tx_execution_info, py_casm_hash_calculation_resources)
-                    }
-                    Err(error) => {
-                        transactional_state.abort();
-                        return Err(error);
-                    }
-                };
-
-            let has_enough_room_for_tx = Python::with_gil(|py| {
-                // Can be done because `py_tx_execution_info` is a `Py<PyTransactionExecutionInfo>`,
-                // hence is allocated on the Python heap.
-                let args =
-                    (py_tx_execution_info.borrow(py), py_casm_hash_calculation_resources.clone());
-                enough_room_for_tx.call1(args) // Callback to Python code.
-            });
-
-            match has_enough_room_for_tx {
-                Ok(_) => {
-                    transactional_state.commit();
-                    executor.executed_class_hashes.extend(&tx_executed_class_hashes);
-                    Ok((py_tx_execution_info, py_casm_hash_calculation_resources))
-                }
-                // Unexpected error, abort and let caller know.
-                Err(error) if unexpected_callback_error(&error) => {
-                    transactional_state.abort();
-                    Err(error.into())
-                }
-                // Not enough room in batch, abort and let caller verify on its own.
-                Err(_not_enough_weight_error) => {
-                    transactional_state.abort();
-                    Ok((py_tx_execution_info, py_casm_hash_calculation_resources))
-                }
+                (py_tx_execution_info, py_casm_hash_calculation_resources)
             }
-        })
+            Err(error) => {
+                transactional_state.abort();
+                return Err(error);
+            }
+        };
+
+        let has_enough_room_for_tx = Python::with_gil(|py| {
+            // Can be done because `py_tx_execution_info` is a `Py<PyTransactionExecutionInfo>`,
+            // hence is allocated on the Python heap.
+            let args =
+                (py_tx_execution_info.borrow(py), py_casm_hash_calculation_resources.clone());
+            enough_room_for_tx.call1(args) // Callback to Python code.
+        });
+
+        match has_enough_room_for_tx {
+            Ok(_) => {
+                transactional_state.commit();
+                self.executed_class_hashes.extend(&tx_executed_class_hashes);
+                Ok((py_tx_execution_info, py_casm_hash_calculation_resources))
+            }
+            // Unexpected error, abort and let caller know.
+            Err(error) if unexpected_callback_error(&error) => {
+                transactional_state.abort();
+                Err(error.into())
+            }
+            // Not enough room in batch, abort and let caller verify on its own.
+            Err(_not_enough_weight_error) => {
+                transactional_state.abort();
+                Ok((py_tx_execution_info, py_casm_hash_calculation_resources))
+            }
+        }
     }
 
     /// Returns the state diff resulting in executing transactions.
     pub fn finalize(&mut self) -> PyStateDiff {
-        PyStateDiff::from(self.borrow_state().to_state_diff())
+        PyStateDiff::from(self.state.to_state_diff())
     }
 
     // Block pre-processing; see `block_execution::pre_process_block` documentation.
@@ -214,9 +202,7 @@ impl TransactionExecutor {
         let old_block_number_and_hash = old_block_number_and_hash
             .map(|(block_number, block_hash)| (BlockNumber(block_number), BlockHash(block_hash.0)));
 
-        self.with_mut(|executor| {
-            pre_process_block(executor.state, old_block_number_and_hash);
-        });
+        pre_process_block(&mut self.state, old_block_number_and_hash);
 
         Ok(())
     }
@@ -281,40 +267,6 @@ pub fn py_block_context(
     Ok(block_context)
 }
 
-pub fn build_tx_executor(
-    block_context: BlockContext,
-    storage_reader: papyrus_storage::StorageReader,
-) -> NativeBlockifierResult<TransactionExecutor> {
-    // The following callbacks are required to capture the local lifetime parameter.
-    fn storage_tx_builder(
-        storage_reader: &papyrus_storage::StorageReader,
-    ) -> NativeBlockifierResult<papyrus_storage::StorageTxn<'_, RO>> {
-        Ok(storage_reader.begin_ro_txn()?)
-    }
-
-    fn state_builder<'a>(
-        storage_tx: &'a papyrus_storage::StorageTxn<'a, RO>,
-        block_number: BlockNumber,
-    ) -> NativeBlockifierResult<CachedState<PapyrusReader<'a>>> {
-        let state_reader = storage_tx.get_state_reader()?;
-        let state_reader = PapyrusStateReader::new(state_reader, block_number);
-        let papyrus_reader = PapyrusReader::new(storage_tx, state_reader);
-        Ok(CachedState::new(papyrus_reader))
-    }
-
-    let executed_class_hashes = HashSet::<ClassHash>::new();
-    let block_number = block_context.block_number;
-    // The builder struct below is implicitly created by `ouroboros`.
-    let py_tx_executor_builder = TransactionExecutorTryBuilder {
-        block_context,
-        executed_class_hashes,
-        storage_reader,
-        storage_tx_builder,
-        state_builder: |storage_tx| state_builder(storage_tx, block_number),
-    };
-    py_tx_executor_builder.try_build()
-}
-
 fn unexpected_callback_error(error: &PyErr) -> bool {
     let error_string = error.to_string();
     !(error_string.contains("BatchFull") || error_string.contains("TransactionBiggerThanBatch"))
@@ -323,7 +275,7 @@ fn unexpected_callback_error(error: &PyErr) -> bool {
 /// Returns the estimated VM resources for Casm hash calculation (done by the OS), of the newly
 /// executed classes by the current transaction.
 pub fn get_casm_hash_calculation_resources(
-    state: &mut TransactionalState<'_, PapyrusReader<'_>>,
+    state: &mut TransactionalState<'_, PapyrusReader>,
     executed_class_hashes: &HashSet<ClassHash>,
     tx_executed_class_hashes: &HashSet<ClassHash>,
 ) -> NativeBlockifierResult<PyVmExecutionResources> {


### PR DESCRIPTION
Basically, saving an open `ro_tx` is unnecessary, opening a new ro transaction on demand is the right way to go.
If an open RO tx isn't being saved on the instance, no lifetime/ouroboros is necessary.

In more detail:
- PapyrusReader is simplified, generating the required transactions on demand.
- The changes in py_transaction_executor.py are basically removing ourobors, which amounts to removing its required fields and elaborate constructor methods (now using a reuglar consturctor) and replace its `with_X` accessors with regular accessors; note that the large diff in `execute` is only removing the `with_mut` closure and other `with_X` accessors, no other changes are made there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/757)
<!-- Reviewable:end -->
