### PR TITLE
Make `PyBlockInfo` resemble the Python class better

### DIFF
--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -66,7 +66,7 @@ impl PyBlockExecutor {
         &mut self,
         next_block_info: PyBlockInfo,
     ) -> NativeBlockifierResult<()> {
-        let papyrus_reader = self.get_aligned_reader(next_block_info.block_number);
+        let papyrus_reader = self.get_aligned_reader(next_block_info.block_number());
 
         let tx_executor = TransactionExecutor::new(
             papyrus_reader,
@@ -281,7 +281,7 @@ pub fn into_block_context(
     max_recursion_depth: usize,
 ) -> NativeBlockifierResult<BlockContext> {
     let starknet_os_config = general_config.starknet_os_config.clone();
-    let block_number = BlockNumber(block_info.block_number);
+    let block_number = BlockNumber(block_info.block_number());
     let block_context = BlockContext {
         chain_id: starknet_os_config.chain_id,
         block_number,

--- a/crates/native_blockifier/src/storage.rs
+++ b/crates/native_blockifier/src/storage.rs
@@ -19,7 +19,7 @@ use crate::py_state_diff::PyBlockInfo;
 use crate::py_utils::{int_to_chain_id, PyFelt};
 use crate::PyStateDiff;
 
-const GENESIS_BLOCK_ID: u64 = u64::MAX;
+pub const GENESIS_BLOCK_ID: u64 = u64::MAX;
 
 // Invariant: Only one instance of this struct should exist.
 // Reader and writer fields must be cleared before the struct goes out of scope in Python;
@@ -97,9 +97,9 @@ impl Storage {
     ) -> NativeBlockifierResult<()> {
         log::debug!(
             "Appending state diff with {block_id:?} for block_number: {}.",
-            py_block_info.block_number
+            py_block_info.block_number()
         );
-        let block_number = BlockNumber(py_block_info.block_number);
+        let block_number = BlockNumber(py_block_info.block_number());
         let state_number = StateNumber(block_number);
 
         // Deserialize contract classes.


### PR DESCRIPTION
In python the block_number sentinel object is -1, in Papyrus it is `u64::MAX`, this makes `PyBlockInfo` resemble this better.

This hasn't been an issue thus far, because we were careful not to send the sentinel block into Rust.
However, in the subsequent PRs that add blockifier support to gateway validations, this can no longer be avoided (since the first block's validation will reference its previous block number).

Therefore, this change shouldn't affect functionality of the current system.

Python: https://reviewable.io/reviews/starkware-industries/starkware/32102

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/977)
<!-- Reviewable:end -->
