### PR TITLE
Revert "Refactor `PapyrusReader` and `py_transaction_executor.py` to …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +44,12 @@ checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "allocator-api2"
@@ -1943,6 +1955,7 @@ dependencies = [
  "indexmap 1.9.3",
  "log",
  "num-bigint",
+ "ouroboros",
  "papyrus_storage",
  "pyo3",
  "pyo3-log",
@@ -2122,6 +2135,29 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
+dependencies = [
+ "Inflector",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ log = "0.4"
 num-bigint = "0.4"
 num-integer = "0.1.45"
 num-traits = "0.2"
+ouroboros = "0.15.6"
 rstest = "0.17.0"
 papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "42ebef8" }
 phf = { version = "0.11", features = ["macros"] }

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -22,6 +22,7 @@ cairo-vm.workspace = true
 indexmap.workspace = true
 log.workspace = true
 num-bigint.workspace = true
+ouroboros.workspace = true
 papyrus_storage = { workspace = true, features = ["testing"] }
 pyo3 = { version = "0.17.3", features = [
     "extension-module",

--- a/crates/native_blockifier/src/papyrus_state.rs
+++ b/crates/native_blockifier/src/papyrus_state.rs
@@ -1,10 +1,10 @@
 use blockifier::execution::contract_class::{ContractClass, ContractClassV0, ContractClassV1};
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::{StateReader, StateResult};
+use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use papyrus_storage::compiled_class::CasmStorageReader;
 use papyrus_storage::db::RO;
-use papyrus_storage::state::StateStorageReader;
-use papyrus_storage::StorageReader;
+use papyrus_storage::StorageResult;
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
@@ -14,46 +14,43 @@ use starknet_api::state::{StateNumber, StorageKey};
 #[path = "papyrus_state_test.rs"]
 mod test;
 
-type RawPapyrusReader<'env> = papyrus_storage::StorageTxn<'env, RO>;
+type RawPapyrusStateReader<'env> = papyrus_storage::state::StateReader<'env, RO>;
 
-pub struct PapyrusReader {
-    storage_reader: StorageReader,
-    latest_block: BlockNumber,
+pub struct PapyrusReader<'env> {
+    state: PapyrusStateReader<'env>,
+    contract_classes: PapyrusExecutableClassReader<'env>,
 }
 
-impl PapyrusReader {
-    pub fn new(storage_reader: StorageReader, latest_block: BlockNumber) -> Self {
-        Self { storage_reader, latest_block }
+impl<'env> PapyrusReader<'env> {
+    pub fn new(
+        storage_tx: &'env papyrus_storage::StorageTxn<'env, RO>,
+        state_reader: PapyrusStateReader<'env>,
+    ) -> Self {
+        let contract_classes = PapyrusExecutableClassReader::new(storage_tx);
+        Self { state: state_reader, contract_classes }
     }
 
-    fn reader(&self) -> StateResult<RawPapyrusReader<'_>> {
-        self.storage_reader
-            .begin_ro_txn()
-            .map_err(|error| StateError::StateReadError(error.to_string()))
+    pub fn state_reader(&mut self) -> &RawPapyrusStateReader<'env> {
+        &self.state.reader
     }
 }
 
 // Currently unused - will soon replace the same `impl` for `PapyrusStateReader`.
-impl StateReader for PapyrusReader {
+impl<'env> StateReader for PapyrusReader<'env> {
     fn get_storage_at(
         &mut self,
         contract_address: ContractAddress,
         key: StorageKey,
     ) -> StateResult<StarkFelt> {
-        let state_number = StateNumber(self.latest_block);
-        self.reader()?
-            .get_state_reader()
-            .and_then(|sr| sr.get_storage_at(state_number, &contract_address, &key))
-            .map_err(|error| StateError::StateReadError(error.to_string()))
+        let state_number = StateNumber(*self.state.latest_block());
+        self.state_reader()
+            .get_storage_at(state_number, &contract_address, &key)
+            .map_err(|err| StateError::StateReadError(err.to_string()))
     }
 
     fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
-        let state_number = StateNumber(self.latest_block);
-        match self
-            .reader()?
-            .get_state_reader()
-            .and_then(|sr| sr.get_nonce_at(state_number, &contract_address))
-        {
+        let state_number = StateNumber(*self.state.latest_block());
+        match self.state_reader().get_nonce_at(state_number, &contract_address) {
             Ok(Some(nonce)) => Ok(nonce),
             Ok(None) => Ok(Nonce::default()),
             Err(err) => Err(StateError::StateReadError(err.to_string())),
@@ -61,12 +58,8 @@ impl StateReader for PapyrusReader {
     }
 
     fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
-        let state_number = StateNumber(self.latest_block);
-        match self
-            .reader()?
-            .get_state_reader()
-            .and_then(|sr| sr.get_class_hash_at(state_number, &contract_address))
-        {
+        let state_number = StateNumber(*self.state.latest_block());
+        match self.state_reader().get_class_hash_at(state_number, &contract_address) {
             Ok(Some(class_hash)) => Ok(class_hash),
             Ok(None) => Ok(ClassHash::default()),
             Err(err) => Err(StateError::StateReadError(err.to_string())),
@@ -79,19 +72,18 @@ impl StateReader for PapyrusReader {
         &mut self,
         class_hash: &ClassHash,
     ) -> StateResult<ContractClass> {
-        let state_number = StateNumber(self.latest_block);
+        let state_number = StateNumber(*self.state.latest_block());
         let class_declaration_block_number = self
-            .reader()?
-            .get_state_reader()
-            .and_then(|sr| sr.get_class_definition_block_number(class_hash))
+            .state_reader()
+            .get_class_definition_block_number(class_hash)
             .map_err(|err| StateError::StateReadError(err.to_string()))?;
         let class_is_declared: bool = matches!(class_declaration_block_number,
                     Some(block_number) if block_number <= state_number.0);
 
         if class_is_declared {
             let casm_contract_class = self
-                .reader()?
-                .get_casm(class_hash)
+                .contract_classes
+                .get_casm(*class_hash)
                 .map_err(|err| StateError::StateReadError(err.to_string()))?
                 .expect(
                     "Should be able to fetch a Casm class if its definition exists, database is \
@@ -102,9 +94,8 @@ impl StateReader for PapyrusReader {
         }
 
         let v0_contract_class = self
-            .reader()?
-            .get_state_reader()
-            .and_then(|sr| sr.get_deprecated_class_definition_at(state_number, class_hash))
+            .state_reader()
+            .get_deprecated_class_definition_at(state_number, class_hash)
             .map_err(|err| StateError::StateReadError(err.to_string()))?;
 
         match v0_contract_class {
@@ -120,5 +111,34 @@ impl StateReader for PapyrusReader {
         _class_hash: ClassHash,
     ) -> StateResult<CompiledClassHash> {
         todo!()
+    }
+}
+
+pub struct PapyrusStateReader<'env> {
+    pub reader: RawPapyrusStateReader<'env>,
+    // Invariant: Read-Only.
+    latest_block: BlockNumber,
+}
+
+impl<'env> PapyrusStateReader<'env> {
+    pub fn new(reader: RawPapyrusStateReader<'env>, latest_block: BlockNumber) -> Self {
+        Self { reader, latest_block }
+    }
+
+    pub fn latest_block(&self) -> &BlockNumber {
+        &self.latest_block
+    }
+}
+pub struct PapyrusExecutableClassReader<'env> {
+    txn: &'env papyrus_storage::StorageTxn<'env, RO>,
+}
+
+impl<'env> PapyrusExecutableClassReader<'env> {
+    pub fn new(txn: &'env papyrus_storage::StorageTxn<'env, RO>) -> Self {
+        Self { txn }
+    }
+
+    fn get_casm(&self, class_hash: ClassHash) -> StorageResult<Option<CasmContractClass>> {
+        self.txn.get_casm(&class_hash)
     }
 }

--- a/crates/native_blockifier/src/papyrus_state_test.rs
+++ b/crates/native_blockifier/src/papyrus_state_test.rs
@@ -8,7 +8,7 @@ use blockifier::test_utils::{
     TEST_CONTRACT_ADDRESS, TEST_CONTRACT_CAIRO0_PATH,
 };
 use indexmap::IndexMap;
-use papyrus_storage::state::StateStorageWriter;
+use papyrus_storage::state::{StateStorageReader, StateStorageWriter};
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{ClassHash, ContractAddress, PatriciaKey};
 use starknet_api::hash::{StarkFelt, StarkHash};
@@ -16,7 +16,7 @@ use starknet_api::state::{StateDiff, StorageKey};
 use starknet_api::transaction::Calldata;
 use starknet_api::{calldata, patricia_key, stark_felt};
 
-use crate::papyrus_state::PapyrusReader;
+use crate::papyrus_state::{PapyrusReader, PapyrusStateReader};
 
 #[test]
 fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
@@ -37,9 +37,13 @@ fn test_entry_point_with_papyrus_state() -> papyrus_storage::StorageResult<()> {
         .append_state_diff(BlockNumber::default(), state_diff, deprecated_declared_classes)?
         .commit()?;
 
+    let storage_tx = storage_reader.begin_ro_txn()?;
+    let state_reader = storage_tx.get_state_reader()?;
+
     // BlockNumber is 1 due to the initialization step above.
     let block_number = BlockNumber(1);
-    let papyrus_reader = PapyrusReader::new(storage_reader, block_number);
+    let state_reader = PapyrusStateReader::new(state_reader, block_number);
+    let papyrus_reader = PapyrusReader::new(&storage_tx, state_reader);
     let mut state = CachedState::new(papyrus_reader);
 
     // Call entrypoint that want to write to storage, which updates the cached state's write cache.

--- a/crates/native_blockifier/src/py_transaction_executor.rs
+++ b/crates/native_blockifier/src/py_transaction_executor.rs
@@ -8,12 +8,15 @@ use blockifier::state::state_api::{State, StateReader};
 use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResources;
+use ouroboros;
+use papyrus_storage::db::RO;
+use papyrus_storage::state::StateStorageReader;
 use pyo3::prelude::*;
 use starknet_api::block::{BlockHash, BlockNumber, BlockTimestamp};
 use starknet_api::core::{ChainId, ClassHash, ContractAddress};
 
 use crate::errors::{NativeBlockifierError, NativeBlockifierResult};
-use crate::papyrus_state::PapyrusReader;
+use crate::papyrus_state::{PapyrusReader, PapyrusStateReader};
 use crate::py_state_diff::PyStateDiff;
 use crate::py_transaction::py_tx;
 use crate::py_transaction_execution_info::{PyTransactionExecutionInfo, PyVmExecutionResources};
@@ -38,7 +41,7 @@ impl PyTransactionExecutor {
         max_recursion_depth: usize,
     ) -> NativeBlockifierResult<Self> {
         log::debug!("Initializing Transaction Executor...");
-        let executor = TransactionExecutor::new(
+        let executor = TransactionExecutor::create(
             papyrus_storage,
             general_config,
             block_info,
@@ -87,6 +90,9 @@ impl PyTransactionExecutor {
     }
 }
 
+// To access a field you must use `self.borrow_{field_name}()`.
+// Alternately, you can borrow the whole object using `self.with[_mut]()`.
+#[ouroboros::self_referencing]
 pub struct TransactionExecutor {
     pub block_context: BlockContext,
 
@@ -94,11 +100,18 @@ pub struct TransactionExecutor {
     pub executed_class_hashes: HashSet<ClassHash>,
 
     // State-related fields.
-    pub state: CachedState<PapyrusReader>,
+    // Storage reader and transaction are kept merely for lifetime parameter referencing.
+    pub storage_reader: papyrus_storage::StorageReader,
+    #[borrows(storage_reader)]
+    #[covariant]
+    pub storage_tx: papyrus_storage::StorageTxn<'this, RO>,
+    #[borrows(storage_tx)]
+    #[covariant]
+    pub state: CachedState<PapyrusReader<'this>>,
 }
 
 impl TransactionExecutor {
-    pub fn new(
+    pub fn create(
         papyrus_storage: &Storage,
         general_config: PyGeneralConfig,
         block_info: &PyAny,
@@ -108,9 +121,7 @@ impl TransactionExecutor {
         let reader = papyrus_storage.reader().clone();
 
         let block_context = py_block_context(general_config, block_info, max_recursion_depth)?;
-        let state = CachedState::new(PapyrusReader::new(reader, block_context.block_number));
-        let executed_class_hashes = HashSet::<ClassHash>::new();
-        Ok(Self { block_context, executed_class_hashes, state })
+        build_tx_executor(block_context, reader)
     }
 
     /// Executes the given transaction on the state maintained by the executor.
@@ -127,68 +138,72 @@ impl TransactionExecutor {
         let tx: Transaction = py_tx(&tx_type, tx, raw_contract_class)?;
 
         let mut tx_executed_class_hashes = HashSet::<ClassHash>::new();
-        let mut transactional_state = CachedState::create_transactional(&mut self.state);
-        let tx_execution_result = tx
-            .execute_raw(&mut transactional_state, &self.block_context, true)
-            .map_err(NativeBlockifierError::from);
-        let (py_tx_execution_info, py_casm_hash_calculation_resources) = match tx_execution_result {
-            Ok(tx_execution_info) => {
-                tx_executed_class_hashes.extend(tx_execution_info.get_executed_class_hashes());
+        self.with_mut(|executor| {
+            let mut transactional_state = CachedState::create_transactional(executor.state);
+            let tx_execution_result = tx
+                .execute_raw(&mut transactional_state, executor.block_context, true)
+                .map_err(NativeBlockifierError::from);
+            let (py_tx_execution_info, py_casm_hash_calculation_resources) =
+                match tx_execution_result {
+                    Ok(tx_execution_info) => {
+                        tx_executed_class_hashes = tx_execution_info.get_executed_class_hashes();
 
-                let py_tx_execution_info = Python::with_gil(|py| {
-                    // Allocate this instance on the Python heap.
-                    // This is necessary in order to pass a reference to it to the callback
-                    // (otherwise, if it were allocated on Rust's heap/stack, giving Python
-                    // a reference to the objects will not
-                    // work).
-                    Py::new(py, PyTransactionExecutionInfo::from(tx_execution_info))
-                        .expect("Should be able to allocate on Python heap")
-                });
+                        let py_tx_execution_info = Python::with_gil(|py| {
+                            // Allocate this instance on the Python heap.
+                            // This is necessary in order to pass a reference to it to the callback
+                            // (otherwise, if it were allocated on Rust's heap/stack, giving Python
+                            // a reference to the objects will not
+                            // work).
+                            Py::new(py, PyTransactionExecutionInfo::from(tx_execution_info))
+                                .expect("Should be able to allocate on Python heap")
+                        });
 
-                let py_casm_hash_calculation_resources = get_casm_hash_calculation_resources(
-                    &mut transactional_state,
-                    &self.executed_class_hashes,
-                    &tx_executed_class_hashes,
-                )?;
+                        let py_casm_hash_calculation_resources =
+                            get_casm_hash_calculation_resources(
+                                &mut transactional_state,
+                                executor.executed_class_hashes,
+                                &tx_executed_class_hashes,
+                            )?;
 
-                (py_tx_execution_info, py_casm_hash_calculation_resources)
-            }
-            Err(error) => {
-                transactional_state.abort();
-                return Err(error);
-            }
-        };
+                        (py_tx_execution_info, py_casm_hash_calculation_resources)
+                    }
+                    Err(error) => {
+                        transactional_state.abort();
+                        return Err(error);
+                    }
+                };
 
-        let has_enough_room_for_tx = Python::with_gil(|py| {
-            // Can be done because `py_tx_execution_info` is a `Py<PyTransactionExecutionInfo>`,
-            // hence is allocated on the Python heap.
-            let args =
-                (py_tx_execution_info.borrow(py), py_casm_hash_calculation_resources.clone());
-            enough_room_for_tx.call1(args) // Callback to Python code.
-        });
+            let has_enough_room_for_tx = Python::with_gil(|py| {
+                // Can be done because `py_tx_execution_info` is a `Py<PyTransactionExecutionInfo>`,
+                // hence is allocated on the Python heap.
+                let args =
+                    (py_tx_execution_info.borrow(py), py_casm_hash_calculation_resources.clone());
+                enough_room_for_tx.call1(args) // Callback to Python code.
+            });
 
-        match has_enough_room_for_tx {
-            Ok(_) => {
-                transactional_state.commit();
-                self.executed_class_hashes.extend(&tx_executed_class_hashes);
-                Ok((py_tx_execution_info, py_casm_hash_calculation_resources))
+            match has_enough_room_for_tx {
+                Ok(_) => {
+                    transactional_state.commit();
+                    executor.executed_class_hashes.extend(&tx_executed_class_hashes);
+                    Ok((py_tx_execution_info, py_casm_hash_calculation_resources))
+                }
+                // Unexpected error, abort and let caller know.
+                Err(error) if unexpected_callback_error(&error) => {
+                    transactional_state.abort();
+                    Err(error.into())
+                }
+                // Not enough room in batch, abort and let caller verify on its own.
+                Err(_not_enough_weight_error) => {
+                    transactional_state.abort();
+                    Ok((py_tx_execution_info, py_casm_hash_calculation_resources))
+                }
             }
-            // Unexpected error, abort and let caller know.
-            Err(error) if unexpected_callback_error(&error) => {
-                transactional_state.abort();
-                Err(error.into())
-            }
-            // Not enough room in batch, abort and let caller verify on its own.
-            Err(_not_enough_weight_error) => {
-                transactional_state.abort();
-                Ok((py_tx_execution_info, py_casm_hash_calculation_resources))
-            }
-        }
+        })
     }
 
     /// Returns the state diff resulting in executing transactions.
     pub fn finalize(&mut self) -> PyStateDiff {
-        PyStateDiff::from(self.state.to_state_diff())
+        PyStateDiff::from(self.borrow_state().to_state_diff())
     }
 
     // Block pre-processing; see `block_execution::pre_process_block` documentation.
@@ -199,7 +214,9 @@ impl TransactionExecutor {
         let old_block_number_and_hash = old_block_number_and_hash
             .map(|(block_number, block_hash)| (BlockNumber(block_number), BlockHash(block_hash.0)));
 
-        pre_process_block(&mut self.state, old_block_number_and_hash);
+        self.with_mut(|executor| {
+            pre_process_block(executor.state, old_block_number_and_hash);
+        });
 
         Ok(())
     }
@@ -264,6 +281,40 @@ pub fn py_block_context(
     Ok(block_context)
 }
 
+pub fn build_tx_executor(
+    block_context: BlockContext,
+    storage_reader: papyrus_storage::StorageReader,
+) -> NativeBlockifierResult<TransactionExecutor> {
+    // The following callbacks are required to capture the local lifetime parameter.
+    fn storage_tx_builder(
+        storage_reader: &papyrus_storage::StorageReader,
+    ) -> NativeBlockifierResult<papyrus_storage::StorageTxn<'_, RO>> {
+        Ok(storage_reader.begin_ro_txn()?)
+    }
+
+    fn state_builder<'a>(
+        storage_tx: &'a papyrus_storage::StorageTxn<'a, RO>,
+        block_number: BlockNumber,
+    ) -> NativeBlockifierResult<CachedState<PapyrusReader<'a>>> {
+        let state_reader = storage_tx.get_state_reader()?;
+        let state_reader = PapyrusStateReader::new(state_reader, block_number);
+        let papyrus_reader = PapyrusReader::new(storage_tx, state_reader);
+        Ok(CachedState::new(papyrus_reader))
+    }
+
+    let executed_class_hashes = HashSet::<ClassHash>::new();
+    let block_number = block_context.block_number;
+    // The builder struct below is implicitly created by `ouroboros`.
+    let py_tx_executor_builder = TransactionExecutorTryBuilder {
+        block_context,
+        executed_class_hashes,
+        storage_reader,
+        storage_tx_builder,
+        state_builder: |storage_tx| state_builder(storage_tx, block_number),
+    };
+    py_tx_executor_builder.try_build()
+}
+
 fn unexpected_callback_error(error: &PyErr) -> bool {
     let error_string = error.to_string();
     !(error_string.contains("BatchFull") || error_string.contains("TransactionBiggerThanBatch"))
@@ -272,7 +323,7 @@ fn unexpected_callback_error(error: &PyErr) -> bool {
 /// Returns the estimated VM resources for Casm hash calculation (done by the OS), of the newly
 /// executed classes by the current transaction.
 pub fn get_casm_hash_calculation_resources(
-    state: &mut TransactionalState<'_, PapyrusReader>,
+    state: &mut TransactionalState<'_, PapyrusReader<'_>>,
     executed_class_hashes: &HashSet<ClassHash>,
     tx_executed_class_hashes: &HashSet<ClassHash>,
 ) -> NativeBlockifierResult<PyVmExecutionResources> {


### PR DESCRIPTION
…remove unnecessary RO tx storage (#758)"

This reverts commit 34536f183f5b066cb929ef18eec33c9b07a4e4b6.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/770)
<!-- Reviewable:end -->
