### PR TITLE
Fix fee calculation in native blockifier validation

### DIFF
--- a/crates/native_blockifier/src/py_validator.rs
+++ b/crates/native_blockifier/src/py_validator.rs
@@ -47,6 +47,10 @@ impl PyValidator {
     ) -> NativeBlockifierResult<()> {
         let reader = PyStateReader::new(state_reader_proxy);
 
+        assert!(
+            self.tx_executor.is_none(),
+            "Transaction executor should be torn down between calls to validate"
+        );
         self.tx_executor = Some(TransactionExecutor::new(
             reader,
             &self.general_config,

--- a/crates/native_blockifier/src/transaction_executor.rs
+++ b/crates/native_blockifier/src/transaction_executor.rs
@@ -110,6 +110,12 @@ impl<S: StateReader> TransactionExecutor<S> {
 
         let mut execution_resources = ExecutionResources::default();
         let account_tx_context = account_tx.get_account_tx_context();
+
+        // For fee charging purposes, the nonce-increment cost is taken into consideration when
+        // calculating the fees for validation.
+        // Note: This assumes that the state is reset between calls to validate.
+        self.state.increment_nonce(account_tx_context.sender_address())?;
+
         let validate_call_info = account_tx.validate_tx(
             &mut self.state,
             &mut execution_resources,


### PR DESCRIPTION
Make handle_nonce public and call it before validating in
native_blockifier.
Note that this makes the usual assumption that the state of
TransactionExecutor is reset between calls to it's validate/execute API.


Python: https://reviewable.io/reviews/starkware-industries/starkware/31652

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1007)
<!-- Reviewable:end -->
