### PR TITLE
Add calldata generator + one usage

### DIFF
--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -3,11 +3,11 @@ use std::collections::HashSet;
 use cairo_vm::serde::deserialize_program::BuiltinName;
 use num_bigint::BigInt;
 use pretty_assertions::assert_eq;
-use starknet_api::core::{EntryPointSelector, PatriciaKey};
+use starknet_api::core::{ContractAddress, EntryPointSelector, PatriciaKey};
 use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::Calldata;
-use starknet_api::{calldata, patricia_key, stark_felt};
+use starknet_api::{calldata, contract_address, patricia_key, stark_felt};
 
 use crate::abi::abi_utils::{get_storage_var_address, selector_from_name};
 use crate::execution::call_info::{CallExecution, CallInfo, Retdata};
@@ -16,7 +16,7 @@ use crate::execution::errors::EntryPointExecutionError;
 use crate::retdata;
 use crate::state::cached_state::CachedState;
 use crate::test_utils::{
-    create_test_state, deprecated_create_test_state, pad_address_to_64,
+    create_calldata, create_test_state, deprecated_create_test_state, pad_address_to_64,
     trivial_external_entry_point, trivial_external_entry_point_security_test, DictStateReader,
     SECURITY_TEST_CONTRACT_ADDRESS, TEST_CONTRACT_ADDRESS, TEST_CONTRACT_ADDRESS_2,
 };
