### PR TITLE
Fix the Starknet spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@
 
 ## About
 
-Blockifier is a Rust implementation for the transaction-executing component in the StarkNet sequencer, in charge of creating state diffs and blocks.
+Blockifier is a Rust implementation for the transaction-executing component in the Starknet sequencer, in charge of creating state diffs and blocks.
 
 ## Roadmap
 
-The Blockifier will be a step towards a decentralized sequencer client for StarkNet, allowing anyone to run one.
+The Blockifier will be a step towards a decentralized sequencer client for Starknet, allowing anyone to run one.
 We'll add more milestones to this table once we finish the first one, where we blockify transactions sequentially, including all existing functionality.
 
 | name                                                                                                                                   | status |
 | -------------------------------------------------------------------------------------------------------------------------------------- | :----: |
 | Add the ability to execute a block and output a state diff.                                                                            |   ✅   |
-| Integrate with the existing StarkNet Sequencer by replacing its current transaction-blockifying component, which is written in Python. |   ⏳   |
+| Integrate with the existing Starknet Sequencer by replacing its current transaction-blockifying component, which is written in Python. |   ⏳   |
 | Implement optimistic concurrency of transaction execution.                                                                             |        |
-| Extend the Blockifier into a full StarkNet sequencer, written in Rust, replacing the one currently in use.                             |        |
+| Extend the Blockifier into a full Starknet sequencer, written in Rust, replacing the one currently in use.                             |        |
 
 ## Support
 


### PR DESCRIPTION
The official spelling is Starknet now. Fixed in README.