### PR TITLE
Remove python bouncer callback from `native_blockifier`

### DIFF
--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -580,6 +580,18 @@ pub type TransactionalState<'a, S> = CachedState<MutRefState<'a, CachedState<S>>
 
 /// Adds the ability to perform a transactional execution.
 impl<'a, S: StateReader> TransactionalState<'a, S> {
+    // Detach `state`, moving the instance to a pending state, which can be committed or aborted.
+    pub fn stage(self, tx_executed_class_hashes: HashSet<ClassHash>) -> StagedTransactionalState {
+        let TransactionalState { cache, class_hash_to_class, global_class_hash_to_class, .. } =
+            self;
+        StagedTransactionalState {
+            cache,
+            class_hash_to_class,
+            global_class_hash_to_class,
+            tx_executed_class_hashes,
+        }
+    }
+
     /// Commits changes in the child (wrapping) state to its parent.
     pub fn commit(self) {
         let state = self.state.0;
@@ -591,6 +603,16 @@ impl<'a, S: StateReader> TransactionalState<'a, S> {
 
     /// Drops `self`.
     pub fn abort(self) {}
+}
+
+/// Represents the interim state, containing the changes made by a transaction after execution but
+/// before commitment to the state. Can be passed to external services that validate and count
+/// resources to decide whether the transaction should be committed or aborted.
+pub struct StagedTransactionalState {
+    pub cache: StateCache,
+    pub class_hash_to_class: ContractClassMapping,
+    pub global_class_hash_to_class: GlobalContractCache,
+    pub tx_executed_class_hashes: HashSet<ClassHash>,
 }
 
 /// Holds uncommitted changes induced on StarkNet contracts.

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -76,15 +76,13 @@ impl PyBlockExecutor {
         self.tx_executor = None;
     }
 
-    #[pyo3(signature = (tx, raw_contract_class, enough_room_for_tx))]
+    #[pyo3(signature = (tx, raw_contract_class))]
     pub fn execute(
         &mut self,
         tx: &PyAny,
         raw_contract_class: Option<&str>,
-        // This is functools.partial(bouncer.add, tw_written=tx_written).
-        enough_room_for_tx: &PyAny,
-    ) -> NativeBlockifierResult<(Py<PyTransactionExecutionInfo>, PyVmExecutionResources)> {
-        self.tx_executor().execute(tx, raw_contract_class, enough_room_for_tx)
+    ) -> NativeBlockifierResult<(PyTransactionExecutionInfo, PyVmExecutionResources)> {
+        self.tx_executor().execute(tx, raw_contract_class)
     }
 
     pub fn finalize(&mut self, is_pending_block: bool) -> PyStateDiff {
@@ -101,6 +99,14 @@ impl PyBlockExecutor {
         old_block_number_and_hash: Option<(u64, PyFelt)>,
     ) -> NativeBlockifierResult<()> {
         self.tx_executor().pre_process_block(old_block_number_and_hash)
+    }
+
+    pub fn commit_tx(&mut self) {
+        self.tx_executor().commit()
+    }
+
+    pub fn abort_tx(&mut self) {
+        self.tx_executor().abort()
     }
 
     // Storage Alignment API.


### PR DESCRIPTION
- Removed `enough_room_for_tx`, a Python bouncer callback, allowing PyTransactionExecutionInfo to be allocated in Rust, rather than on the Python heap (so it is no longer of type `Py<PyTransactionExecutionInfo>`, just `PyTransactionExecutionInfo`). Also, now no longer need specialized Python exception handling, since we are no longer running Python code.
- Added new API to block-executor to replace the callback: `commit_tx` and `abort_tx`, which Python calls after getting the results from the bouncer.
- Added `StagedTransactionalState`, which represents a TransactionalState after the transaction has finished executing. Thus, it only holds the results of the exeuction that are subject to be commited to the state, or the set of executed class hashes. There is still a bit of duplication between it's commit/abort and the ones in `TransactionalState`, but this will be hard to refactor, since the commit here must use `&mut self`, while in `TransactionalState` they consume self.

Python (includes test): https://reviewable.io/reviews/starkware-industries/starkware/31464

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/839)
<!-- Reviewable:end -->
