### PR TITLE
Return `actual_fee` from native validation API

### DIFF
--- a/crates/blockifier/src/fee.rs
+++ b/crates/blockifier/src/fee.rs
@@ -1,3 +1,4 @@
+pub mod actual_cost_metrics;
 pub mod eth_gas_constants;
 pub mod fee_utils;
 pub mod gas_usage;

--- a/crates/blockifier/src/fee/actual_cost_metrics.rs
+++ b/crates/blockifier/src/fee/actual_cost_metrics.rs
@@ -1,0 +1,149 @@
+use std::cmp::min;
+
+use starknet_api::transaction::{Fee, TransactionVersion};
+
+use crate::abi::constants as abi_constants;
+use crate::block_context::BlockContext;
+use crate::execution::call_info::CallInfo;
+use crate::execution::entry_point::ExecutionResources;
+use crate::state::cached_state::{CachedState, StateChanges, StateChangesCount};
+use crate::state::state_api::{StateReader, StateResult};
+use crate::transaction::objects::{
+    AccountTransactionContext, HasRelatedFeeType, ResourcesMapping, TransactionExecutionResult,
+};
+use crate::transaction::transaction_types::TransactionType;
+use crate::transaction::transaction_utils::{calculate_l1_gas_usage, calculate_tx_resources};
+
+// TODO(Gilad): Use everywhere instead of passing the `actual_{fee,resources}` tuple, which often
+// get passed around together.
+pub struct ActualCostMetrics {
+    pub actual_fee: Fee,
+    pub actual_resources: ResourcesMapping,
+}
+
+#[derive(Debug, Clone)]
+// Invariant: private fields constructed after `new` is called via dedicated methods.
+pub struct ActualCostMetricsBuilder<'a> {
+    pub account_tx_context: AccountTransactionContext,
+    pub version: TransactionVersion,
+    pub tx_type: TransactionType,
+    pub block_context: BlockContext,
+    validate_call_info: Option<&'a CallInfo>,
+    execute_call_info: Option<&'a CallInfo>,
+    state_changes: StateChanges,
+}
+
+impl<'a> ActualCostMetricsBuilder<'a> {
+    // Recommendation: use the account transaction constructor to build this.
+    pub fn new(
+        block_context: &BlockContext,
+        account_tx_context: AccountTransactionContext,
+        tx_version: TransactionVersion,
+        tx_type: TransactionType,
+    ) -> Self {
+        Self {
+            block_context: block_context.clone(),
+            account_tx_context,
+            version: tx_version,
+            tx_type,
+            validate_call_info: None,
+            execute_call_info: None,
+            state_changes: StateChanges::default(),
+        }
+    }
+
+    // Call the build_* methods to construct the cost metrics object, after feeding the builder
+    // using the setters below.
+    pub fn build_for_non_reverted_tx(
+        self,
+        execution_resources: &ExecutionResources,
+    ) -> TransactionExecutionResult<ActualCostMetrics> {
+        self.calculate_actual_fee_and_resources(
+            execution_resources,
+            false, // is_reverted
+            0,     // n_reverted_steps
+        )
+    }
+
+    pub fn build_for_reverted_tx(
+        self,
+        execution_resources: &ExecutionResources,
+        n_reverted_steps: usize,
+    ) -> TransactionExecutionResult<ActualCostMetrics> {
+        self.calculate_actual_fee_and_resources(
+            execution_resources,
+            true, // is_reverted
+            n_reverted_steps,
+        )
+    }
+
+    // Setters.
+
+    pub fn with_validate_call_info(mut self, validate_call_info: Option<&'a CallInfo>) -> Self {
+        self.validate_call_info = validate_call_info;
+        self
+    }
+
+    pub fn with_execute_call_info(mut self, execute_call_info: Option<&'a CallInfo>) -> Self {
+        self.execute_call_info = execute_call_info;
+        self
+    }
+
+    pub fn try_add_state_changes(
+        mut self,
+        state: &mut CachedState<impl StateReader>,
+    ) -> StateResult<Self> {
+        let fee_token_address =
+            self.block_context.fee_token_address(&self.account_tx_context.fee_type());
+
+        let new_state_changes = state.get_actual_state_changes_for_fee_charge(
+            fee_token_address,
+            Some(self.account_tx_context.sender_address()),
+        )?;
+
+        self.state_changes = StateChanges::merge(vec![self.state_changes, new_state_changes]);
+        Ok(self)
+    }
+
+    // Private methods.
+
+    // Construct the cost metrics object using all fields that were set in the builder.
+    fn calculate_actual_fee_and_resources(
+        &self,
+        execution_resources: &ExecutionResources,
+        is_reverted: bool,
+        n_reverted_steps: usize,
+    ) -> TransactionExecutionResult<ActualCostMetrics> {
+        let state_changes_count = StateChangesCount::from(&self.state_changes);
+        let non_optional_call_infos = vec![self.validate_call_info, self.execute_call_info]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<&CallInfo>>();
+        let l1_gas_usage =
+            calculate_l1_gas_usage(&non_optional_call_infos, state_changes_count, None)?;
+        let mut actual_resources =
+            calculate_tx_resources(execution_resources, l1_gas_usage, self.tx_type)?;
+
+        // Add reverted steps to actual_resources' n_steps for correct fee charge.
+        *actual_resources.0.get_mut(&abi_constants::N_STEPS_RESOURCE.to_string()).unwrap() +=
+            n_reverted_steps;
+
+        let mut actual_fee = self.calculate_tx_fee(&actual_resources, &self.block_context)?;
+        if is_reverted || !self.account_tx_context.enforce_fee() {
+            // We cannot charge more than max_fee for reverted txs.
+            actual_fee = min(actual_fee, self.account_tx_context.max_fee());
+        }
+
+        Ok(ActualCostMetrics { actual_fee, actual_resources })
+    }
+}
+
+impl HasRelatedFeeType for ActualCostMetricsBuilder<'_> {
+    fn version(&self) -> TransactionVersion {
+        self.version
+    }
+
+    fn is_l1_handler(&self) -> bool {
+        false
+    }
+}

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -1,5 +1,3 @@
-use std::cmp::min;
-
 use cairo_vm::vm::runners::cairo_runner::ResourceTracker;
 use itertools::concat;
 use starknet_api::calldata;
