### PR TITLE
Add `Transaction::hash` utility method

### DIFF
--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -57,8 +57,8 @@ pub enum AccountTransaction {
 impl HasRelatedFeeType for AccountTransaction {
     fn version(&self) -> TransactionVersion {
         match self {
-            Self::Declare(tx) => tx.tx().version(),
-            Self::DeployAccount(tx) => tx.tx().version(),
+            Self::Declare(tx) => tx.tx.version(),
+            Self::DeployAccount(tx) => tx.tx.version(),
             Self::Invoke(tx) => match tx.tx {
                 starknet_api::transaction::InvokeTransaction::V0(_) => TransactionVersion::ZERO,
                 starknet_api::transaction::InvokeTransaction::V1(_) => TransactionVersion::ONE,
@@ -125,9 +125,9 @@ impl AccountTransaction {
     fn get_account_transaction_context(&self) -> AccountTransactionContext {
         match self {
             Self::Declare(tx) => {
-                let sn_api_tx = &tx.tx();
+                let sn_api_tx = &tx.tx;
                 AccountTransactionContext {
-                    transaction_hash: tx.tx_hash(),
+                    transaction_hash: tx.tx_hash.to_owned(),
                     max_fee: tx.max_fee(),
                     version: self.version(),
                     signature: sn_api_tx.signature(),
@@ -136,7 +136,7 @@ impl AccountTransaction {
                 }
             }
             Self::DeployAccount(tx) => {
-                let sn_api_tx = &tx.tx();
+                let sn_api_tx = &tx.tx;
                 AccountTransactionContext {
                     transaction_hash: tx.tx_hash,
                     max_fee: tx.max_fee(),

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -33,6 +33,15 @@ impl Transaction {
     pub fn initial_gas() -> u64 {
         abi_constants::INITIAL_GAS_COST - abi_constants::TRANSACTION_GAS_COST
     }
+
+    pub fn hash(&self) -> &TransactionHash {
+        match self {
+            Self::L1HandlerTransaction(L1HandlerTransaction { tx_hash, .. }) => tx_hash,
+            Self::AccountTransaction(AccountTransaction::Declare(declare)) => &declare.tx_hash,
+            Self::AccountTransaction(AccountTransaction::DeployAccount(deploy)) => &deploy.tx_hash,
+            Self::AccountTransaction(AccountTransaction::Invoke(invoke)) => &invoke.tx_hash,
+        }
+    }
 }
 
 impl Transaction {

--- a/crates/blockifier/src/transaction/transactions.rs
+++ b/crates/blockifier/src/transaction/transactions.rs
@@ -90,9 +90,9 @@ pub trait Executable<S: State> {
 
 #[derive(Debug)]
 pub struct DeclareTransaction {
-    tx: starknet_api::transaction::DeclareTransaction,
-    tx_hash: TransactionHash,
-    contract_class: ContractClass,
+    pub tx: starknet_api::transaction::DeclareTransaction,
+    pub tx_hash: TransactionHash,
+    pub contract_class: ContractClass,
 }
 
 fn verify_contract_class_version(
@@ -135,14 +135,6 @@ impl DeclareTransaction {
     }
 
     implement_inner_tx_getter_calls!((class_hash, ClassHash));
-
-    pub fn tx(&self) -> &starknet_api::transaction::DeclareTransaction {
-        &self.tx
-    }
-
-    pub fn tx_hash(&self) -> TransactionHash {
-        self.tx_hash
-    }
 
     pub fn contract_class(&self) -> ContractClass {
         self.contract_class.clone()
@@ -229,10 +221,6 @@ impl DeployAccountTransaction {
         (nonce, Nonce),
         (signature, TransactionSignature)
     );
-
-    pub fn tx(&self) -> &starknet_api::transaction::DeployAccountTransaction {
-        &self.tx
-    }
 
     pub fn max_fee(&self) -> Fee {
         match &self.tx {


### PR DESCRIPTION
Add a utility method to conveniently expose the hash of the execution transaction.

Make fields of `DeclareTransaction` public, similar to other `AccountTransaction` variants.
With the fields being public, there is no need it `tx()` and similar utility methods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/927)
<!-- Reviewable:end -->
