### PR TITLE
account_transaction - formatting

### DIFF
--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -53,47 +53,6 @@ pub enum AccountTransaction {
     Invoke(InvokeTransaction),
 }
 
-/// Represents a bundle of validate-execute stage execution effects.
-struct ValidateExecuteCallInfo {
-    validate_call_info: Option<CallInfo>,
-    execute_call_info: Option<CallInfo>,
-    revert_error: Option<String>,
-    final_fee: Fee,
-    final_resources: ResourcesMapping,
-}
-
-impl ValidateExecuteCallInfo {
-    pub fn new_accepted(
-        validate_call_info: Option<CallInfo>,
-        execute_call_info: Option<CallInfo>,
-        final_fee: Fee,
-        final_resources: ResourcesMapping,
-    ) -> Self {
-        Self {
-            validate_call_info,
-            execute_call_info,
-            revert_error: None,
-            final_fee,
-            final_resources,
-        }
-    }
-
-    pub fn new_reverted(
-        validate_call_info: Option<CallInfo>,
-        revert_error: String,
-        final_fee: Fee,
-        final_resources: ResourcesMapping,
-    ) -> Self {
-        Self {
-            validate_call_info,
-            execute_call_info: None,
-            revert_error: Some(revert_error),
-            final_fee,
-            final_resources,
-        }
-    }
-}
-
 impl AccountTransaction {
     pub fn tx_type(&self) -> TransactionType {
         match self {
@@ -781,5 +740,46 @@ impl<S: StateReader> ExecutableTransaction<S> for AccountTransaction {
             revert_error,
         };
         Ok(tx_execution_info)
+    }
+}
+
+/// Represents a bundle of validate-execute stage execution effects.
+struct ValidateExecuteCallInfo {
+    validate_call_info: Option<CallInfo>,
+    execute_call_info: Option<CallInfo>,
+    revert_error: Option<String>,
+    final_fee: Fee,
+    final_resources: ResourcesMapping,
+}
+
+impl ValidateExecuteCallInfo {
+    pub fn new_accepted(
+        validate_call_info: Option<CallInfo>,
+        execute_call_info: Option<CallInfo>,
+        final_fee: Fee,
+        final_resources: ResourcesMapping,
+    ) -> Self {
+        Self {
+            validate_call_info,
+            execute_call_info,
+            revert_error: None,
+            final_fee,
+            final_resources,
+        }
+    }
+
+    pub fn new_reverted(
+        validate_call_info: Option<CallInfo>,
+        revert_error: String,
+        final_fee: Fee,
+        final_resources: ResourcesMapping,
+    ) -> Self {
+        Self {
+            validate_call_info,
+            execute_call_info: None,
+            revert_error: Some(revert_error),
+            final_fee,
+            final_resources,
+        }
     }
 }


### PR DESCRIPTION
`impl Account Transaction` should appear after the struct definition; `ValidateExecuteCallInfo` was in the way.
Moved it down, cause it isn't important enough to be up top. No other changes, just move.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/871)
<!-- Reviewable:end -->
