### PR TITLE
Add global contract cache test for `CachedState`

### DIFF
--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -366,3 +366,30 @@ fn test_state_changes_merge() {
         state_changes_final
     );
 }
+
+#[test]
+fn global_contract_cache_is_used() {
+    // Initialize the global cache with a single class, and initialize an empty state with this
+    // cache.
+    let global_cache = GlobalContractCache::default();
+    let class_hash = class_hash!(TEST_CLASS_HASH);
+    let contract_class = get_test_contract_class();
+    global_cache.lock().unwrap().cache_set(class_hash, contract_class.clone());
+    assert_eq!(global_cache.lock().unwrap().cache_size(), 1);
+    let mut state = CachedState::new(DictStateReader::default(), global_cache.clone());
+
+    // Assert local cache is initialized empty even if global cache is not empty.
+    assert!(state.class_hash_to_class.get(&class_hash).is_none());
+
+    // Check state uses the global cache.
+    assert_eq!(state.get_compiled_contract_class(&class_hash).unwrap(), contract_class);
+    assert_eq!(global_cache.lock().unwrap().cache_hits().unwrap(), 1);
+    assert_eq!(global_cache.lock().unwrap().cache_size(), 1);
+    // Verify local cache is also updated.
+    assert_eq!(state.class_hash_to_class.get(&class_hash).unwrap(), &contract_class);
+
+    // Idempotency: getting the same class again uses the local cache.
+    assert_eq!(state.get_compiled_contract_class(&class_hash).unwrap(), contract_class);
+    assert_eq!(global_cache.lock().unwrap().cache_hits().unwrap(), 1);
+    assert_eq!(global_cache.lock().unwrap().cache_size(), 1);
+}


### PR DESCRIPTION
The global cache update action will be tested in a subsequent PR (it needs some extra changes in pyo3).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/805)
<!-- Reviewable:end -->
