### PR TITLE
Unwrap `get_storage_var_address`

### DIFF
--- a/crates/blockifier/src/abi/abi_utils.rs
+++ b/crates/blockifier/src/abi/abi_utils.rs
@@ -42,10 +42,7 @@ pub fn selector_from_name(entry_point_name: &str) -> EntryPointSelector {
 }
 
 /// Returns the storage address of a StarkNet storage variable given its name and arguments.
-pub fn get_storage_var_address(
-    storage_var_name: &str,
-    args: &[StarkFelt],
-) -> Result<StorageKey, StarknetApiError> {
+pub fn get_storage_var_address(storage_var_name: &str, args: &[StarkFelt]) -> StorageKey {
     let storage_var_name_hash = starknet_keccak(storage_var_name.as_bytes());
     let storage_var_name_hash = felt_to_stark_felt(&storage_var_name_hash);
 
@@ -56,6 +53,7 @@ pub fn get_storage_var_address(
         .mod_floor(&Felt252::from_bytes_be(&L2_ADDRESS_UPPER_BOUND.to_bytes_be()));
 
     StorageKey::try_from(felt_to_stark_felt(&storage_key))
+        .expect("Should be within bounds as retrieved mod L2_ADDRESS_UPPER_BOUND.")
 }
 
 /// Gets storage keys for a Uint256 storage variable.
@@ -63,7 +61,7 @@ pub fn get_uint256_storage_var_addresses(
     storage_var_name: &str,
     args: &[StarkFelt],
 ) -> Result<(StorageKey, StorageKey), StarknetApiError> {
-    let low_key = get_storage_var_address(storage_var_name, args)?;
+    let low_key = get_storage_var_address(storage_var_name, args);
     // TODO(Dori, 1/7/2023): When a standard representation for large integers is set, there may
     //   be a better way to add 1 to the key.
     let high_key = StorageKey(PatriciaKey::try_from(StarkFelt::from(

--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -465,7 +465,7 @@ fn test_storage_related_members() {
     assert_eq!(actual_call_info.storage_read_values, vec![stark_felt!(0_u8), stark_felt!(39_u8)]);
     assert_eq!(
         actual_call_info.accessed_storage_keys,
-        HashSet::from([get_storage_var_address("number_map", &[stark_felt!(1_u8)]).unwrap()])
+        HashSet::from([get_storage_var_address("number_map", &[stark_felt!(1_u8)])])
     );
 
     // Test raw storage read and write.

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -83,15 +83,13 @@ pub const ERC20_CONTRACT_PATH: &str =
 
 // Storage keys.
 pub fn test_erc20_sequencer_balance_key() -> StorageKey {
-    get_storage_var_address("ERC20_balances", &[stark_felt!(TEST_SEQUENCER_ADDRESS)]).unwrap()
+    get_storage_var_address("ERC20_balances", &[stark_felt!(TEST_SEQUENCER_ADDRESS)])
 }
 pub fn test_erc20_account_balance_key() -> StorageKey {
     get_storage_var_address("ERC20_balances", &[stark_felt!(TEST_ACCOUNT_CONTRACT_ADDRESS)])
-        .unwrap()
 }
 pub fn test_erc20_faulty_account_balance_key() -> StorageKey {
     get_storage_var_address("ERC20_balances", &[stark_felt!(TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS)])
-        .unwrap()
 }
 
 // The max_fee used for txs in this test.

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -100,7 +100,7 @@ fn create_test_init_data(
     // Update the balance of the about-to-be deployed account contract in the erc20 contract, so it
     // can pay for the transaction execution.
     let deployed_account_balance_key =
-        get_storage_var_address("ERC20_balances", &[*account_address.0.key()]).unwrap();
+        get_storage_var_address("ERC20_balances", &[*account_address.0.key()]);
     state.set_storage_at(fee_token_address, deployed_account_balance_key, stark_felt!(BALANCE));
 
     account_tx.execute(&mut state, &block_context, true, true).unwrap();
@@ -306,7 +306,7 @@ fn test_revert_invoke(
     // Update the balance of the about-to-be deployed account contract in the erc20 contract, so it
     // can pay for the transaction execution.
     let deployed_account_balance_key =
-        get_storage_var_address("ERC20_balances", &[*deployed_account_address.0.key()]).unwrap();
+        get_storage_var_address("ERC20_balances", &[*deployed_account_address.0.key()]);
     state.set_storage_at(fee_token_address, deployed_account_balance_key, stark_felt!(BALANCE));
 
     let account_tx = AccountTransaction::DeployAccount(deploy_account_tx);

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -73,8 +73,8 @@ pub fn create_account_tx_test_state(
         (test_strk_token_address, test_erc20_class_hash),
         (test_eth_token_address, test_erc20_class_hash),
     ]);
-    let minter_var_address = get_storage_var_address("permitted_minter", &[])
-        .expect("Failed to get permitted_minter storage address.");
+    let minter_var_address = get_storage_var_address("permitted_minter", &[]);
+
     let initial_balance_felt = stark_felt!(initial_account_balance);
     let storage_view = HashMap::from([
         ((test_strk_token_address, erc20_account_balance_key), initial_balance_felt),

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -786,7 +786,7 @@ fn test_deploy_account_tx(
     // Update the balance of the about to be deployed account contract in the erc20 contract, so it
     // can pay for the transaction execution.
     let deployed_account_balance_key =
-        get_storage_var_address("ERC20_balances", &[*deployed_account_address.0.key()]).unwrap();
+        get_storage_var_address("ERC20_balances", &[*deployed_account_address.0.key()]);
     state.set_storage_at(fee_token_address, deployed_account_balance_key, stark_felt!(BALANCE));
 
     let account_tx = AccountTransaction::DeployAccount(deploy_account);

--- a/crates/native_blockifier/bench/blockifier_bench.rs
+++ b/crates/native_blockifier/bench/blockifier_bench.rs
@@ -146,8 +146,7 @@ fn prepare_accounts(
         addresses.push(deployed_account_address);
         nonces.push(1_u64);
         let deployed_account_balance_key =
-            get_storage_var_address("ERC20_balances", &[*deployed_account_address.0.key()])
-                .unwrap();
+            get_storage_var_address("ERC20_balances", &[*deployed_account_address.0.key()]);
         state.set_storage_at(
             block_context.fee_token_addresses.eth_fee_token_address,
             deployed_account_balance_key,


### PR DESCRIPTION
`storage_key` is fetched modulo `L2_ADDRESS_UPPER_BOUND`, which is smaller than the `PatriciaKey` upper bounds. This change ensures that the `try_from` operation for `StorageKey` stays within bounds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/942)
<!-- Reviewable:end -->
