### PR TITLE
Read all written values when casting from `CachedState` to `CommitmenttStateDiff`

### DIFF
--- a/crates/blockifier/src/state/state_api.rs
+++ b/crates/blockifier/src/state/state_api.rs
@@ -94,5 +94,5 @@ pub trait State: StateReader {
         compiled_class_hash: CompiledClassHash,
     ) -> StateResult<()>;
 
-    fn to_state_diff(&self) -> CommitmentStateDiff;
+    fn to_state_diff(&mut self) -> CommitmentStateDiff;
 }

--- a/crates/native_blockifier/src/py_transaction_executor.rs
+++ b/crates/native_blockifier/src/py_transaction_executor.rs
@@ -203,7 +203,7 @@ impl TransactionExecutor {
 
     /// Returns the state diff resulting in executing transactions.
     pub fn finalize(&mut self) -> PyStateDiff {
-        PyStateDiff::from(self.borrow_state().to_state_diff())
+        PyStateDiff::from(self.with_state_mut(|state| state.to_state_diff()))
     }
 
     // Block pre-processing; see `block_execution::pre_process_block` documentation.


### PR DESCRIPTION
This ensures that the `CommitmentStateDiff` doesn't contain any write actions that don't change the existing value.

This is a performance optimization, since it saves the state diff consumer from doing this at a later stage, which could be costly.

Python: https://reviewable.io/reviews/starkware-industries/starkware/31816

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/911)
<!-- Reviewable:end -->
