### PR TITLE
Lock serde at 1.0.71 for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2855,18 +2855,18 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.178"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60363bdd39a7be0266a520dab25fdc9241d2f987b08a01e01f0ec6d06a981348"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.178"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28482318d6641454cb273da158647922d1be6b5a2fcc6165cd89ebdd7ed576b"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ rstest = "0.17.0"
 papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "42ebef8" }
 phf = { version = "0.11", features = ["macros"] }
 pretty_assertions = "1.2.1"
-serde = "1.0.130"
+# TODO(Gilad): Figure out why serde >= 1.0.72 breaks our Python build.
+serde = "=1.0.171"
 serde_json = "1.0.81"
 sha3 = "0.10.6"
 starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "8f620bc" }


### PR DESCRIPTION
Some changes made in `1.0.72` break our Python build, will investigate,
for now we don't anything higher than this.

Python: https://reviewable.io/reviews/starkware-industries/starkware/31211

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/813)
<!-- Reviewable:end -->
