### PR TITLE
Hide `Storage` from Python

### DIFF
--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -17,7 +17,7 @@ use py_transaction_execution_info::{
     PyVmExecutionResources,
 };
 use pyo3::prelude::*;
-use storage::{Storage, StorageConfig};
+use storage::StorageConfig;
 
 use crate::py_state_diff::PyStateDiff;
 use crate::py_utils::raise_error_for_testing;
@@ -35,7 +35,6 @@ fn native_blockifier(py: Python<'_>, py_module: &PyModule) -> PyResult<()> {
     py_module.add_class::<PyStateDiff>()?;
     py_module.add_class::<PyTransactionExecutionInfo>()?;
     py_module.add_class::<PyVmExecutionResources>()?;
-    py_module.add_class::<Storage>()?;
     py_module.add_class::<StorageConfig>()?;
     add_py_exceptions(py, py_module)?;
 

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -11,59 +11,56 @@ use crate::py_state_diff::{PyBlockInfo, PyStateDiff};
 use crate::py_transaction_execution_info::{PyTransactionExecutionInfo, PyVmExecutionResources};
 use crate::py_transaction_executor::TransactionExecutor;
 use crate::py_utils::{int_to_chain_id, PyFelt};
-use crate::storage::Storage;
+use crate::storage::{Storage, StorageConfig};
 
 #[pyclass]
 pub struct PyBlockExecutor {
     pub general_config: PyGeneralConfig,
     pub max_recursion_depth: usize,
     pub tx_executor: Option<TransactionExecutor>,
-    // TODO: add TransactionExecutor and Storage as fields.
+    pub storage: Storage,
 }
 
 #[pymethods]
 impl PyBlockExecutor {
     #[new]
-    #[args(general_config, max_recursion_depth)]
-    pub fn create(general_config: PyGeneralConfig, max_recursion_depth: usize) -> Self {
+    #[args(general_config, max_recursion_depth, target_storage_config)]
+    pub fn create(
+        general_config: PyGeneralConfig,
+        max_recursion_depth: usize,
+        target_storage_config: StorageConfig,
+    ) -> Self {
+        log::debug!("Initializing Block Executor...");
         let tx_executor = None;
+        let storage = Storage::new(target_storage_config).expect("Failed to initialize storage");
+
         log::debug!("Initialized Block Executor.");
-        Self { general_config, max_recursion_depth, tx_executor }
+        Self { general_config, max_recursion_depth, tx_executor, storage }
     }
 
-    #[args(general_config)]
-    #[staticmethod]
-    fn create_for_testing(general_config: PyGeneralConfig) -> Self {
-        Self { general_config, max_recursion_depth: 50, tx_executor: None }
-    }
+    // Transaction Execution API.
 
     /// Initializes the transaction executor for the given block.
-    #[args(storage, block_info)]
+    #[args(storage, next_block_info)]
     fn setup_block_execution(
         &mut self,
-        storage: &Storage,
-        block_info: PyBlockInfo,
+        next_block_info: PyBlockInfo,
     ) -> NativeBlockifierResult<()> {
+        self.storage.validate_aligned(next_block_info.block_number);
+
         let tx_executor = TransactionExecutor::new(
-            storage,
+            &self.storage,
             &self.general_config,
-            block_info,
+            next_block_info,
             self.max_recursion_depth,
         )?;
         self.tx_executor = Some(tx_executor);
+
         Ok(())
     }
 
     fn teardown_block_execution(&mut self) {
         self.tx_executor = None;
-    }
-
-    /// Deallocate the transaction executor and close storage connections.
-    pub fn close(&mut self) {
-        log::debug!("Closing Block Executor.");
-        // If the block was not finalized (due to some exception occuring _in Python_), we need
-        // to deallocate the transaction executor here to prevent leaks.
-        self.teardown_block_execution();
     }
 
     #[args(tx, raw_contract_class, enough_room_for_tx)]
@@ -91,6 +88,89 @@ impl PyBlockExecutor {
         old_block_number_and_hash: Option<(u64, PyFelt)>,
     ) -> NativeBlockifierResult<()> {
         self.tx_executor().pre_process_block(old_block_number_and_hash)
+    }
+
+    // Storage Alignment API.
+
+    /// Appends state diff and block header into Papyrus storage.
+    // Previous block ID can either be a block hash (starting from a Papyrus snapshot), or a
+    // sequential ID (throughout sequencing).
+    #[args(
+        block_id,
+        previous_block_id,
+        py_block_info,
+        py_state_diff,
+        declared_class_hash_to_class,
+        deprecated_declared_class_hash_to_class
+    )]
+    pub fn append_block(
+        &mut self,
+        block_id: u64,
+        previous_block_id: Option<PyFelt>,
+        py_block_info: PyBlockInfo,
+        py_state_diff: PyStateDiff,
+        declared_class_hash_to_class: HashMap<PyFelt, (PyFelt, String)>,
+        deprecated_declared_class_hash_to_class: HashMap<PyFelt, String>,
+    ) -> NativeBlockifierResult<()> {
+        self.storage.append_block(
+            block_id,
+            previous_block_id,
+            py_block_info,
+            py_state_diff,
+            declared_class_hash_to_class,
+            deprecated_declared_class_hash_to_class,
+        )
+    }
+
+    /// Returns the next block number, for which block header was not yet appended.
+    /// Block header stream is usually ahead of the state diff stream, so this is the indicative
+    /// marker.
+    pub fn get_header_marker(&self) -> NativeBlockifierResult<u64> {
+        self.storage.get_header_marker()
+    }
+
+    /// Returns the unique identifier of the given block number in bytes.
+    #[args(block_number)]
+    fn get_block_id_at_target(&self, block_number: u64) -> NativeBlockifierResult<Option<u64>> {
+        let block_id_bytes = self.storage.get_block_id(block_number)?;
+        let block_id_u64 = block_id_bytes.map(|block_id_bytes| {
+            u64::from_be_bytes(block_id_bytes[block_id_bytes.len() - 8..].try_into().unwrap())
+        });
+
+        Ok(block_id_u64)
+    }
+
+    #[args(source_block_number)]
+    pub fn validate_aligned(&self, source_block_number: u64) {
+        self.storage.validate_aligned(source_block_number);
+    }
+
+    /// Atomically reverts block header and state diff of given block number.
+    /// If header exists without a state diff (usually the case), only the header is reverted.
+    /// (this is true for every partial existence of information at tables).
+    #[args(block_number)]
+    pub fn revert_block(&mut self, block_number: u64) -> NativeBlockifierResult<()> {
+        self.storage.revert_block(block_number)
+    }
+
+    /// Deallocate the transaction executor and close storage connections.
+    pub fn close(&mut self) {
+        log::debug!("Closing Block Executor.");
+        // If the block was not finalized (due to some exception occuring _in Python_), we need
+        // to deallocate the transaction executor here to prevent leaks.
+        self.teardown_block_execution();
+        self.storage.close();
+    }
+
+    #[args(general_config)]
+    #[staticmethod]
+    fn create_for_testing(general_config: PyGeneralConfig, path: std::path::PathBuf) -> Self {
+        Self {
+            storage: Storage::new_for_testing(path, &general_config.starknet_os_config.chain_id),
+            general_config,
+            max_recursion_depth: 50,
+            tx_executor: None,
+        }
     }
 }
 

