### PR TITLE
rc2 versioning fix and READMEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "native_blockifier"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 members = ["crates/blockifier", "crates/native_blockifier"]
 
 [workspace.package]
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 edition = "2021"
 repository = "https://github.com/starkware-libs/blockifier/"
 license = "Apache-2.0"

--- a/crates/blockifier/README.md
+++ b/crates/blockifier/README.md
@@ -1,0 +1,5 @@
+# blockifier
+
+## Description
+
+The transaction-executing component in the StarkNet sequencer.

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 repository.workspace = true
 license-file.workspace = true
-description = "Bridge between the Rust blockifier crate and Python."
+description = "A Bridge between the Rust blockifier crate and Python."
 
 [lib]
 name = "native_blockifier"
@@ -16,7 +16,9 @@ name = "native_blockifier"
 crate-type = ["cdylib"]
 
 [dependencies]
-blockifier = { path = "../blockifier", features = ["testing"] }
+blockifier = { path = "../blockifier", version = "0.1.0-rc2", features = [
+    "testing",
+] }
 cairo-lang-starknet.workspace = true
 cairo-vm.workspace = true
 indexmap.workspace = true

--- a/crates/native_blockifier/README.md
+++ b/crates/native_blockifier/README.md
@@ -1,0 +1,5 @@
+# native_blockifier
+
+## Description
+
+A Bridge between the Rust blockifier crate and Python.


### PR DESCRIPTION
* make native_blockifier depend on `blockifier` with a `path` when
  working locally, and with `version` in crates.io (which doesn't
  support path deps).
* add READMEs to both crates.



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/801)
<!-- Reviewable:end -->
