### PR TITLE
Execution mode for deploy-account transaction.

### DIFF
--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -13,6 +13,7 @@ use starknet_api::transaction::{
 use crate::abi::abi_utils::selector_from_name;
 use crate::abi::constants as abi_constants;
 use crate::block_context::BlockContext;
+use crate::execution::common_hints::ExecutionMode;
 use crate::execution::contract_class::ContractClass;
 use crate::execution::entry_point::{
     CallEntryPoint, CallInfo, CallType, EntryPointExecutionContext, ExecutionResources, Retdata,
@@ -411,6 +412,7 @@ impl AccountTransaction {
         let execute_call_info: Option<CallInfo>;
         if matches!(self, Self::DeployAccount(_)) {
             // Handle `DeployAccount` transactions separately, due to different order of things.
+            execution_context.execution_mode = ExecutionMode::Validate;
             execute_call_info =
                 self.run_execute(state, resources, &mut execution_context, remaining_gas)?;
             validate_call_info =


### PR DESCRIPTION
Set the execution mode for the execution of a Deploy account transaction to validate mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/936)
<!-- Reviewable:end -->
