### PR TITLE
Make get_fee_token_balance consider transaction version

### DIFF
--- a/crates/blockifier/src/block_context.rs
+++ b/crates/blockifier/src/block_context.rs
@@ -12,8 +12,7 @@ pub struct BlockContext {
 
     // Fee-related.
     pub sequencer_address: ContractAddress,
-    pub deprecated_fee_token_address: ContractAddress,
-    pub fee_token_address: ContractAddress,
+    pub fee_token_addresses: FeeTokenAddresses,
     pub vm_resource_fee_cost: Arc<HashMap<String, f64>>,
     pub eth_l1_gas_price: u128, // In wei.
     // TODO(Amos, 01/09/2023): NEW_TOKEN_SUPPORT use this gas price for V3 txs.
@@ -23,4 +22,10 @@ pub struct BlockContext {
     pub invoke_tx_max_n_steps: u32,
     pub validate_max_n_steps: u32,
     pub max_recursion_depth: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct FeeTokenAddresses {
+    pub fee_token_address: ContractAddress,
+    pub deprecated_fee_token_address: ContractAddress,
 }

--- a/crates/blockifier/src/block_context.rs
+++ b/crates/blockifier/src/block_context.rs
@@ -3,6 +3,10 @@ use std::sync::Arc;
 
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::core::{ChainId, ContractAddress};
+use starknet_api::hash::StarkFelt;
+use starknet_api::transaction::TransactionVersion;
+
+use crate::transaction::objects::HasTransactionVersion;
 
 #[derive(Clone, Debug)]
 pub struct BlockContext {
@@ -24,8 +28,24 @@ pub struct BlockContext {
     pub max_recursion_depth: usize,
 }
 
+impl BlockContext {
+    pub fn fee_token_address(&self, version: &dyn HasTransactionVersion) -> ContractAddress {
+        self.fee_token_addresses.get_for_version(version)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct FeeTokenAddresses {
     pub fee_token_address: ContractAddress,
     pub deprecated_fee_token_address: ContractAddress,
+}
+
+impl FeeTokenAddresses {
+    pub fn get_for_version(&self, has_version: &dyn HasTransactionVersion) -> ContractAddress {
+        if has_version.version() >= TransactionVersion(StarkFelt::from(3_u128)) {
+            self.fee_token_address
+        } else {
+            self.deprecated_fee_token_address
+        }
+    }
 }

--- a/crates/blockifier/src/block_context.rs
+++ b/crates/blockifier/src/block_context.rs
@@ -36,16 +36,16 @@ impl BlockContext {
 
 #[derive(Clone, Debug)]
 pub struct FeeTokenAddresses {
-    pub fee_token_address: ContractAddress,
-    pub deprecated_fee_token_address: ContractAddress,
+    pub strk_fee_token_address: ContractAddress,
+    pub eth_fee_token_address: ContractAddress,
 }
 
 impl FeeTokenAddresses {
     pub fn get_for_version(&self, has_version: &dyn HasTransactionVersion) -> ContractAddress {
         if has_version.version() >= TransactionVersion(StarkFelt::from(3_u128)) {
-            self.fee_token_address
+            self.strk_fee_token_address
         } else {
-            self.deprecated_fee_token_address
+            self.eth_fee_token_address
         }
     }
 }

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -306,7 +306,7 @@ fn test_state_changes_merge() {
     let mut state: CachedState<DictStateReader> = CachedState::default();
     let mut transactional_state = CachedState::create_transactional(&mut state);
     let block_context = BlockContext::create_for_testing();
-    let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+    let fee_token_address = block_context.fee_token_addresses.eth_fee_token_address;
     let state_changes1 = create_state_changes_for_test(&mut transactional_state, fee_token_address);
     transactional_state.commit();
 

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -306,7 +306,7 @@ fn test_state_changes_merge() {
     let mut state: CachedState<DictStateReader> = CachedState::default();
     let mut transactional_state = CachedState::create_transactional(&mut state);
     let block_context = BlockContext::create_for_testing();
-    let fee_token_address = block_context.deprecated_fee_token_address;
+    let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
     let state_changes1 = create_state_changes_for_test(&mut transactional_state, fee_token_address);
     transactional_state.commit();
 

--- a/crates/blockifier/src/state/state_api.rs
+++ b/crates/blockifier/src/state/state_api.rs
@@ -56,8 +56,14 @@ pub trait StateReader {
         contract_address: &ContractAddress,
     ) -> Result<(StarkFelt, StarkFelt), StateError> {
         let (low_key, high_key) = get_erc20_balance_var_addresses(contract_address)?;
-        let low = self.get_storage_at(block_context.deprecated_fee_token_address, low_key)?;
-        let high = self.get_storage_at(block_context.deprecated_fee_token_address, high_key)?;
+        let low = self.get_storage_at(
+            block_context.fee_token_addresses.deprecated_fee_token_address,
+            low_key,
+        )?;
+        let high = self.get_storage_at(
+            block_context.fee_token_addresses.deprecated_fee_token_address,
+            high_key,
+        )?;
 
         Ok((low, high))
     }

--- a/crates/blockifier/src/state/state_api.rs
+++ b/crates/blockifier/src/state/state_api.rs
@@ -3,7 +3,6 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 
 use crate::abi::abi_utils::get_erc20_balance_var_addresses;
-use crate::block_context::BlockContext;
 use crate::execution::contract_class::ContractClass;
 use crate::state::cached_state::CommitmentStateDiff;
 use crate::state::errors::StateError;
@@ -52,18 +51,12 @@ pub trait StateReader {
     //   once v3 is introduced.
     fn get_fee_token_balance(
         &mut self,
-        block_context: &BlockContext,
         contract_address: &ContractAddress,
+        fee_token_address: &ContractAddress,
     ) -> Result<(StarkFelt, StarkFelt), StateError> {
         let (low_key, high_key) = get_erc20_balance_var_addresses(contract_address)?;
-        let low = self.get_storage_at(
-            block_context.fee_token_addresses.deprecated_fee_token_address,
-            low_key,
-        )?;
-        let high = self.get_storage_at(
-            block_context.fee_token_addresses.deprecated_fee_token_address,
-            high_key,
-        )?;
+        let low = self.get_storage_at(*fee_token_address, low_key)?;
+        let high = self.get_storage_at(*fee_token_address, high_key)?;
 
         Ok((low, high))
     }

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -27,7 +27,7 @@ use starknet_api::{calldata, class_hash, contract_address, patricia_key, stark_f
 
 use crate::abi::abi_utils::get_storage_var_address;
 use crate::abi::constants;
-use crate::block_context::BlockContext;
+use crate::block_context::{BlockContext, FeeTokenAddresses};
 use crate::execution::call_info::{CallExecution, CallInfo, Retdata};
 use crate::execution::contract_class::{ContractClass, ContractClassV0, ContractClassV1};
 use crate::execution::entry_point::{
@@ -343,8 +343,10 @@ impl BlockContext {
             block_number: BlockNumber(CURRENT_BLOCK_NUMBER),
             block_timestamp: BlockTimestamp::default(),
             sequencer_address: contract_address!(TEST_SEQUENCER_ADDRESS),
-            deprecated_fee_token_address: contract_address!(TEST_ERC20_CONTRACT_ADDRESS),
-            fee_token_address: contract_address!(TEST_ERC20_CONTRACT_ADDRESS2),
+            fee_token_addresses: FeeTokenAddresses {
+                deprecated_fee_token_address: contract_address!(TEST_ERC20_CONTRACT_ADDRESS),
+                fee_token_address: contract_address!(TEST_ERC20_CONTRACT_ADDRESS2),
+            },
             vm_resource_fee_cost: Default::default(),
             eth_l1_gas_price: DEFAULT_ETH_L1_GAS_PRICE,
             strk_l1_gas_price: DEFAULT_STRK_L1_GAS_PRICE,

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -344,8 +344,8 @@ impl BlockContext {
             block_timestamp: BlockTimestamp::default(),
             sequencer_address: contract_address!(TEST_SEQUENCER_ADDRESS),
             fee_token_addresses: FeeTokenAddresses {
-                deprecated_fee_token_address: contract_address!(TEST_ERC20_CONTRACT_ADDRESS),
-                fee_token_address: contract_address!(TEST_ERC20_CONTRACT_ADDRESS2),
+                eth_fee_token_address: contract_address!(TEST_ERC20_CONTRACT_ADDRESS),
+                strk_fee_token_address: contract_address!(TEST_ERC20_CONTRACT_ADDRESS2),
             },
             vm_resource_fee_cost: Default::default(),
             eth_l1_gas_price: DEFAULT_ETH_L1_GAS_PRICE,

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -305,8 +305,10 @@ impl AccountTransaction {
                 });
             }
 
-            let (balance_low, balance_high) =
-                state.get_fee_token_balance(block_context, &account_tx_context.sender_address)?;
+            let (balance_low, balance_high) = state.get_fee_token_balance(
+                &account_tx_context.sender_address,
+                &block_context.fee_token_address(&account_tx_context),
+            )?;
             if !Self::is_sufficient_fee_balance(balance_low, balance_high, max_fee) {
                 return Err(TransactionExecutionError::MaxFeeExceedsBalance {
                     max_fee,
@@ -526,8 +528,10 @@ impl AccountTransaction {
 
                 // Check if as a result of tx execution the sender's fee token balance is maxed out,
                 // so that they can't pay fee. If so, the transaction must be reverted.
-                let (balance_low, balance_high) = execution_state
-                    .get_fee_token_balance(block_context, &account_tx_context.sender_address)?;
+                let (balance_low, balance_high) = execution_state.get_fee_token_balance(
+                    &account_tx_context.sender_address,
+                    &block_context.fee_token_address(&account_tx_context),
+                )?;
                 let is_maxed_out =
                     !Self::is_sufficient_fee_balance(balance_low, balance_high, actual_fee);
                 let max_fee = account_tx_context.max_fee;

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -356,7 +356,7 @@ impl AccountTransaction {
         let msb_amount = StarkFelt::from(0_u8);
 
         // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT address depends on tx version.
-        let storage_address = block_context.deprecated_fee_token_address;
+        let storage_address = block_context.fee_token_addresses.deprecated_fee_token_address;
         let fee_transfer_call = CallEntryPoint {
             class_hash: None,
             code_address: None,
@@ -406,7 +406,7 @@ impl AccountTransaction {
         let validate_call_info: Option<CallInfo>;
         let execute_call_info: Option<CallInfo>;
         // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT fee address depends on tx version.
-        let fee_token_address = block_context.deprecated_fee_token_address;
+        let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
         if matches!(self, Self::DeployAccount(_)) {
             // Handle `DeployAccount` transactions separately, due to different order of things.
             execute_call_info =
@@ -451,7 +451,7 @@ impl AccountTransaction {
     ) -> TransactionExecutionResult<ValidateExecuteCallInfo> {
         let account_tx_context = self.get_account_transaction_context();
         // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT fee address depends on tx version.
-        let fee_token_address = block_context.deprecated_fee_token_address;
+        let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
         // Run the validation, and if execution later fails, only keep the validation diff.
         let validate_call_info =
             self.handle_validate_tx(state, resources, remaining_gas, block_context, validate)?;

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -358,7 +358,7 @@ impl AccountTransaction {
         let msb_amount = StarkFelt::from(0_u8);
 
         // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT address depends on tx version.
-        let storage_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+        let storage_address = block_context.fee_token_addresses.eth_fee_token_address;
         let fee_transfer_call = CallEntryPoint {
             class_hash: None,
             code_address: None,
@@ -408,7 +408,7 @@ impl AccountTransaction {
         let validate_call_info: Option<CallInfo>;
         let execute_call_info: Option<CallInfo>;
         // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT fee address depends on tx version.
-        let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+        let fee_token_address = block_context.fee_token_addresses.eth_fee_token_address;
         if matches!(self, Self::DeployAccount(_)) {
             // Handle `DeployAccount` transactions separately, due to different order of things.
             execute_call_info =
@@ -453,7 +453,7 @@ impl AccountTransaction {
     ) -> TransactionExecutionResult<ValidateExecuteCallInfo> {
         let account_tx_context = self.get_account_transaction_context();
         // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT fee address depends on tx version.
-        let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+        let fee_token_address = block_context.fee_token_addresses.eth_fee_token_address;
         // Run the validation, and if execution later fails, only keep the validation diff.
         let validate_call_info =
             self.handle_validate_tx(state, resources, remaining_gas, block_context, validate)?;

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -64,7 +64,7 @@ fn create_state(block_context: BlockContext) -> CachedState<DictStateReader> {
     ]);
     // Deploy the erc20 contract.
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT consider deploying and using an extra token.
-    let test_erc20_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+    let test_erc20_address = block_context.fee_token_addresses.eth_fee_token_address;
     let address_to_class_hash = HashMap::from([(test_erc20_address, test_erc20_class_hash)]);
 
     CachedState::from(DictStateReader {
@@ -83,7 +83,7 @@ fn create_test_init_data(
     let mut nonce_manager = NonceManager::default();
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT this token should depend on the versions of txs
     //   used to init.
-    let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+    let fee_token_address = block_context.fee_token_addresses.eth_fee_token_address;
 
     // Deploy an account contract.
     let deploy_account_tx = deploy_account_tx(
@@ -288,7 +288,7 @@ fn test_revert_invoke(
 ) {
     let mut nonce_manager = NonceManager::default();
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT this token should depend on the tx version.
-    let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+    let fee_token_address = block_context.fee_token_addresses.eth_fee_token_address;
     // Deploy an account contract.
     let deploy_account_tx = deploy_account_tx(
         TEST_ACCOUNT_CONTRACT_CLASS_HASH,
@@ -407,7 +407,7 @@ fn test_fail_declare(max_fee: Fee, #[from(create_test_init_data)] init_data: Tes
     let TestInitData { mut state, account_address, mut nonce_manager, block_context, .. } =
         init_data;
     let class_hash = class_hash!(0xdeadeadeaf72_u128);
-    let tx_version = TransactionVersion(stark_felt!(1_u8));
+    let tx_version = TransactionVersion(stark_felt!(2_u8));
     let contract_class = ContractClass::V1(ContractClassV1::default());
     let initial_balance = state
         .get_fee_token_balance(&account_address, &block_context.fee_token_address(&tx_version))
@@ -815,7 +815,7 @@ fn write_and_transfer(
     state: &mut CachedState<DictStateReader>,
 ) -> TransactionExecutionInfo {
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT this token should depend on the tx version.
-    let fee_token_address = *block_context.fee_token_addresses.deprecated_fee_token_address.0.key();
+    let fee_token_address = *block_context.fee_token_addresses.eth_fee_token_address.0.key();
     let execute_calldata = calldata![
         *test_contract_address.0.key(),                  // Contract address.
         selector_from_name("test_write_and_transfer").0, // EP selector.
@@ -839,7 +839,7 @@ fn test_revert_on_overdraft(
     #[from(create_state)] state: CachedState<DictStateReader>,
 ) {
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT this token should depend on the tx version.
-    let fee_token_address = *block_context.fee_token_addresses.deprecated_fee_token_address.0.key();
+    let fee_token_address = *block_context.fee_token_addresses.eth_fee_token_address.0.key();
     // An address to be written into to observe state changes.
     let storage_address = stark_felt!(10_u8);
     let storage_key = StorageKey::try_from(storage_address).unwrap();

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -64,7 +64,7 @@ fn create_state(block_context: BlockContext) -> CachedState<DictStateReader> {
     ]);
     // Deploy the erc20 contract.
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT consider deploying and using an extra token.
-    let test_erc20_address = block_context.deprecated_fee_token_address;
+    let test_erc20_address = block_context.fee_token_addresses.deprecated_fee_token_address;
     let address_to_class_hash = HashMap::from([(test_erc20_address, test_erc20_class_hash)]);
 
     CachedState::from(DictStateReader {
@@ -83,7 +83,7 @@ fn create_test_init_data(
     let mut nonce_manager = NonceManager::default();
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT this token should depend on the versions of txs
     //   used to init.
-    let fee_token_address = block_context.deprecated_fee_token_address;
+    let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
 
     // Deploy an account contract.
     let deploy_account_tx = deploy_account_tx(
@@ -288,7 +288,7 @@ fn test_revert_invoke(
 ) {
     let mut nonce_manager = NonceManager::default();
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT this token should depend on the tx version.
-    let fee_token_address = block_context.deprecated_fee_token_address;
+    let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
     // Deploy an account contract.
     let deploy_account_tx = deploy_account_tx(
         TEST_ACCOUNT_CONTRACT_CLASS_HASH,
@@ -790,7 +790,7 @@ fn write_and_transfer(
     state: &mut CachedState<DictStateReader>,
 ) -> TransactionExecutionInfo {
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT this token should depend on the tx version.
-    let fee_token_address = *block_context.deprecated_fee_token_address.0.key();
+    let fee_token_address = *block_context.fee_token_addresses.deprecated_fee_token_address.0.key();
     let execute_calldata = calldata![
         *test_contract_address.0.key(),                  // Contract address.
         selector_from_name("test_write_and_transfer").0, // EP selector.
@@ -814,7 +814,7 @@ fn test_revert_on_overdraft(
     #[from(create_state)] state: CachedState<DictStateReader>,
 ) {
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT this token should depend on the tx version.
-    let fee_token_address = *block_context.deprecated_fee_token_address.0.key();
+    let fee_token_address = *block_context.fee_token_addresses.deprecated_fee_token_address.0.key();
     // An address to be written into to observe state changes.
     let storage_address = stark_felt!(10_u8);
     let storage_key = StorageKey::try_from(storage_address).unwrap();

--- a/crates/blockifier/src/transaction/objects.rs
+++ b/crates/blockifier/src/transaction/objects.rs
@@ -28,6 +28,12 @@ impl AccountTransactionContext {
     }
 }
 
+impl HasTransactionVersion for AccountTransactionContext {
+    fn version(&self) -> TransactionVersion {
+        self.version
+    }
+}
+
 /// Contains the information gathered by the execution of a transaction.
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct TransactionExecutionInfo {
@@ -76,3 +82,13 @@ impl TransactionExecutionInfo {
 /// A mapping from a transaction execution resource to its actual usage.
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct ResourcesMapping(pub HashMap<String, usize>);
+
+pub trait HasTransactionVersion {
+    fn version(&self) -> TransactionVersion;
+}
+
+impl HasTransactionVersion for TransactionVersion {
+    fn version(&self) -> TransactionVersion {
+        *self
+    }
+}

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -66,7 +66,7 @@ pub fn create_account_tx_test_state(
     // address.
     let test_account_address = contract_address!(account_address);
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT add another fee token to the initial state.
-    let test_erc20_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+    let test_erc20_address = block_context.fee_token_addresses.eth_fee_token_address;
     let address_to_class_hash = HashMap::from([
         (test_contract_address, test_contract_class_hash),
         (test_account_address, test_account_class_hash),

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -66,7 +66,7 @@ pub fn create_account_tx_test_state(
     // address.
     let test_account_address = contract_address!(account_address);
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT add another fee token to the initial state.
-    let test_erc20_address = block_context.deprecated_fee_token_address;
+    let test_erc20_address = block_context.fee_token_addresses.deprecated_fee_token_address;
     let address_to_class_hash = HashMap::from([
         (test_contract_address, test_contract_class_hash),
         (test_account_address, test_account_class_hash),

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -94,7 +94,7 @@ impl<S: StateReader> ExecutableTransaction<S> for L1HandlerTransaction {
         _validate: bool,
     ) -> TransactionExecutionResult<TransactionExecutionInfo> {
         // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT token address should depend on tx version.
-        let fee_token_address = block_context.deprecated_fee_token_address;
+        let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
         let tx = &self.tx;
         let tx_context = AccountTransactionContext {
             transaction_hash: self.tx_hash,

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -94,7 +94,7 @@ impl<S: StateReader> ExecutableTransaction<S> for L1HandlerTransaction {
         _validate: bool,
     ) -> TransactionExecutionResult<TransactionExecutionInfo> {
         // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT token address should depend on tx version.
-        let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+        let fee_token_address = block_context.fee_token_addresses.eth_fee_token_address;
         let tx = &self.tx;
         let tx_context = AccountTransactionContext {
             transaction_hash: self.tx_hash,

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -12,7 +12,7 @@ use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::{
     Calldata, DeclareTransactionV0V1, DeclareTransactionV2, EventContent, EventData, EventKey, Fee,
-    InvokeTransactionV1, TransactionHash, TransactionSignature,
+    InvokeTransactionV1, TransactionHash, TransactionSignature, TransactionVersion,
 };
 use starknet_api::{calldata, class_hash, contract_address, patricia_key, stark_felt};
 use test_case::test_case;
@@ -433,8 +433,12 @@ fn test_state_get_fee_token_balance(state: &mut CachedState<DictStateReader>) {
     AccountTransaction::Invoke(mint_tx.into()).execute(state, block_context, true, true).unwrap();
 
     // Get balance from state, and validate.
-    let (low, high) =
-        state.get_fee_token_balance(block_context, &contract_address!(recipient)).unwrap();
+    let (low, high) = state
+        .get_fee_token_balance(
+            &contract_address!(recipient),
+            &block_context.fee_token_address(&TransactionVersion(stark_felt!(1_u8))),
+        )
+        .unwrap();
 
     assert_eq!(low, mint_low);
     assert_eq!(high, mint_high);

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -149,7 +149,7 @@ fn expected_fee_transfer_call_info(
     // The most significant 128 bits of the expected amount transferred.
     let msb_expected_amount = stark_felt!(0_u8);
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT storage address should depend on tx version(s).
-    let storage_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+    let storage_address = block_context.fee_token_addresses.eth_fee_token_address;
     let expected_fee_transfer_call = CallEntryPoint {
         class_hash: Some(expected_fee_token_class_hash),
         code_address: None,
@@ -223,7 +223,7 @@ fn validate_final_balances(
 ) {
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT this function should probably accept fee token
     //   address (or at least, tx version) as input.
-    let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+    let fee_token_address = block_context.fee_token_addresses.eth_fee_token_address;
     let account_balance =
         state.get_storage_at(fee_token_address, erc20_account_balance_key).unwrap();
     assert_eq!(account_balance, stark_felt!(expected_account_balance));
@@ -764,7 +764,7 @@ fn test_deploy_account_tx(
 ) {
     let block_context = &BlockContext::create_for_account_testing();
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT fee token address should depend on tx version.
-    let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+    let fee_token_address = block_context.fee_token_addresses.eth_fee_token_address;
     let mut nonce_manager = NonceManager::default();
     let deploy_account =
         deploy_account_tx(TEST_ACCOUNT_CONTRACT_CLASS_HASH, None, None, &mut nonce_manager);
@@ -966,7 +966,7 @@ fn test_calculate_tx_gas_usage() {
     let state = &mut create_state_with_trivial_validation_account();
     let block_context = &BlockContext::create_for_account_testing();
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT fee token address should depend on tx version.
-    let fee_token_address = *block_context.fee_token_addresses.deprecated_fee_token_address.0.key();
+    let fee_token_address = *block_context.fee_token_addresses.eth_fee_token_address.0.key();
 
     let invoke_tx = invoke_tx();
     let account_tx = AccountTransaction::Invoke(invoke_tx.into());

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -149,7 +149,7 @@ fn expected_fee_transfer_call_info(
     // The most significant 128 bits of the expected amount transferred.
     let msb_expected_amount = stark_felt!(0_u8);
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT storage address should depend on tx version(s).
-    let storage_address = block_context.deprecated_fee_token_address;
+    let storage_address = block_context.fee_token_addresses.deprecated_fee_token_address;
     let expected_fee_transfer_call = CallEntryPoint {
         class_hash: Some(expected_fee_token_class_hash),
         code_address: None,
@@ -223,7 +223,7 @@ fn validate_final_balances(
 ) {
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT this function should probably accept fee token
     //   address (or at least, tx version) as input.
-    let fee_token_address = block_context.deprecated_fee_token_address;
+    let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
     let account_balance =
         state.get_storage_at(fee_token_address, erc20_account_balance_key).unwrap();
     assert_eq!(account_balance, stark_felt!(expected_account_balance));
@@ -760,7 +760,7 @@ fn test_deploy_account_tx(
 ) {
     let block_context = &BlockContext::create_for_account_testing();
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT fee token address should depend on tx version.
-    let fee_token_address = block_context.deprecated_fee_token_address;
+    let fee_token_address = block_context.fee_token_addresses.deprecated_fee_token_address;
     let mut nonce_manager = NonceManager::default();
     let deploy_account =
         deploy_account_tx(TEST_ACCOUNT_CONTRACT_CLASS_HASH, None, None, &mut nonce_manager);
@@ -962,7 +962,7 @@ fn test_calculate_tx_gas_usage() {
     let state = &mut create_state_with_trivial_validation_account();
     let block_context = &BlockContext::create_for_account_testing();
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT fee token address should depend on tx version.
-    let fee_token_address = *block_context.deprecated_fee_token_address.0.key();
+    let fee_token_address = *block_context.fee_token_addresses.deprecated_fee_token_address.0.key();
 
     let invoke_tx = invoke_tx();
     let account_tx = AccountTransaction::Invoke(invoke_tx.into());

--- a/crates/native_blockifier/bench/blockifier_bench.rs
+++ b/crates/native_blockifier/bench/blockifier_bench.rs
@@ -43,7 +43,7 @@ fn create_state() -> CachedState<DictStateReader> {
         (test_erc20_class_hash, ContractClassV0::from_file(ERC20_CONTRACT_PATH).into()),
     ]);
     // Deploy the ERC20 contract.
-    let test_erc20_address = block_context.fee_token_addresses.deprecated_fee_token_address;
+    let test_erc20_address = block_context.fee_token_addresses.eth_fee_token_address;
     let address_to_class_hash = HashMap::from([(test_erc20_address, test_erc20_class_hash)]);
 
     CachedState::from(DictStateReader {
@@ -85,7 +85,9 @@ fn do_transfer(
 
     let entry_point_selector =
         selector_from_name(blockifier::transaction::constants::TRANSFER_ENTRY_POINT_NAME);
-    let contract_address = *block_context.fee_token_addresses.deprecated_fee_token_address.0.key();
+    // TODO(gilad, 06/09/2023): NEW_TOKEN_SUPPORT this should depend the version of invoke tx.
+    let contract_address = *block_context.fee_token_addresses.eth_fee_token_address.0.key();
+
     let execute_calldata = calldata![
         contract_address,                   // Contract address.
         entry_point_selector.0,             // EP selector.
@@ -141,7 +143,7 @@ fn prepare_accounts(
             get_storage_var_address("ERC20_balances", &[*deployed_account_address.0.key()])
                 .unwrap();
         state.set_storage_at(
-            block_context.fee_token_addresses.deprecated_fee_token_address,
+            block_context.fee_token_addresses.eth_fee_token_address,
             deployed_account_balance_key,
             stark_felt!(BALANCE * 1000),
         );

--- a/crates/native_blockifier/bench/blockifier_bench.rs
+++ b/crates/native_blockifier/bench/blockifier_bench.rs
@@ -43,7 +43,7 @@ fn create_state() -> CachedState<DictStateReader> {
         (test_erc20_class_hash, ContractClassV0::from_file(ERC20_CONTRACT_PATH).into()),
     ]);
     // Deploy the ERC20 contract.
-    let test_erc20_address = block_context.deprecated_fee_token_address;
+    let test_erc20_address = block_context.fee_token_addresses.deprecated_fee_token_address;
     let address_to_class_hash = HashMap::from([(test_erc20_address, test_erc20_class_hash)]);
 
     CachedState::from(DictStateReader {
@@ -85,13 +85,14 @@ fn do_transfer(
 
     let entry_point_selector =
         selector_from_name(blockifier::transaction::constants::TRANSFER_ENTRY_POINT_NAME);
+    let contract_address = *block_context.fee_token_addresses.deprecated_fee_token_address.0.key();
     let execute_calldata = calldata![
-        *block_context.deprecated_fee_token_address.0.key(), // Contract address.
-        entry_point_selector.0,                              // EP selector.
-        stark_felt!(3_u8),                                   // Calldata length.
-        *recipient_account_address.0.key(),                  // Calldata: recipient.
-        stark_felt!(1_u8),                                   // Calldata: lsb amount.
-        stark_felt!(0_u8)                                    // Calldata: msb amount.
+        contract_address,                   // Contract address.
+        entry_point_selector.0,             // EP selector.
+        stark_felt!(3_u8),                  // Calldata length.
+        *recipient_account_address.0.key(), // Calldata: recipient.
+        stark_felt!(1_u8),                  // Calldata: lsb amount.
+        stark_felt!(0_u8)                   // Calldata: msb amount.
     ];
 
     let tx = invoke_tx(execute_calldata, sender_account_address, Fee(MAX_FEE), None);
@@ -140,7 +141,7 @@ fn prepare_accounts(
             get_storage_var_address("ERC20_balances", &[*deployed_account_address.0.key()])
                 .unwrap();
         state.set_storage_at(
-            block_context.deprecated_fee_token_address,
+            block_context.fee_token_addresses.deprecated_fee_token_address,
             deployed_account_balance_key,
             stark_felt!(BALANCE * 1000),
         );

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -275,10 +275,12 @@ pub fn into_block_context(
         block_timestamp: BlockTimestamp(block_info.block_timestamp),
         sequencer_address: ContractAddress::try_from(block_info.sequencer_address.0)?,
         fee_token_addresses: FeeTokenAddresses {
-            deprecated_fee_token_address: ContractAddress::try_from(
+            eth_fee_token_address: ContractAddress::try_from(
                 starknet_os_config.deprecated_fee_token_address.0,
             )?,
-            fee_token_address: ContractAddress::try_from(starknet_os_config.fee_token_address.0)?,
+            strk_fee_token_address: ContractAddress::try_from(
+                starknet_os_config.fee_token_address.0,
+            )?,
         },
         vm_resource_fee_cost: general_config.cairo_resource_fee_weights.clone(),
         eth_l1_gas_price: block_info.eth_l1_gas_price,

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use blockifier::block_context::BlockContext;
+use blockifier::block_context::{BlockContext, FeeTokenAddresses};
 use blockifier::state::cached_state::GlobalContractCache;
 use pyo3::prelude::*;
 use starknet_api::block::{BlockNumber, BlockTimestamp};
@@ -274,10 +274,12 @@ pub fn into_block_context(
         block_number,
         block_timestamp: BlockTimestamp(block_info.block_timestamp),
         sequencer_address: ContractAddress::try_from(block_info.sequencer_address.0)?,
-        deprecated_fee_token_address: ContractAddress::try_from(
-            starknet_os_config.deprecated_fee_token_address.0,
-        )?,
-        fee_token_address: ContractAddress::try_from(starknet_os_config.fee_token_address.0)?,
+        fee_token_addresses: FeeTokenAddresses {
+            deprecated_fee_token_address: ContractAddress::try_from(
+                starknet_os_config.deprecated_fee_token_address.0,
+            )?,
+            fee_token_address: ContractAddress::try_from(starknet_os_config.fee_token_address.0)?,
+        },
         vm_resource_fee_cost: general_config.cairo_resource_fee_weights.clone(),
         eth_l1_gas_price: block_info.eth_l1_gas_price,
         strk_l1_gas_price: block_info.strk_l1_gas_price,


### PR DESCRIPTION
- Store fee token addresses in a dedicated struct `FeeTokenAddresses`.
- Add `HasTransactionVersion` to represent objects that store
  `TransactionVersion` (or store fields that store `TransactionVersion`,
  and so on). Ideally, we should have a `Versioned` trait in SN API for
  this kind of thing, which will be more generic, rather than
  specifically a TransactionVersion.
- Changes in tests currently just preserve the current state, once we
  add support for the new transactions we'll update the tests to not
  hard-code deprecated transactions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/889)
<!-- Reviewable:end -->
