### PR TITLE
Cherry-pick: Use stable clippy.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,25 @@ on:
       - auto_merge_enabled
 
 jobs:
-  checks:
+  format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master
         with:
-          components: rustfmt, clippy
+          components: rustfmt
           toolchain: nightly-2023-07-05
       - uses: Swatinem/rust-cache@v2
       - run: scripts/rust_fmt.sh --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
       - run: scripts/clippy.sh
 
   run-tests:


### PR DESCRIPTION
Already merged in main at #823.
This is a ci-only change, which reorganizes the required checks on github.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/974)
<!-- Reviewable:end -->
