### PR TITLE
Refactor run_or_revert.

### DIFF
--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -56,7 +56,7 @@ struct ValidateExecuteCallInfo {
     execute_call_info: Option<CallInfo>,
     revert_error: Option<String>,
     n_reverted_steps: usize,
-    out_of_gas: bool,
+    charge_max_fee_for_reverted: bool,
 }
 
 impl ValidateExecuteCallInfo {
@@ -69,7 +69,7 @@ impl ValidateExecuteCallInfo {
             execute_call_info,
             revert_error: None,
             n_reverted_steps: 0,
-            out_of_gas: false,
+            charge_max_fee_for_reverted: false,
         }
     }
 
@@ -77,14 +77,14 @@ impl ValidateExecuteCallInfo {
         validate_call_info: Option<CallInfo>,
         revert_error: String,
         n_reverted_steps: usize,
-        out_of_gas: bool,
+        charge_max_fee_for_reverted: bool,
     ) -> Self {
         Self {
             validate_call_info,
             execute_call_info: None,
             revert_error: Some(revert_error),
             n_reverted_steps,
-            out_of_gas,
+            charge_max_fee_for_reverted,
         }
     }
 }
@@ -487,7 +487,10 @@ impl AccountTransaction {
                 if actual_fee > self.max_fee() {
                     // Insufficient fee. Revert the execution.
                     execution_state.abort();
-                    let remaining_steps = execution_context.vm_run_resources.get_n_steps().unwrap();
+                    let remaining_steps = execution_context
+                        .vm_run_resources
+                        .get_n_steps()
+                        .expect("Invalid remaining steps in RunResources.");
                     let reverted_steps = allotted_steps - remaining_steps;
 
                     return Ok(ValidateExecuteCallInfo::new_reverted(
@@ -512,13 +515,12 @@ impl AccountTransaction {
                 execution_state.abort();
                 let remaining_steps = execution_context.vm_run_resources.get_n_steps().unwrap();
                 let reverted_steps = allotted_steps - remaining_steps;
-                let out_of_gas = allotted_steps == reverted_steps;
 
                 Ok(ValidateExecuteCallInfo::new_reverted(
                     validate_call_info,
                     execution_context.error_trace(),
                     reverted_steps,
-                    out_of_gas,
+                    false,
                 ))
             }
         }
@@ -626,9 +628,10 @@ impl<S: StateReader> ExecutableTransaction<S> for AccountTransaction {
             execute_call_info,
             revert_error,
             n_reverted_steps,
-            out_of_gas,
+            charge_max_fee_for_reverted,
         } = self.run_or_revert(state, &mut resources, &mut remaining_gas, block_context)?;
 
+        let is_reverted = revert_error.is_some();
         let state_changes = state.get_actual_state_changes_for_fee_charge(
             block_context.fee_token_address,
             Some(account_tx_context.sender_address),
@@ -639,11 +642,12 @@ impl<S: StateReader> ExecutableTransaction<S> for AccountTransaction {
             &validate_call_info,
             resources,
             block_context,
-            revert_error.is_some(),
+            is_reverted,
             n_reverted_steps,
         )?;
 
-        if out_of_gas {
+        // Charge max fee when a transaction reverts due to insufficient max fee.
+        if charge_max_fee_for_reverted && is_reverted {
             actual_fee = account_tx_context.max_fee;
         }
         let fee_transfer_call_info =

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -460,7 +460,7 @@ fn test_reverted_reach_steps_limit(
     #[from(create_state)] state: CachedState<DictStateReader>,
 ) {
     // Limit the number of execution steps (so we quickly hit the limit).
-    block_context.invoke_tx_max_n_steps = 4000;
+    block_context.invoke_tx_max_n_steps = 5000;
 
     let TestInitData {
         mut state,
@@ -737,9 +737,25 @@ fn test_insufficient_max_fee_to_insufficient_steps(
     assert!(!tx_execution_info1.is_reverted());
     let actual_fee_depth1 = tx_execution_info1.actual_fee;
 
-    // Invoke the `recurse` function with depth of 300 and actual_fee_depth1 as max fee.
-    // This call should fail due to no remaining steps.
+    // Invoke the `recurse` function with depth of 2 and actual_fee_depth1 as max fee.
+    // This call should fail due to insufficient max fee.
     let tx_execution_info2: TransactionExecutionInfo = run_recursive_function(
+        &mut state,
+        &block_context,
+        actual_fee_depth1,
+        &contract_address,
+        &account_address,
+        &mut nonce_manager,
+        "recurse",
+        2,
+    );
+    assert!(tx_execution_info2.is_reverted());
+    assert!(tx_execution_info2.actual_fee == actual_fee_depth1);
+    assert!(tx_execution_info2.revert_error.unwrap().contains("Insufficient max fee"));
+
+    // Invoke the `recurse` function with depth of 800 and actual_fee_depth1 as max fee.
+    // This call should fail due to no remaining steps.
+    let tx_execution_info3: TransactionExecutionInfo = run_recursive_function(
         &mut state,
         &block_context,
         actual_fee_depth1,
@@ -749,9 +765,9 @@ fn test_insufficient_max_fee_to_insufficient_steps(
         "recurse",
         800,
     );
-    assert!(tx_execution_info2.is_reverted());
-    assert!(tx_execution_info2.actual_fee == actual_fee_depth1);
+    assert!(tx_execution_info3.is_reverted());
+    assert!(tx_execution_info3.actual_fee == actual_fee_depth1);
     assert!(
-        tx_execution_info2.revert_error.unwrap().contains("RunResources has no remaining steps.")
+        tx_execution_info3.revert_error.unwrap().contains("RunResources has no remaining steps.")
     );
 }

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -751,7 +751,7 @@ fn test_insufficient_max_fee_to_insufficient_steps(
     );
     assert!(tx_execution_info2.is_reverted());
     assert!(tx_execution_info2.actual_fee == actual_fee_depth1);
-    assert!(tx_execution_info2.revert_error.unwrap().contains("Insufficient max fee"));
+    assert!(tx_execution_info2.revert_error.unwrap().starts_with("Insufficient max fee"));
 
     // Invoke the `recurse` function with depth of 800 and actual_fee_depth1 as max fee.
     // This call should fail due to no remaining steps.

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -531,14 +531,13 @@ fn test_negative_invoke_tx_flows(state: &mut CachedState<DictStateReader>) {
         max_fee: invalid_max_fee,
         ..valid_invoke_tx.clone()
     }));
-    let execution_error = invalid_tx.execute(state, block_context, true).unwrap_err();
+    let execution_result = invalid_tx.execute(state, block_context, true).unwrap();
+    let execution_error = execution_result.revert_error.unwrap();
 
     // Test error.
-    assert_matches!(
-        execution_error,
-        TransactionExecutionError::FeeTransferError{ max_fee, .. }
-        if max_fee == invalid_max_fee
-    );
+    assert!(execution_error.contains("Insufficient max fee:"));
+    // Test that fee was charged.
+    assert_eq!(execution_result.actual_fee, invalid_max_fee);
 
     // Invalid nonce.
     // Use a fresh state to facilitate testing.

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -535,7 +535,7 @@ fn test_negative_invoke_tx_flows(state: &mut CachedState<DictStateReader>) {
     let execution_error = execution_result.revert_error.unwrap();
 
     // Test error.
-    assert!(execution_error.contains("Insufficient max fee:"));
+    assert!(execution_error.starts_with("Insufficient max fee:"));
     // Test that fee was charged.
     assert_eq!(execution_result.actual_fee, invalid_max_fee);
 


### PR DESCRIPTION
Check actual fee before committing the execution result. Revert and charge max fee when running out of gas instead of failing due to FeeTransferError and charging nothing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/796)
<!-- Reviewable:end -->
