### PR TITLE
Return `actual_fee` from native validation API

### DIFF
--- a/crates/native_blockifier/src/py_validator.rs
+++ b/crates/native_blockifier/src/py_validator.rs
@@ -80,9 +80,11 @@ impl PyValidator {
         tx: &PyAny,
         remaining_gas: u64,
         raw_contract_class: Option<&str>,
-    ) -> NativeBlockifierResult<Option<PyCallInfo>> {
-        let maybe_call_info = self.tx_executor().validate(tx, remaining_gas, raw_contract_class)?;
-        Ok(maybe_call_info.map(PyCallInfo::from))
+    ) -> NativeBlockifierResult<(Option<PyCallInfo>, u128)> {
+        let (optional_call_info, actual_fee) =
+            self.tx_executor().validate(tx, remaining_gas, raw_contract_class)?;
+        let py_optional_call_info = optional_call_info.map(PyCallInfo::from);
+        Ok((py_optional_call_info, actual_fee.0))
     }
 
     pub fn close(&mut self) {

--- a/crates/native_blockifier/src/transaction_executor.rs
+++ b/crates/native_blockifier/src/transaction_executor.rs
@@ -4,6 +4,7 @@ use blockifier::block_context::BlockContext;
 use blockifier::block_execution::pre_process_block;
 use blockifier::execution::call_info::CallInfo;
 use blockifier::execution::entry_point::ExecutionResources;
+use blockifier::fee::actual_cost::ActualCost;
 use blockifier::state::cached_state::{
     CachedState, GlobalContractCache, StagedTransactionalState, TransactionalState,
 };
@@ -14,6 +15,7 @@ use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResour
 use pyo3::prelude::*;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::ClassHash;
+use starknet_api::transaction::Fee;
 
 use crate::errors::{NativeBlockifierError, NativeBlockifierResult};
 use crate::py_block_executor::{into_block_context, PyGeneralConfig};
@@ -99,20 +101,28 @@ impl<S: StateReader> TransactionExecutor<S> {
         tx: &PyAny,
         mut remaining_gas: u64,
         raw_contract_class: Option<&str>,
-    ) -> NativeBlockifierResult<Option<CallInfo>> {
+    ) -> NativeBlockifierResult<(Option<CallInfo>, Fee)> {
         let tx_type: String = py_enum_name(tx, "tx_type")?;
         let Transaction::AccountTransaction(account_tx) = py_tx(&tx_type, tx, raw_contract_class)?
         else {
             panic!("L1 handlers should not be validated separately, only as part of execution")
         };
 
-        let mut resources = ExecutionResources::default();
-        Ok(account_tx.validate_tx(
+        let mut execution_resources = ExecutionResources::default();
+        let validate_call_info = account_tx.validate_tx(
             &mut self.state,
-            &mut resources,
+            &mut execution_resources,
             &mut remaining_gas,
             &self.block_context,
-        )?)
+        )?;
+
+        let ActualCost { actual_fee, .. } = account_tx
+            .into_actual_cost_builder(&self.block_context)
+            .with_validate_call_info(&validate_call_info)
+            .try_add_state_changes(&mut self.state)?
+            .build_for_non_reverted_tx(&execution_resources)?;
+
+        Ok((validate_call_info, actual_fee))
     }
 
     /// Returns the state diff resulting in executing transactions.


### PR DESCRIPTION
This should have been added before, since Python needs blockifier to calculate the actual fee in order to validate that there is sufficient fee for the validation call.

fixes comments from: https://reviewable.io/reviews/starkware-libs/blockifier/997

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1004)
<!-- Reviewable:end -->
