### PR TITLE
Add `PyBlockExecutor`

### DIFF
--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -673,7 +673,7 @@ fn test_max_fee_to_max_steps_conversion(
     let n_steps1 = tx_execution_info1.actual_resources.0.get("n_steps").unwrap();
 
     // Second invocation of `with_arg` gets twice the pre-calculated actual fee as max_fee.
-    let tx2 = invoke_tx(execute_calldata.clone(), account_address, Fee(2 * actual_fee), None);
+    let tx2 = invoke_tx(execute_calldata, account_address, Fee(2 * actual_fee), None);
     let account_tx2: AccountTransaction =
         AccountTransaction::Invoke(InvokeTransaction::V1(InvokeTransactionV1 {
             nonce: nonce_manager.next(account_address),

--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod errors;
 pub mod papyrus_state;
+pub mod py_block_executor;
 pub mod py_state_diff;
 #[cfg(any(feature = "testing", test))]
 pub mod py_test_utils;
@@ -10,6 +11,7 @@ pub mod py_utils;
 pub mod storage;
 
 use errors::add_py_exceptions;
+use py_block_executor::PyBlockExecutor;
 use py_transaction_execution_info::{
     PyCallInfo, PyOrderedEvent, PyOrderedL2ToL1Message, PyTransactionExecutionInfo,
     PyVmExecutionResources,
@@ -27,6 +29,7 @@ fn native_blockifier(py: Python<'_>, py_module: &PyModule) -> PyResult<()> {
     // Usage: just create a Python logger as usual, and it'll capture Rust prints.
     pyo3_log::init();
 
+    py_module.add_class::<PyBlockExecutor>()?;
     py_module.add_class::<PyCallInfo>()?;
     py_module.add_class::<PyOrderedEvent>()?;
     py_module.add_class::<PyOrderedL2ToL1Message>()?;

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -1,0 +1,106 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use blockifier::block_context::BlockContext;
+use pyo3::prelude::*;
+use starknet_api::block::{BlockNumber, BlockTimestamp};
+use starknet_api::core::{ChainId, ContractAddress};
+
+use crate::errors::NativeBlockifierResult;
+use crate::py_transaction_executor::PyTransactionExecutor;
+use crate::py_utils::{int_to_chain_id, py_attr, PyFelt};
+use crate::storage::Storage;
+
+#[pyclass]
+pub struct PyBlockExecutor {
+    pub general_config: PyGeneralConfig,
+    pub max_recursion_depth: usize,
+    // TODO: add TransactionExecutor and Storage as fields.
+}
+
+#[pymethods]
+impl PyBlockExecutor {
+    #[new]
+    #[args(general_config, max_recursion_depth)]
+    pub fn create(general_config: PyGeneralConfig, max_recursion_depth: usize) -> Self {
+        Self { general_config, max_recursion_depth }
+    }
+
+    #[args(general_config)]
+    #[staticmethod]
+    fn create_for_testing(general_config: PyGeneralConfig) -> Self {
+        Self { general_config, max_recursion_depth: 50 }
+    }
+
+    fn initialize_tx_executor(
+        &self,
+        storage: &Storage,
+        block_info: &PyAny,
+    ) -> NativeBlockifierResult<PyTransactionExecutor> {
+        PyTransactionExecutor::create(
+            storage,
+            &self.general_config,
+            block_info,
+            self.max_recursion_depth,
+        )
+    }
+}
+
+pub struct PyGeneralConfig {
+    pub starknet_os_config: PyOsConfig,
+    pub sequencer_address: PyFelt,
+    pub cairo_resource_fee_weights: Arc<HashMap<String, f64>>,
+    pub invoke_tx_max_n_steps: u32,
+    pub validate_max_n_steps: u32,
+}
+
+impl FromPyObject<'_> for PyGeneralConfig {
+    fn extract(general_config: &PyAny) -> PyResult<Self> {
+        let starknet_os_config = general_config.getattr("starknet_os_config")?.extract()?;
+        let sequencer_address = general_config.getattr("sequencer_address")?.extract()?;
+        let cairo_resource_fee_weights: HashMap<String, f64> =
+            general_config.getattr("cairo_resource_fee_weights")?.extract()?;
+
+        let cairo_resource_fee_weights = Arc::new(cairo_resource_fee_weights);
+        let invoke_tx_max_n_steps = general_config.getattr("invoke_tx_max_n_steps")?.extract()?;
+        let validate_max_n_steps = general_config.getattr("validate_max_n_steps")?.extract()?;
+
+        Ok(Self {
+            starknet_os_config,
+            sequencer_address,
+            cairo_resource_fee_weights,
+            invoke_tx_max_n_steps,
+            validate_max_n_steps,
+        })
+    }
+}
+
+#[derive(FromPyObject, Clone)]
+pub struct PyOsConfig {
+    #[pyo3(from_py_with = "int_to_chain_id")]
+    pub chain_id: ChainId,
+    pub fee_token_address: PyFelt,
+}
+
+pub fn into_block_context(
+    general_config: &PyGeneralConfig,
+    block_info: &PyAny,
+    max_recursion_depth: usize,
+) -> NativeBlockifierResult<BlockContext> {
+    let starknet_os_config = general_config.starknet_os_config.clone();
+    let block_number = BlockNumber(py_attr(block_info, "block_number")?);
+    let block_context = BlockContext {
+        chain_id: starknet_os_config.chain_id,
+        block_number,
+        block_timestamp: BlockTimestamp(py_attr(block_info, "block_timestamp")?),
+        sequencer_address: ContractAddress::try_from(general_config.sequencer_address.0)?,
+        fee_token_address: ContractAddress::try_from(starknet_os_config.fee_token_address.0)?,
+        vm_resource_fee_cost: general_config.cairo_resource_fee_weights.clone(),
+        gas_price: py_attr(block_info, "gas_price")?,
+        invoke_tx_max_n_steps: general_config.invoke_tx_max_n_steps,
+        validate_max_n_steps: general_config.validate_max_n_steps,
+        max_recursion_depth,
+    };
+
+    Ok(block_context)
+}

--- a/crates/native_blockifier/src/py_transaction_executor.rs
+++ b/crates/native_blockifier/src/py_transaction_executor.rs
@@ -1,5 +1,4 @@
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::collections::HashSet;
 
 use blockifier::block_context::BlockContext;
 use blockifier::block_execution::pre_process_block;
@@ -9,15 +8,16 @@ use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResources;
 use pyo3::prelude::*;
-use starknet_api::block::{BlockHash, BlockNumber, BlockTimestamp};
-use starknet_api::core::{ChainId, ClassHash, ContractAddress};
+use starknet_api::block::{BlockHash, BlockNumber};
+use starknet_api::core::ClassHash;
 
 use crate::errors::{NativeBlockifierError, NativeBlockifierResult};
 use crate::papyrus_state::PapyrusReader;
+use crate::py_block_executor::{into_block_context, PyGeneralConfig};
 use crate::py_state_diff::PyStateDiff;
 use crate::py_transaction::py_tx;
 use crate::py_transaction_execution_info::{PyTransactionExecutionInfo, PyVmExecutionResources};
-use crate::py_utils::{int_to_chain_id, py_attr, py_enum_name, PyFelt};
+use crate::py_utils::{py_enum_name, PyFelt};
 use crate::storage::Storage;
 
 /// Wraps the transaction executor in an optional, to allow an explicit deallocation of it.
@@ -29,26 +29,6 @@ pub struct PyTransactionExecutor {
 
 #[pymethods]
 impl PyTransactionExecutor {
-    #[new]
-    #[args(papyrus_storage, general_config, block_info, max_recursion_depth)]
-    pub fn create(
-        papyrus_storage: &Storage,
-        general_config: PyGeneralConfig,
-        block_info: &PyAny,
-        max_recursion_depth: usize,
-    ) -> NativeBlockifierResult<Self> {
-        log::debug!("Initializing Transaction Executor...");
-        let executor = TransactionExecutor::new(
-            papyrus_storage,
-            general_config,
-            block_info,
-            max_recursion_depth,
-        )?;
-        log::debug!("Initialized Transaction Executor.");
-
-        Ok(Self { executor: Some(executor) })
-    }
-
     #[args(tx, raw_contract_class, enough_room_for_tx)]
     pub fn execute(
         &mut self,
@@ -82,6 +62,24 @@ impl PyTransactionExecutor {
 }
 
 impl PyTransactionExecutor {
+    pub fn create(
+        papyrus_storage: &Storage,
+        general_config: &PyGeneralConfig,
+        block_info: &PyAny,
+        max_recursion_depth: usize,
+    ) -> NativeBlockifierResult<Self> {
+        log::debug!("Initializing Transaction Executor...");
+        let executor = TransactionExecutor::new(
+            papyrus_storage,
+            general_config,
+            block_info,
+            max_recursion_depth,
+        )?;
+        log::debug!("Initialized Transaction Executor.");
+
+        Ok(Self { executor: Some(executor) })
+    }
+
     fn executor(&mut self) -> &mut TransactionExecutor {
         self.executor.as_mut().expect("Transaction executor should be initialized.")
     }
@@ -100,14 +98,14 @@ pub struct TransactionExecutor {
 impl TransactionExecutor {
     pub fn new(
         papyrus_storage: &Storage,
-        general_config: PyGeneralConfig,
+        general_config: &PyGeneralConfig,
         block_info: &PyAny,
         max_recursion_depth: usize,
     ) -> NativeBlockifierResult<Self> {
         // Assumption: storage is aligned.
         let reader = papyrus_storage.reader().clone();
 
-        let block_context = py_block_context(general_config, block_info, max_recursion_depth)?;
+        let block_context = into_block_context(general_config, block_info, max_recursion_depth)?;
         let state = CachedState::new(PapyrusReader::new(reader, block_context.block_number));
         let executed_class_hashes = HashSet::<ClassHash>::new();
         Ok(Self { block_context, executed_class_hashes, state })
@@ -203,65 +201,6 @@ impl TransactionExecutor {
 
         Ok(())
     }
-}
-
-pub struct PyGeneralConfig {
-    pub starknet_os_config: PyOsConfig,
-    pub sequencer_address: PyFelt,
-    pub cairo_resource_fee_weights: Arc<HashMap<String, f64>>,
-    pub invoke_tx_max_n_steps: u32,
-    pub validate_max_n_steps: u32,
-}
-
-impl FromPyObject<'_> for PyGeneralConfig {
-    fn extract(general_config: &PyAny) -> PyResult<Self> {
-        let starknet_os_config = general_config.getattr("starknet_os_config")?.extract()?;
-        let sequencer_address = general_config.getattr("sequencer_address")?.extract()?;
-        let cairo_resource_fee_weights: HashMap<String, f64> =
-            general_config.getattr("cairo_resource_fee_weights")?.extract()?;
-
-        let cairo_resource_fee_weights = Arc::new(cairo_resource_fee_weights);
-        let invoke_tx_max_n_steps = general_config.getattr("invoke_tx_max_n_steps")?.extract()?;
-        let validate_max_n_steps = general_config.getattr("validate_max_n_steps")?.extract()?;
-
-        Ok(Self {
-            starknet_os_config,
-            sequencer_address,
-            cairo_resource_fee_weights,
-            invoke_tx_max_n_steps,
-            validate_max_n_steps,
-        })
-    }
-}
-
-#[derive(FromPyObject)]
-pub struct PyOsConfig {
-    #[pyo3(from_py_with = "int_to_chain_id")]
-    pub chain_id: ChainId,
-    pub fee_token_address: PyFelt,
-}
-
-pub fn py_block_context(
-    general_config: PyGeneralConfig,
-    block_info: &PyAny,
-    max_recursion_depth: usize,
-) -> NativeBlockifierResult<BlockContext> {
-    let starknet_os_config = general_config.starknet_os_config;
-    let block_number = BlockNumber(py_attr(block_info, "block_number")?);
-    let block_context = BlockContext {
-        chain_id: starknet_os_config.chain_id,
-        block_number,
-        block_timestamp: BlockTimestamp(py_attr(block_info, "block_timestamp")?),
-        sequencer_address: ContractAddress::try_from(general_config.sequencer_address.0)?,
-        fee_token_address: ContractAddress::try_from(starknet_os_config.fee_token_address.0)?,
-        vm_resource_fee_cost: general_config.cairo_resource_fee_weights,
-        gas_price: py_attr(block_info, "gas_price")?,
-        invoke_tx_max_n_steps: general_config.invoke_tx_max_n_steps,
-        validate_max_n_steps: general_config.validate_max_n_steps,
-        max_recursion_depth,
-    };
-
-    Ok(block_context)
 }
 
 fn unexpected_callback_error(error: &PyErr) -> bool {


### PR DESCRIPTION
* For simplicity, all it does at the moment is hold general_config and max_recursion_depth, where the former's definition was moved into `PyBlockExecutor`'s module, since it is its primary owner.
* It is also in charge of initializing the PyTransactionExecutor for Python.
* Make `py_block_context` into a method of `PyGeneralConfig` --- note that PyBlockInfo can be used there instead of PyAny, will do in separate PR to keep the diff small.
* in subsequent PRs it will also be in charge of Storage, and later on hide both storage and transaction executor from Python.
* The change in `account_transactions_test`.rs is an unrelated unnecessary `clone` clippy spotted only now for some reason.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/776)
<!-- Reviewable:end -->
