### PR TITLE
Attempt to fix coverage upload errors

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,5 +23,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
           fail_ci_if_error: true


### PR DESCRIPTION
Token isn't required for public repos (see https://github.com/taiki-e/cargo-llvm-cov/), which is why it wasn't added previously.

However, the following posts claims this fixes the upload errors for public repos: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954/3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/824)
<!-- Reviewable:end -->
