### PR TITLE
Temporarily adding DataAvailabilityMode enum until bumping starknet_a…

### DIFF
--- a/crates/blockifier/src/state/state_api.rs
+++ b/crates/blockifier/src/state/state_api.rs
@@ -10,6 +10,12 @@ use crate::state::errors::StateError;
 
 pub type StateResult<T> = Result<T, StateError>;
 
+// TODO(barak, 01/10/2023): Remove this enum from here once it can be used from starknet_api.
+pub enum DataAvailabilityMode {
+    L1 = 0,
+    L2 = 1,
+}
+
 /// A read-only API for accessing StarkNet global state.
 ///
 /// The `self` argument is mutable for flexibility during reads (for example, caching reads),


### PR DESCRIPTION
…pi crate version so we can use it from there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/841)
<!-- Reviewable:end -->
