### PR TITLE
Add new struct in AcoountTransactionContext for V3.

### DIFF
--- a/crates/blockifier/src/transaction/objects.rs
+++ b/crates/blockifier/src/transaction/objects.rs
@@ -2,7 +2,11 @@ use std::collections::{HashMap, HashSet};
 
 use itertools::concat;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
-use starknet_api::transaction::{Fee, TransactionHash, TransactionSignature, TransactionVersion};
+use starknet_api::data_availability::DataAvailabilityMode;
+use starknet_api::transaction::{
+    AccountDeploymentData, Fee, PaymasterData, Resource, ResourceBoundsMapping, Tip,
+    TransactionHash, TransactionSignature, TransactionVersion,
+};
 use strum_macros::EnumIter;
 
 use crate::block_context::BlockContext;
@@ -11,16 +15,6 @@ use crate::fee::fee_utils::calculate_tx_fee;
 use crate::transaction::errors::TransactionExecutionError;
 
 pub type TransactionExecutionResult<T> = Result<T, TransactionExecutionError>;
-
-macro_rules! implement_inner_account_tx_context_getter_calls {
-    ($(($field:ident, $field_type:ty)),*) => {
-        $(pub fn $field(&self) -> $field_type {
-            match self{
-                Self::Deprecated(context) => context.$field,
-            }
-        })*
-    };
-}
 
 #[derive(EnumIter)]
 pub enum FeeType {
@@ -31,12 +25,23 @@ pub enum FeeType {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AccountTransactionContext {
     Deprecated(DeprecatedAccountTransactionContext),
+    Current(CurrentAccountTransactionContext),
+}
+
+macro_rules! implement_inner_account_tx_context_getter_calls {
+    ($(($field:ident, $field_type:ty)),*) => {
+        $(pub fn $field(&self) -> $field_type {
+            match self {
+                Self::Deprecated(context) => context.$field(),
+                Self::Current(context) => context.$field(),
+            }
+        })*
+    };
 }
 
 impl AccountTransactionContext {
     implement_inner_account_tx_context_getter_calls!(
         (transaction_hash, TransactionHash),
-        (max_fee, Fee),
         (version, TransactionVersion),
         (nonce, Nonce),
         (sender_address, ContractAddress)
@@ -45,6 +50,19 @@ impl AccountTransactionContext {
     pub fn signature(&self) -> TransactionSignature {
         match self {
             Self::Deprecated(context) => context.signature.clone(),
+            Self::Current(context) => context.signature.clone(),
+        }
+    }
+
+    pub fn max_fee(&self) -> Fee {
+        match self {
+            Self::Deprecated(context) => context.max_fee,
+            Self::Current(context) => {
+                let l1_resource_bounds =
+                    context.resource_bounds.0.get(&Resource::L1Gas).copied().unwrap_or_default();
+                // TODO(nir, 01/11/2023): Change to max_amount * block_context.gas_price.
+                Fee(l1_resource_bounds.max_amount as u128 * l1_resource_bounds.max_price_per_unit)
+            }
         }
     }
 
@@ -63,7 +81,86 @@ impl HasRelatedFeeType for AccountTransactionContext {
     }
 }
 
+macro_rules! add_getters {
+    ($(($field:ident, $field_type:ty)),*) => {
+        $(pub fn $field(&self) -> $field_type {
+            self.$field
+        })*
+    };
+}
 /// Contains the account information of the transaction (outermost call).
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CurrentAccountTransactionContext {
+    transaction_hash: TransactionHash,
+    max_fee: Fee,
+    version: TransactionVersion,
+    signature: TransactionSignature,
+    nonce: Nonce,
+    sender_address: ContractAddress,
+    resource_bounds: ResourceBoundsMapping,
+    tip: Tip,
+    nonce_data_availability_mode: DataAvailabilityMode,
+    fee_data_availability_mode: DataAvailabilityMode,
+    paymaster_data: PaymasterData,
+    account_deployment_data: AccountDeploymentData,
+}
+
+// TODO(nir, 01/11/2023): Remove this clippy exception.
+#[allow(clippy::too_many_arguments)]
+impl CurrentAccountTransactionContext {
+    pub fn new(
+        transaction_hash: TransactionHash,
+        max_fee: Fee,
+        version: TransactionVersion,
+        signature: TransactionSignature,
+        nonce: Nonce,
+        sender_address: ContractAddress,
+        resource_bounds: ResourceBoundsMapping,
+        tip: Tip,
+        nonce_data_availability_mode: DataAvailabilityMode,
+        fee_data_availability_mode: DataAvailabilityMode,
+        paymaster_data: PaymasterData,
+        account_deployment_data: AccountDeploymentData,
+    ) -> Self {
+        Self {
+            transaction_hash,
+            max_fee,
+            version,
+            signature,
+            nonce,
+            sender_address,
+            resource_bounds,
+            tip,
+            nonce_data_availability_mode,
+            fee_data_availability_mode,
+            paymaster_data,
+            account_deployment_data,
+        }
+    }
+
+    add_getters!(
+        (transaction_hash, TransactionHash),
+        (version, TransactionVersion),
+        (nonce, Nonce),
+        (sender_address, ContractAddress),
+        (tip, Tip),
+        (nonce_data_availability_mode, DataAvailabilityMode),
+        (fee_data_availability_mode, DataAvailabilityMode)
+    );
+
+    pub fn resource_bounds(&self) -> ResourceBoundsMapping {
+        self.resource_bounds.clone()
+    }
+
+    pub fn paymaster_data(&self) -> PaymasterData {
+        self.paymaster_data.clone()
+    }
+
+    pub fn account_deployment_data(&self) -> AccountDeploymentData {
+        self.account_deployment_data.clone()
+    }
+}
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DeprecatedAccountTransactionContext {
     transaction_hash: TransactionHash,
@@ -85,6 +182,13 @@ impl DeprecatedAccountTransactionContext {
     ) -> Self {
         Self { transaction_hash, max_fee, version, signature, nonce, sender_address }
     }
+
+    add_getters!(
+        (transaction_hash, TransactionHash),
+        (version, TransactionVersion),
+        (nonce, Nonce),
+        (sender_address, ContractAddress)
+    );
 }
 
 /// Contains the information gathered by the execution of a transaction.


### PR DESCRIPTION
A few things:
1) A suggestion for a better name than CurrentAccountTransactionContext.
2) I saw one (not in test file) of too_many_arguments, is it a good solution here? or is there a better solution for this case?
3) When implementing the function get_account_tx_context is it better to implement match over version? asking in this case because in the V3 part I need to convert to V3 type to access the fields. 
4) Or maybe we want to implement (as in invoke in starknet_api) with default values for the version for which the fields not exist?
5) max_fee V3 - currently with value as in the rest of our code and with TODO. in the following PR will be fixed, needs access to block_context.gas_price, so we need to choose a solution (e.g. max_fee will receive as input the gas_price).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/965)
<!-- Reviewable:end -->
