### PR TITLE
Remove single use testing util

### DIFF
--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -75,13 +75,6 @@ impl AccountTransaction {
         }
     }
 
-    pub fn get_address_of_deploy(&self) -> Option<ContractAddress> {
-        match self {
-            AccountTransaction::DeployAccount(deploy_tx) => Some(deploy_tx.contract_address),
-            _ => None,
-        }
-    }
-
     fn validate_entry_point_selector(&self) -> EntryPointSelector {
         let validate_entry_point_name = match self {
             Self::Declare(_) => constants::VALIDATE_DECLARE_ENTRY_POINT_NAME,

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -567,7 +567,11 @@ fn test_fail_deploy_account(block_context: BlockContext) {
         &mut NonceManager::default(),
     );
     let fee_token_address = block_context.fee_token_address(&deploy_account_tx.fee_type());
-    let deploy_address = deploy_account_tx.get_address_of_deploy().unwrap();
+
+    let deploy_address = match &deploy_account_tx {
+        AccountTransaction::DeployAccount(deploy_tx) => deploy_tx.contract_address,
+        _ => unreachable!("deploy_account_tx is a DeployAccount"),
+    };
 
     let initial_balance =
         state.get_fee_token_balance(&deployed_account_address, &fee_token_address).unwrap();


### PR DESCRIPTION
Method is only used once, in a test, and is probably too specific to appear in `AccountTransaction API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1065)
<!-- Reviewable:end -->
