### PR TITLE
Storage cleanup

### DIFF
--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -16,7 +16,7 @@ use py_transaction_execution_info::{
 };
 use py_transaction_executor::PyTransactionExecutor;
 use pyo3::prelude::*;
-use storage::Storage;
+use storage::{Storage, StorageConfig};
 
 use crate::py_state_diff::PyStateDiff;
 use crate::py_utils::raise_error_for_testing;
@@ -35,6 +35,7 @@ fn native_blockifier(py: Python<'_>, py_module: &PyModule) -> PyResult<()> {
     py_module.add_class::<PyTransactionExecutor>()?;
     py_module.add_class::<PyVmExecutionResources>()?;
     py_module.add_class::<Storage>()?;
+    py_module.add_class::<StorageConfig>()?;
     add_py_exceptions(py, py_module)?;
 
     // TODO(Dori, 1/4/2023): If and when supported in the Python build environment, gate this code


### PR DESCRIPTION
- initialize storage using a `StorageConfig` motivation is two-fold: first, `Storage` will soon be internalized into a more general struct (BlockExecutor), so when we initialize it we want to wrap all the storage-relevant arguments up nicely to differentiate from the other arguments it is initialized with; second, there will soon be an additional argument here (chain_id) and three arguments is starting to get verbose.
- Added a testing initializer for Python usage (currently we're doing this in Python, which is wrong cause this is an implementation detail)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/772)
<!-- Reviewable:end -->