--- a/crates/native_blockifier/src/storage.rs
+++ b/crates/native_blockifier/src/storage.rs
@@ -21,7 +21,6 @@ use crate::PyStateDiff;
 
 const GENESIS_BLOCK_ID: u64 = u64::MAX;
 
-#[pyclass]
 // Invariant: Only one instance of this struct should exist.
 // Reader and writer fields must be cleared before the struct goes out of scope in Python;
 // to prevent possible memory leaks (TODO: see if this is indeed necessary).
@@ -30,10 +29,7 @@ pub struct Storage {
     writer: Option<papyrus_storage::StorageWriter>,
 }
 
-#[pymethods]
 impl Storage {
-    #[new]
-    #[args(path_prefix, chain_id, max_size)]
     pub fn new(config: StorageConfig) -> NativeBlockifierResult<Storage> {
         log::debug!("Initializing Blockifier storage...");
         let db_config = papyrus_storage::db::DbConfig {
@@ -52,6 +48,7 @@ impl Storage {
     /// Manually drops the storage reader and writer.
     /// Python does not necessarily drop them even if instance is no longer live.
     pub fn close(&mut self) {
+        log::debug!("Closing Blockifier storage.");
         self.reader = None;
         self.writer = None;
     }
@@ -62,16 +59,11 @@ impl Storage {
         Ok(block_number.0)
     }
 
-    /// Returns the next block number, for which block header was not yet appended.
-    /// Block header stream is usually ahead of the state diff stream, so this is the indicative
-    /// marker.
     pub fn get_header_marker(&self) -> NativeBlockifierResult<u64> {
         let block_number = self.reader().begin_ro_txn()?.get_header_marker()?;
         Ok(block_number.0)
     }
 
-    #[args(block_number)]
-    /// Returns the unique identifier of the given block number in bytes.
     pub fn get_block_id(&self, block_number: u64) -> NativeBlockifierResult<Option<Vec<u8>>> {
         let block_number = BlockNumber(block_number);
         let block_hash = self
@@ -82,10 +74,6 @@ impl Storage {
         Ok(block_hash)
     }
 
-    /// Atomically reverts block header and state diff of given block number.
-    /// If header exists without a state diff (usually the case), only the header is reverted.
-    /// (this is true for every partial existence of information at tables).
-    #[args(block_number)]
     pub fn revert_block(&mut self, block_number: u64) -> NativeBlockifierResult<()> {
         log::debug!("Reverting state diff for {block_number:?}.");
         let block_number = BlockNumber(block_number);
@@ -98,17 +86,6 @@ impl Storage {
     }
 
     // TODO(Gilad): Refactor.
-    #[args(
-        block_id,
-        previous_block_id,
-        py_block_info,
-        py_state_diff,
-        declared_class_hash_to_class,
-        deprecated_declared_class_hash_to_class
-    )]
-    /// Appends state diff and block header into Papyrus storage.
-    // Previous block ID can either be a block hash (starting from a Papyrus snapshot), or a
-    // sequential ID (throughout sequencing).
     pub fn append_block(
         &mut self,
         block_id: u64,
@@ -220,15 +197,10 @@ impl Storage {
         Ok(())
     }
 
-    #[staticmethod]
-    #[args(path)]
-    pub fn new_for_testing(
-        path_prefix: PathBuf,
-        #[pyo3(from_py_with = "int_to_chain_id")] chain_id: ChainId,
-    ) -> Storage {
+    pub fn new_for_testing(path_prefix: PathBuf, chain_id: &ChainId) -> Storage {
         let db_config = papyrus_storage::db::DbConfig {
             path_prefix,
-            chain_id,
+            chain_id: chain_id.clone(),
             min_size: 1 << 20,    // 1MB
             max_size: 1 << 35,    // 32GB
             growth_step: 1 << 26, // 64MB
@@ -237,13 +209,29 @@ impl Storage {
 
         Storage { reader: Some(reader), writer: Some(writer) }
     }
-}
 
-// Internal getters, Python should not have access to them, and only use the public API.
-impl Storage {
+    pub fn validate_aligned(&self, source_block_number: u64) {
+        let header_marker = self.get_header_marker().expect("Should have a header marker");
+        let state_marker = self.get_state_marker().expect("Should have a state marker");
+
+        assert_eq!(
+            header_marker, state_marker,
+            "Block header marker ({}) must be aligned to block state diff marker ({}) before \
+             sequencing starts.",
+            header_marker, state_marker
+        );
+
+        assert_eq!(
+            state_marker, source_block_number,
+            "Target storage (block number {}) should have been aligned to block number {}.",
+            state_marker, source_block_number
+        );
+    }
+
     pub fn reader(&self) -> &papyrus_storage::StorageReader {
         self.reader.as_ref().expect("Storage should be initialized.")
     }
+
     pub fn writer(&mut self) -> &mut papyrus_storage::StorageWriter {
         self.writer.as_mut().expect("Storage should be initialized.")
     }
@@ -260,6 +248,7 @@ pub struct StorageConfig {
 #[pymethods]
 impl StorageConfig {
     #[new]
+    #[args(path_prefix, chain_id, max_size)]
     pub fn new(
         path_prefix: PathBuf,
         #[pyo3(from_py_with = "int_to_chain_id")] chain_id: ChainId,


### PR DESCRIPTION
- Make `Storage` a pure Rust struct, thus making `PyBlockExecutor` the sole pyo3 construct Python has accesss to.
- Also makes memory management easier, since we don't have to track this at Python.
- Basically `PyBlockExecutor` swallowed `BlockifierStorage`, delegate the same API to `Storage`, with the exception of `validate_aligned` which is executed in Rust in the same way as it did in Python.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/779)
<!-- Reviewable:end -->
