### PR TITLE
Make `charge_fee` optional in `native_blockifier` execution

### DIFF
--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -88,7 +88,8 @@ impl PyBlockExecutor {
         tx: &PyAny,
         raw_contract_class: Option<&str>,
     ) -> NativeBlockifierResult<(PyTransactionExecutionInfo, PyVmExecutionResources)> {
-        self.tx_executor().execute(tx, raw_contract_class)
+        let charge_fee = true;
+        self.tx_executor().execute(tx, raw_contract_class, charge_fee)
     }
 
     pub fn finalize(&mut self, is_pending_block: bool) -> PyStateDiff {

--- a/crates/native_blockifier/src/transaction_executor.rs
+++ b/crates/native_blockifier/src/transaction_executor.rs
@@ -59,13 +59,13 @@ impl<S: StateReader> TransactionExecutor<S> {
         &mut self,
         tx: &PyAny,
         raw_contract_class: Option<&str>,
+        charge_fee: bool,
     ) -> NativeBlockifierResult<(PyTransactionExecutionInfo, PyVmExecutionResources)> {
         let tx_type: String = py_enum_name(tx, "tx_type")?;
         let tx: Transaction = py_tx(&tx_type, tx, raw_contract_class)?;
 
         let mut tx_executed_class_hashes = HashSet::<ClassHash>::new();
         let mut transactional_state = CachedState::create_transactional(&mut self.state);
-        let charge_fee = true;
         let validate = true;
         let tx_execution_result = tx
             .execute_raw(&mut transactional_state, &self.block_context, charge_fee, validate)


### PR DESCRIPTION
Sets the stage for the upcoming addition of `validate` to the `TransactionExecutor` api.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/859)
<!-- Reviewable:end -->