@@ -22,9 +20,7 @@ use crate::fee::actual_cost_metrics::{ActualCostMetrics, ActualCostMetricsBuilde
 use crate::fee::gas_usage::estimate_minimal_fee;
 use crate::fee::os_resources::OS_RESOURCES;
 use crate::retdata;
-use crate::state::cached_state::{
-    CachedState, StateChanges, StateChangesCount, TransactionalState,
-};
+use crate::state::cached_state::{CachedState, TransactionalState};
 use crate::state::state_api::{State, StateReader};
 use crate::transaction::constants;
 use crate::transaction::errors::TransactionExecutionError;
@@ -35,8 +31,7 @@ use crate::transaction::objects::{
 use crate::transaction::transaction_execution::Transaction;
 use crate::transaction::transaction_types::TransactionType;
 use crate::transaction::transaction_utils::{
-    calculate_l1_gas_usage, calculate_tx_resources, update_remaining_gas,
-    verify_no_calls_to_other_contracts,
+    update_remaining_gas, verify_no_calls_to_other_contracts,
 };
 use crate::transaction::transactions::{
     DeclareTransaction, DeployAccountTransaction, Executable, ExecutableTransaction,
@@ -365,10 +360,13 @@ impl AccountTransaction {
     ) -> TransactionExecutionResult<ValidateExecuteCallInfo> {
         let mut resources = ExecutionResources::default();
         let account_tx_context = self.get_account_tx_context();
-        let fee_token_address = block_context.fee_token_address(&account_tx_context.fee_type());
         // Run the validation, and if execution later fails, only keep the validation diff.
         let validate_call_info =
             self.handle_validate_tx(state, &mut resources, remaining_gas, block_context, validate)?;
+
+        let fee_and_resources_builder = self
+            .into_cost_metrics_builder(block_context)
+            .with_validate_call_info(validate_call_info.as_ref());
 
         let validate_steps = validate_call_info
             .as_ref()
@@ -391,10 +389,8 @@ impl AccountTransaction {
 
         // Save the state changes resulting from running `validate_tx`, to be used later for
         // resource and fee calculation.
-        let validate_state_changes = state.get_actual_state_changes_for_fee_charge(
-            fee_token_address,
-            Some(account_tx_context.sender_address()),
-        )?;
+        let fee_and_resources_builder_with_validation_changes =
+            fee_and_resources_builder.try_add_state_changes(state)?;
 
         // Create copies of state and resources for the execution.
         // Both will be rolled back if the execution is reverted or committed upon success.
@@ -412,28 +408,16 @@ impl AccountTransaction {
             Ok(execute_call_info) => {
                 // When execution succeeded, calculate the actual required fee before committing the
                 // transactional state. If max_fee is insufficient, revert the `run_execute` part.
-                let execute_state_changes = execution_state
-                    .get_actual_state_changes_for_fee_charge(
-                        fee_token_address,
-                        Some(account_tx_context.sender_address()),
-                    )?;
-                // Fee is determined by the sum of `validate` and `execute` state changes.
-                // Since `execute_state_changes` are not yet committed, we merge them manually with
-                // `validate_state_changes` to count correctly.
-                let state_changes = StateChanges::merge(vec![
-                    validate_state_changes.clone(),
-                    execute_state_changes,
-                ]);
 
-                let (actual_fee, actual_resources) = self.calculate_actual_fee_and_resources(
-                    StateChangesCount::from(&state_changes),
-                    &execute_call_info,
-                    &validate_call_info,
-                    &execution_resources,
-                    block_context,
-                    false,
-                    0,
-                )?;
+                let ActualCostMetrics { actual_fee, actual_resources } =
+                    fee_and_resources_builder_with_validation_changes
+                    .clone()
+                    .with_execute_call_info(execute_call_info.as_ref())
+                    // Fee is determined by the sum of `validate` and `execute` state changes.
+                    // Since `execute_state_changes` are not yet committed, we merge them manually
+                    // with `validate_state_changes` to count correctly.
+                    .try_add_state_changes(&mut execution_state)?
+                    .build_for_non_reverted_tx(&execution_resources)?;
 
                 // Check if as a result of tx execution the sender's fee token balance is maxed out,
                 // so that they can't pay fee. If so, the transaction must be reverted.
@@ -467,17 +451,11 @@ impl AccountTransaction {
                         .expect("Invalid remaining steps in RunResources.");
                     let n_reverted_steps = n_allotted_steps - n_remaining_steps;
 
-                    // Rerunning `calculate_actual_fee_and_resources` with only the `validate` state
-                    // changes in order to get the correct resources, as `execute` is reverted.
-                    let (_, final_resources) = self.calculate_actual_fee_and_resources(
-                        StateChangesCount::from(&validate_state_changes),
-                        &None,
-                        &validate_call_info,
-                        &execution_resources,
-                        block_context,
-                        true,
-                        n_reverted_steps,
-                    )?;
+                    // Recalculate based on the `validate` state only in order to get the correct
+                    // resources, as `execute` is reverted.
+                    let ActualCostMetrics { actual_resources: final_resources, .. } =
+                        fee_and_resources_builder_with_validation_changes
+                            .build_for_reverted_tx(&execution_resources, n_reverted_steps)?;
 
                     return Ok(ValidateExecuteCallInfo::new_reverted(
                         validate_call_info,
@@ -507,15 +485,9 @@ impl AccountTransaction {
                 let n_reverted_steps = n_allotted_steps - n_remaining_steps;
 
                 // Fee is determined by the `validate` state changes since `execute` is reverted.
-                let (actual_fee, actual_resources) = self.calculate_actual_fee_and_resources(
-                    StateChangesCount::from(&validate_state_changes),
-                    &None,
-                    &validate_call_info,
-                    &execution_resources,
-                    block_context,
-                    true,
-                    n_reverted_steps,
-                )?;
+                let ActualCostMetrics { actual_fee, actual_resources } =
+                    fee_and_resources_builder_with_validation_changes
+                        .build_for_reverted_tx(&execution_resources, n_reverted_steps)?;
 
                 Ok(ValidateExecuteCallInfo::new_reverted(
                     validate_call_info,
@@ -571,42 +543,6 @@ impl AccountTransaction {
             validate,
             charge_fee,
         )
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn calculate_actual_fee_and_resources(
-        &self,
-        state_changes_count: StateChangesCount,
-        execute_call_info: &Option<CallInfo>,
-        validate_call_info: &Option<CallInfo>,
-        execution_resources: &ExecutionResources,
-        block_context: &BlockContext,
-        is_reverted: bool,
-        n_reverted_steps: usize,
-    ) -> TransactionExecutionResult<(Fee, ResourcesMapping)> {
-        let account_tx_context = self.get_account_tx_context();
-
-        let non_optional_call_infos = vec![validate_call_info.as_ref(), execute_call_info.as_ref()]
-            .into_iter()
-            .flatten()
-            .collect::<Vec<&CallInfo>>();
-        let l1_gas_usage =
-            calculate_l1_gas_usage(&non_optional_call_infos, state_changes_count, None)?;
-        let mut actual_resources =
-            calculate_tx_resources(execution_resources, l1_gas_usage, self.tx_type())?;
-
-        // Add reverted steps to actual_resources' n_steps for correct fee charge.
-        *actual_resources.0.get_mut(&abi_constants::N_STEPS_RESOURCE.to_string()).unwrap() +=
-            n_reverted_steps;
-
-        let mut actual_fee = self.calculate_tx_fee(&actual_resources, block_context)?;
-
-        if is_reverted || !account_tx_context.enforce_fee() {
-            // We cannot charge more than max_fee for reverted txs.
-            actual_fee = min(actual_fee, account_tx_context.max_fee());
-        }
-
-        Ok((actual_fee, actual_resources))
     }
 
     pub fn into_cost_metrics_builder<'a>(

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -18,6 +18,7 @@ use crate::execution::contract_class::ContractClass;
 use crate::execution::entry_point::{
     CallEntryPoint, CallType, EntryPointExecutionContext, ExecutionResources,
 };
+use crate::fee::actual_cost_metrics::{ActualCostMetrics, ActualCostMetricsBuilder};
 use crate::fee::gas_usage::estimate_minimal_fee;
 use crate::fee::os_resources::OS_RESOURCES;
 use crate::retdata;
@@ -315,8 +316,6 @@ impl AccountTransaction {
         let mut resources = ExecutionResources::default();
         let validate_call_info: Option<CallInfo>;
         let execute_call_info: Option<CallInfo>;
-        let account_tx_context = self.get_account_tx_context();
-        let fee_token_address = block_context.fee_token_address(&account_tx_context.fee_type());
         if matches!(self, Self::DeployAccount(_)) {
             // Handle `DeployAccount` transactions separately, due to different order of things.
             execute_call_info =
@@ -339,19 +338,14 @@ impl AccountTransaction {
             execute_call_info =
                 self.run_execute(state, &mut resources, &mut execution_context, remaining_gas)?;
         }
-        let state_changes = state.get_actual_state_changes_for_fee_charge(
-            fee_token_address,
-            Some(account_tx_context.sender_address()),
-        )?;
-        let (actual_fee, actual_resources) = self.calculate_actual_fee_and_resources(
-            StateChangesCount::from(&state_changes),
-            &execute_call_info,
-            &validate_call_info,
-            &resources,
-            block_context,
-            false,
-            0,
-        )?;
+
+        let ActualCostMetrics { actual_fee, actual_resources } = self
+            .into_cost_metrics_builder(block_context)
+            .with_validate_call_info(validate_call_info.as_ref())
+            .with_execute_call_info(execute_call_info.as_ref())
+            .try_add_state_changes(state)?
+            .build_for_non_reverted_tx(&resources)?;
+
         Ok(ValidateExecuteCallInfo::new_accepted(
             validate_call_info,
             execute_call_info,
@@ -613,6 +607,18 @@ impl AccountTransaction {
         }
 
         Ok((actual_fee, actual_resources))
+    }
+
+    pub fn into_cost_metrics_builder<'a>(
+        &'a self,
+        block_context: &'a BlockContext,
+    ) -> ActualCostMetricsBuilder<'a> {
+        ActualCostMetricsBuilder::new(
+            block_context,
+            self.get_account_tx_context(),
+            self.version(),
+            self.tx_type(),
+        )
     }
 }
 

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -80,6 +80,8 @@ impl Transaction {
 }
 
 impl<S: StateReader> ExecutableTransaction<S> for L1HandlerTransaction {
+    // TODO(Gilad): Use the actual cost metrics builder to calculate fees here, the logic below
+    // duplicates much of its internal logic.
     fn execute_raw(
         self,
         state: &mut TransactionalState<'_, S>,

--- a/crates/native_blockifier/src/py_validator.rs
+++ b/crates/native_blockifier/src/py_validator.rs
@@ -80,9 +80,11 @@ impl PyValidator {
         tx: &PyAny,
         remaining_gas: u64,
         raw_contract_class: Option<&str>,
-    ) -> NativeBlockifierResult<Option<PyCallInfo>> {
-        let maybe_call_info = self.tx_executor().validate(tx, remaining_gas, raw_contract_class)?;
-        Ok(maybe_call_info.map(PyCallInfo::from))
+    ) -> NativeBlockifierResult<(Option<PyCallInfo>, u128)> {
+        let (maybe_call_info, actual_fee) =
+            self.tx_executor().validate(tx, remaining_gas, raw_contract_class)?;
+        let py_maybe_call_info = maybe_call_info.map(PyCallInfo::from);
+        Ok((py_maybe_call_info, actual_fee.0))
     }
 
     pub fn close(&mut self) {

--- a/crates/native_blockifier/src/transaction_executor.rs
+++ b/crates/native_blockifier/src/transaction_executor.rs
@@ -4,6 +4,7 @@ use blockifier::block_context::BlockContext;
 use blockifier::block_execution::pre_process_block;
 use blockifier::execution::call_info::CallInfo;
 use blockifier::execution::entry_point::ExecutionResources;
+use blockifier::fee::actual_cost_metrics::ActualCostMetrics;
 use blockifier::state::cached_state::{
     CachedState, GlobalContractCache, StagedTransactionalState, TransactionalState,
 };
@@ -14,6 +15,7 @@ use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResour
 use pyo3::prelude::*;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::ClassHash;
+use starknet_api::transaction::Fee;
 
 use crate::errors::{NativeBlockifierError, NativeBlockifierResult};
 use crate::py_block_executor::{into_block_context, PyGeneralConfig};
@@ -99,20 +101,28 @@ impl<S: StateReader> TransactionExecutor<S> {
         tx: &PyAny,
         mut remaining_gas: u64,
         raw_contract_class: Option<&str>,
-    ) -> NativeBlockifierResult<Option<CallInfo>> {
+    ) -> NativeBlockifierResult<(Option<CallInfo>, Fee)> {
         let tx_type: String = py_enum_name(tx, "tx_type")?;
         let Transaction::AccountTransaction(account_tx) = py_tx(&tx_type, tx, raw_contract_class)?
         else {
             panic!("L1 handlers should not be validated separately, only as part of execution")
         };
 
-        let mut resources = ExecutionResources::default();
-        Ok(account_tx.validate_tx(
+        let mut execution_resources = ExecutionResources::default();
+        let validate_call_info = account_tx.validate_tx(
             &mut self.state,
-            &mut resources,
+            &mut execution_resources,
             &mut remaining_gas,
             &self.block_context,
-        )?)
+        )?;
+
+        let ActualCostMetrics { actual_fee, .. } = account_tx
+            .into_cost_metrics_builder(&self.block_context)
+            .with_validate_call_info(validate_call_info.as_ref())
+            .try_add_state_changes(&mut self.state)?
+            .build_for_non_reverted_tx(&execution_resources)?;
+
+        Ok((validate_call_info, actual_fee))
     }
 
     /// Returns the state diff resulting in executing transactions.


### PR DESCRIPTION
This should have been added before, since Python needs blockifier to
calculate the actual fee in order to validate that there is sufficient
fee for the validation call.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/993)
<!-- Reviewable:end -->