@@ -509,19 +509,19 @@ fn test_cairo1_entry_point_segment_arena() {
 fn test_stack_trace() {
     let mut state = deprecated_create_test_state();
     // Nest 3 calls: test_call_contract -> test_call_contract -> assert_0_is_1.
-    let outer_entry_point_selector = selector_from_name("test_call_contract");
+    let call_contract_function_name = "test_call_contract";
     let inner_entry_point_selector = selector_from_name("foo");
-    let calldata = calldata![
-        stark_felt!(TEST_CONTRACT_ADDRESS_2), // Contract address.
-        outer_entry_point_selector.0,         // Calling test_call_contract again.
-        stark_felt!(3_u8),                    /* Calldata length for inner
-                                               * test_call_contract. */
-        stark_felt!(SECURITY_TEST_CONTRACT_ADDRESS), // Contract address.
-        inner_entry_point_selector.0,                // Function selector.
-        stark_felt!(0_u8)                            // Innermost calldata length.
-    ];
+    let calldata = create_calldata(
+        contract_address!(TEST_CONTRACT_ADDRESS_2),
+        call_contract_function_name,
+        &[
+            stark_felt!(SECURITY_TEST_CONTRACT_ADDRESS), // Contract address.
+            inner_entry_point_selector.0,                // Function selector.
+            stark_felt!(0_u8),                           // Innermost calldata length.
+        ],
+    );
     let entry_point_call = CallEntryPoint {
-        entry_point_selector: outer_entry_point_selector,
+        entry_point_selector: selector_from_name(call_contract_function_name),
         calldata,
         ..trivial_external_entry_point()
     };

--- a/crates/blockifier/src/execution/syscalls/syscalls_test.rs
+++ b/crates/blockifier/src/execution/syscalls/syscalls_test.rs
@@ -31,10 +31,10 @@ use crate::execution::syscalls::hint_processor::{
 use crate::retdata;
 use crate::state::state_api::{State, StateReader};
 use crate::test_utils::{
-    check_entry_point_execution_error_for_custom_hint, create_deploy_test_state, create_test_state,
-    trivial_external_entry_point, CHAIN_ID_NAME, CURRENT_BLOCK_NUMBER, CURRENT_BLOCK_TIMESTAMP,
-    TEST_CLASS_HASH, TEST_CONTRACT_ADDRESS, TEST_EMPTY_CONTRACT_CAIRO0_PATH,
-    TEST_EMPTY_CONTRACT_CLASS_HASH, TEST_SEQUENCER_ADDRESS,
+    check_entry_point_execution_error_for_custom_hint, create_calldata, create_deploy_test_state,
+    create_test_state, trivial_external_entry_point, CHAIN_ID_NAME, CURRENT_BLOCK_NUMBER,
+    CURRENT_BLOCK_TIMESTAMP, TEST_CLASS_HASH, TEST_CONTRACT_ADDRESS,
+    TEST_EMPTY_CONTRACT_CAIRO0_PATH, TEST_EMPTY_CONTRACT_CLASS_HASH, TEST_SEQUENCER_ADDRESS,
 };
 
 pub const REQUIRED_GAS_STORAGE_READ_WRITE_TEST: u64 = 34650;
@@ -73,14 +73,14 @@ fn test_call_contract() {
     let mut state = create_test_state();
 
     let outer_entry_point_selector = selector_from_name("test_call_contract");
-    let inner_entry_point_selector = selector_from_name("test_storage_read_write");
-    let calldata = calldata![
-        stark_felt!(TEST_CONTRACT_ADDRESS), // Contract address.
-        inner_entry_point_selector.0,       // Function selector.
-        stark_felt!(2_u8),                  // Calldata length.
-        stark_felt!(405_u16),               // Calldata: address.
-        stark_felt!(48_u8)                  // Calldata: value.
-    ];
+    let calldata = create_calldata(
+        contract_address!(TEST_CONTRACT_ADDRESS),
+        "test_storage_read_write",
+        &[
+            stark_felt!(405_u16), // Calldata: address.
+            stark_felt!(48_u8),   // Calldata: value.
+        ],
+    );
     let entry_point_call = CallEntryPoint {
         entry_point_selector: outer_entry_point_selector,
         calldata,

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -685,3 +685,21 @@ pub fn check_entry_point_execution_error_for_custom_hint(
         panic!("Unexpected structure for error: {:?}", error);
     }
 }
+
+pub fn create_calldata(
+    contract_address: ContractAddress,
+    entry_point_name: &str,
+    entry_point_args: &[StarkFelt],
+) -> Calldata {
+    let n_args = u128::try_from(entry_point_args.len()).expect("Calldata too big");
+    let n_args = StarkFelt::from(n_args);
+
+    let mut calldata = vec![
+        *contract_address.0.key(),              // Contract address.
+        selector_from_name(entry_point_name).0, // EP selector name.
+        n_args,
+    ];
+    calldata.extend(entry_point_args);
+
+    Calldata(calldata.into())
+}

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -9,17 +9,17 @@ use starknet_api::transaction::{
 };
 use starknet_api::{calldata, class_hash, contract_address, patricia_key, stark_felt};
 
-use crate::abi::abi_utils::{get_storage_var_address, selector_from_name};
+use crate::abi::abi_utils::get_storage_var_address;
 use crate::block_context::BlockContext;
 use crate::execution::contract_class::{ContractClass, ContractClassV0, ContractClassV1};
 use crate::invoke_tx_args;
 use crate::state::cached_state::CachedState;
 use crate::test_utils::{
-    invoke_tx, test_erc20_account_balance_key, test_erc20_faulty_account_balance_key,
-    DictStateReader, InvokeTxArgs, NonceManager, ACCOUNT_CONTRACT_CAIRO0_PATH,
-    ACCOUNT_CONTRACT_CAIRO1_PATH, BALANCE, ERC20_CONTRACT_PATH, TEST_ACCOUNT_CONTRACT_ADDRESS,
-    TEST_ACCOUNT_CONTRACT_CLASS_HASH, TEST_CLASS_HASH, TEST_CONTRACT_ADDRESS,
-    TEST_CONTRACT_CAIRO0_PATH, TEST_ERC20_CONTRACT_CLASS_HASH,
+    create_calldata, invoke_tx, test_erc20_account_balance_key,
+    test_erc20_faulty_account_balance_key, DictStateReader, InvokeTxArgs, NonceManager,
+    ACCOUNT_CONTRACT_CAIRO0_PATH, ACCOUNT_CONTRACT_CAIRO1_PATH, BALANCE, ERC20_CONTRACT_PATH,
+    TEST_ACCOUNT_CONTRACT_ADDRESS, TEST_ACCOUNT_CONTRACT_CLASS_HASH, TEST_CLASS_HASH,
+    TEST_CONTRACT_ADDRESS, TEST_CONTRACT_CAIRO0_PATH, TEST_ERC20_CONTRACT_CLASS_HASH,
     TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS, TEST_FAULTY_ACCOUNT_CONTRACT_CAIRO0_PATH,
     TEST_FAULTY_ACCOUNT_CONTRACT_CLASS_HASH,
 };
@@ -188,12 +188,11 @@ pub fn create_account_tx_for_validate_test(
             AccountTransaction::DeployAccount(deploy_account_tx)
         }
         TransactionType::InvokeFunction => {
-            let entry_point_selector = selector_from_name("foo");
-            let execute_calldata = calldata![
-                stark_felt!(TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS), // Contract address.
-                entry_point_selector.0,                            // EP selector.
-                stark_felt!(0_u8)                                  // Calldata length.
-            ];
+            let execute_calldata = create_calldata(
+                contract_address!(TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS),
+                "foo",
+                &[],
+            );
             let invoke_tx = crate::test_utils::invoke_tx(invoke_tx_args! {
                 signature,
                 sender_address: contract_address!(TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS),

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -36,10 +36,10 @@ use crate::state::cached_state::{CachedState, StateChangesCount};
 use crate::state::errors::StateError;
 use crate::state::state_api::{State, StateReader};
 use crate::test_utils::{
-    check_entry_point_execution_error_for_custom_hint, invoke_tx, test_erc20_account_balance_key,
-    test_erc20_sequencer_balance_key, DictStateReader, InvokeTxArgs, NonceManager,
-    ACCOUNT_CONTRACT_CAIRO1_PATH, BALANCE, CHAIN_ID_NAME, CURRENT_BLOCK_NUMBER,
-    CURRENT_BLOCK_TIMESTAMP, MAX_FEE, TEST_ACCOUNT_CONTRACT_ADDRESS,
+    check_entry_point_execution_error_for_custom_hint, create_calldata, invoke_tx,
+    test_erc20_account_balance_key, test_erc20_sequencer_balance_key, DictStateReader,
+    InvokeTxArgs, NonceManager, ACCOUNT_CONTRACT_CAIRO1_PATH, BALANCE, CHAIN_ID_NAME,
+    CURRENT_BLOCK_NUMBER, CURRENT_BLOCK_TIMESTAMP, MAX_FEE, TEST_ACCOUNT_CONTRACT_ADDRESS,
     TEST_ACCOUNT_CONTRACT_CLASS_HASH, TEST_CLASS_HASH, TEST_CONTRACT_ADDRESS,
     TEST_CONTRACT_CAIRO1_PATH, TEST_EMPTY_CONTRACT_CAIRO0_PATH, TEST_EMPTY_CONTRACT_CAIRO1_PATH,
     TEST_EMPTY_CONTRACT_CLASS_HASH, TEST_ERC20_CONTRACT_ADDRESS, TEST_ERC20_CONTRACT_CLASS_HASH,
@@ -267,13 +267,11 @@ fn validate_final_balances(
 }
 
 fn default_invoke_tx_args() -> InvokeTxArgs {
-    let entry_point_selector = selector_from_name("return_result");
-    let execute_calldata = calldata![
-        stark_felt!(TEST_CONTRACT_ADDRESS), // Contract address.
-        entry_point_selector.0,             // EP selector.
-        stark_felt!(1_u8),                  // Calldata length.
-        stark_felt!(2_u8)                   // Calldata: num.
-    ];
+    let execute_calldata = create_calldata(
+        contract_address!(TEST_CONTRACT_ADDRESS),
+        "return_result",
+        &[stark_felt!(2_u8)], // Calldata: num.
+    );
 
     invoke_tx_args! {
         max_fee: Fee(MAX_FEE),
@@ -450,15 +448,11 @@ fn test_state_get_fee_token_balance(state: &mut CachedState<DictStateReader>) {
     let recipient = stark_felt!(10_u8);
 
     // Mint some tokens.
-    let entry_point_selector = selector_from_name("permissionedMint");
-    let execute_calldata = calldata![
-        stark_felt!(TEST_ERC20_CONTRACT_ADDRESS), // Contract address.
-        entry_point_selector.0,                   // EP selector.
-        stark_felt!(3_u8),                        // Calldata length.
-        recipient,
-        mint_low,
-        mint_high
-    ];
+    let execute_calldata = create_calldata(
+        contract_address!(TEST_ERC20_CONTRACT_ADDRESS),
+        "permissionedMint",
+        &[recipient, mint_low, mint_high],
+    );
     let account_tx = account_invoke_tx(invoke_tx_args! {
         max_fee: Fee(MAX_FEE),
         sender_address: contract_address!(TEST_ACCOUNT_CONTRACT_ADDRESS),
@@ -1031,7 +1025,7 @@ fn test_calculate_tx_gas_usage() {
     let state = &mut create_state_with_trivial_validation_account();
     let block_context = &BlockContext::create_for_account_testing();
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT fee token address should depend on tx version.
-    let fee_token_address = *block_context.fee_token_addresses.eth_fee_token_address.0.key();
+    let fee_token_address = block_context.fee_token_addresses.eth_fee_token_address;
 
     let account_tx = account_invoke_tx(default_invoke_tx_args());
     let tx_execution_info = account_tx.execute(state, block_context, true, true).unwrap();
@@ -1049,16 +1043,16 @@ fn test_calculate_tx_gas_usage() {
     assert_eq!(tx_execution_info.actual_resources.gas_usage(), l1_gas_usage);
 
     // A tx that changes the account and some other balance in execute.
-    let entry_point_selector = selector_from_name(constants::TRANSFER_ENTRY_POINT_NAME);
     let some_other_account_address = stark_felt!(TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS);
-    let execute_calldata = calldata![
-        fee_token_address,          // Contract address.
-        entry_point_selector.0,     // EP selector.
-        stark_felt!(3_u8),          // Calldata length.
-        some_other_account_address, // Calldata: recipient.
-        stark_felt!(2_u8),          // Calldata: lsb amount.
-        stark_felt!(0_u8)           // Calldata: msb amount.
-    ];
+    let execute_calldata = create_calldata(
+        fee_token_address,
+        constants::TRANSFER_ENTRY_POINT_NAME,
+        &[
+            some_other_account_address, // Calldata: recipient.
+            stark_felt!(2_u8),          // Calldata: lsb amount.
+            stark_felt!(0_u8),          // Calldata: msb amount.
+        ],
+    );
 
     let account_tx = account_invoke_tx(invoke_tx_args! {
         max_fee: Fee(MAX_FEE),


### PR DESCRIPTION
Usage:
```rust
create_calldata(
    contract_address: <ContractAddress>,
    entry_point_name: "some_entry_point_name",
    entry_point_args: [
	starkfelt_arg_1,
	starkfelt_arg_2,
	...
    ]);
```

To be used instead of this pattern:
```rust
    calldata: calldata![
	*contract_address.0.key(),                      // Contract address.
	selector_from_name("some_entry_point_name").0,  // EP selector.
	stark_felt!(2_u8),                      	// Calldata length.
	stark_felt!(2_u8)                       	// Calldata: arg1.
	stark_felt!(3_u8)                       	// Calldata: arg2.
    ]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1066)
<!-- Reviewable:end -->
