### PR TITLE
Refactor cache handling in `CachedState`

### DIFF
--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -98,6 +98,40 @@ impl<S: StateReader> CachedState<S> {
         })
     }
 
+    /// Drains contract-class cache collected during execution and updates the global cache.
+    pub fn move_classes_to_global_cache(&mut self) {
+        let contract_class_updates: Vec<_> = self.class_hash_to_class.drain().collect();
+        for (key, value) in contract_class_updates {
+            self.global_class_hash_to_class().cache_set(key, value);
+        }
+    }
+
+    // Locks the Mutex and unwraps the MutexGuard, thus exposing the internal cache
+    // store. The Guard will panic only if the Mutex panics during the lock operation, but
+    // this shouldn't happen in our flow.
+    // Note: `&mut` is used since the LRU cache updates internal counters on reads.
+    pub fn global_class_hash_to_class(
+        &mut self,
+    ) -> MutexGuard<'_, SizedCache<ClassHash, ContractClass>> {
+        self.global_class_hash_to_class.lock().expect("Global contract cache is poisoned.")
+    }
+
+    pub fn update_cache(&mut self, cache_updates: StateCache) {
+        self.cache.nonce_writes.extend(cache_updates.nonce_writes);
+        self.cache.class_hash_writes.extend(cache_updates.class_hash_writes);
+        self.cache.storage_writes.extend(cache_updates.storage_writes);
+        self.cache.compiled_class_hash_writes.extend(cache_updates.compiled_class_hash_writes);
+    }
+
+    pub fn update_contract_class_caches(
+        &mut self,
+        local_contract_cache_updates: ContractClassMapping,
+        global_contract_cache: GlobalContractCache,
+    ) {
+        self.class_hash_to_class.extend(local_contract_cache_updates);
+        self.global_class_hash_to_class = global_contract_cache;
+    }
+
     /// Updates cache with initial cell values for write-only access.
     /// If written values match the original, the cell is unchanged and not counted as a
     /// storage-change for fee calculation.
@@ -135,24 +169,6 @@ impl<S: StateReader> CachedState<S> {
         }
 
         Ok(())
-    }
-
-    /// Drains contract-class cache collected during execution and updates the global cache.
-    pub fn move_classes_to_global_cache(&mut self) {
-        let contract_class_updates: Vec<_> = self.class_hash_to_class.drain().collect();
-        for (key, value) in contract_class_updates {
-            self.global_class_hash_to_class().cache_set(key, value);
-        }
-    }
-
-    // Locks the Mutex and unwraps the MutexGuard, thus exposing the internal cache
-    // store. The Guard will panic only if the Mutex panics during the lock operation, but
-    // this shouldn't happen in our flow.
-    // Note: `&mut` is used since the LRU cache updates internal counters on reads.
-    pub fn global_class_hash_to_class(
-        &mut self,
-    ) -> MutexGuard<'_, SizedCache<ClassHash, ContractClass>> {
-        self.global_class_hash_to_class.lock().expect("Global contract cache is poisoned.")
     }
 }
 
@@ -357,7 +373,7 @@ impl From<StorageView> for IndexMap<ContractAddress, IndexMap<StorageKey, StarkF
 
 // Invariant: keys cannot be deleted from fields (only used internally by the cached state).
 #[derive(Debug, Default, PartialEq)]
-struct StateCache {
+pub struct StateCache {
     // Reader's cached information; initial values, read before any write operation (per cell).
     nonce_initial_values: HashMap<ContractAddress, Nonce>,
     class_hash_initial_values: HashMap<ContractAddress, ClassHash>,
@@ -566,15 +582,11 @@ pub type TransactionalState<'a, S> = CachedState<MutRefState<'a, CachedState<S>>
 impl<'a, S: StateReader> TransactionalState<'a, S> {
     /// Commits changes in the child (wrapping) state to its parent.
     pub fn commit(self) {
+        let state = self.state.0;
         let child_cache = self.cache;
-        let parent_cache = &mut self.state.0.cache;
-
-        parent_cache.nonce_writes.extend(child_cache.nonce_writes);
-        parent_cache.class_hash_writes.extend(child_cache.class_hash_writes);
-        parent_cache.storage_writes.extend(child_cache.storage_writes);
-        parent_cache.compiled_class_hash_writes.extend(child_cache.compiled_class_hash_writes);
-        self.state.0.class_hash_to_class.extend(self.class_hash_to_class);
-        self.state.0.global_class_hash_to_class = self.global_class_hash_to_class;
+        state.update_cache(child_cache);
+        state
+            .update_contract_class_caches(self.class_hash_to_class, self.global_class_hash_to_class)
     }
 
     /// Drops `self`.


### PR DESCRIPTION
- Move state cache-updating logic into a method `update_cache`. This will soon be used when we add an additional transactional state type. Consequently, `StateCache` is now public (since `update_cache` is part of the public API).
- Move local and global contract cache into a method `update_contract_class_caches`, for the same reason as the above.
- Code convention fix: move the private method `update_initial_values_of_write_only_access` to the bottom of the `impl` block.
This is why `move_classes_to_global_cache` and `global_class_hash_to_class` appear in the diff, they were hoisted up above `update_initial_values_of_write_only_access`(but were not changed).

Context: getting ready for removing the python callback in `native_blockifier`. 
This will require a different type of `TransactionalState` (without a lifetime, because of Pyo3), so the current change prevents duplicated code in its `commit` stage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/838)
<!-- Reviewable:end -->
