### PR TITLE
Implement setup_block_execution_without_alignment for testing.

### DIFF
--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -80,6 +80,30 @@ impl PyBlockExecutor {
         Ok(())
     }
 
+    /// Initializes the transaction executor without aligning the storage.
+    /// Used for testing.
+    #[pyo3(signature = (next_block_info))]
+    fn setup_block_execution_without_alignment(
+        &mut self,
+        next_block_info: PyBlockInfo,
+    ) -> NativeBlockifierResult<()> {
+        let papyrus_reader = PapyrusReader::new(
+            self.storage.reader().clone(),
+            BlockNumber(next_block_info.block_number),
+        );
+
+        let tx_executor = TransactionExecutor::new(
+            papyrus_reader,
+            &self.general_config,
+            next_block_info,
+            self.max_recursion_depth,
+            self.global_contract_cache.clone(),
+        )?;
+        self.tx_executor = Some(tx_executor);
+
+        Ok(())
+    }
+
     fn teardown_block_execution(&mut self) {
         self.tx_executor = None;
     }


### PR DESCRIPTION
In some python tests (like the os test) we'll want to create a few blocks with the blockifier only, without writing Batches to the python Storage. Therefore the papyrus storage cannot be aligned with the python storage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/913)
<!-- Reviewable:end -->
