### PR TITLE
Release 0.4.0-rc3 + bump SN API to 0.6.0-rc0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,43 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.4.0-rc2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36a7157bb3ae3df0ae2c7c714a56d805e6581a1ce466299a1cc9285ffcd4086"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-secp256k1",
+ "ark-secp256r1",
+ "cached",
+ "cairo-felt",
+ "cairo-lang-casm",
+ "cairo-lang-runner",
+ "cairo-lang-starknet",
+ "cairo-vm",
+ "ctor",
+ "derive_more",
+ "genco",
+ "indexmap 1.9.3",
+ "itertools 0.10.5",
+ "keccak",
+ "log",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.17",
+ "phf",
+ "serde",
+ "serde_json",
+ "sha3",
+ "starknet-crypto",
+ "starknet_api 0.5.0-rc1",
+ "strum",
+ "strum_macros 0.24.3",
+ "thiserror",
+]
+
+[[package]]
+name = "blockifier"
+version = "0.4.0-rc3"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -416,7 +453,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "starknet-crypto",
- "starknet_api",
+ "starknet_api 0.6.0-rc0",
  "strum",
  "strum_macros 0.24.3",
  "test-case",
@@ -2059,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "native_blockifier"
-version = "0.4.0-rc2"
+version = "0.4.0-rc3"
 dependencies = [
- "blockifier",
+ "blockifier 0.4.0-rc2",
  "cached",
  "cairo-lang-starknet",
  "cairo-vm",
@@ -2073,7 +2110,7 @@ dependencies = [
  "pyo3",
  "pyo3-log",
  "serde_json",
- "starknet_api",
+ "starknet_api 0.5.0-rc1",
  "tempfile",
  "thiserror",
 ]
@@ -2241,7 +2278,7 @@ dependencies = [
  "primitive-types",
  "serde",
  "serde_json",
- "starknet_api",
+ "starknet_api 0.5.0-rc1",
  "tempfile",
  "thiserror",
  "tracing",
@@ -3118,6 +3155,27 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-crypto",
+ "thiserror",
+]
+
+[[package]]
+name = "starknet_api"
+version = "0.6.0-rc0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed59a4103c50f0172847080598cc23a35dac0e484ad8dec1cb1f45819736f79b"
+dependencies = [
+ "cairo-lang-starknet",
+ "derive_more",
+ "genco",
+ "hex",
+ "indexmap 1.9.3",
+ "once_cell",
+ "primitive-types",
+ "serde",
+ "serde_json",
+ "starknet-crypto",
+ "strum",
+ "strum_macros 0.24.3",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 members = ["crates/blockifier", "crates/native_blockifier"]
 
 [workspace.package]
-version = "0.4.0-rc2"
+version = "0.4.0-rc3"
 edition = "2021"
 repository = "https://github.com/starkware-libs/blockifier/"
 license = "Apache-2.0"
@@ -39,7 +39,7 @@ pretty_assertions = "1.2.1"
 serde = "1.0.184"
 serde_json = "1.0.81"
 sha3 = "0.10.6"
-starknet_api = "0.5.0-rc1"
+starknet_api = "0.6.0-rc0"
 starknet-crypto = "0.5.1"
 strum = "0.24.1"
 strum_macros = "0.24.3"

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -23,9 +23,7 @@ name = "native_blockifier"
 crate-type = ["cdylib"]
 
 [dependencies]
-blockifier = { path = "../blockifier", version = "0.4.0-rc0", features = [
-    "testing",
-] }
+blockifier = { version = "0.4.0-rc2", features = ["testing"] }
 cairo-lang-starknet.workspace = true
 cairo-vm.workspace = true
 indexmap.workspace = true
@@ -35,7 +33,7 @@ papyrus_storage = { version = "0.0.5", features = ["testing"] }
 pyo3 = { version = "0.19.1", features = ["num-bigint", "hashbrown"] }
 pyo3-log = "0.8.1"
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
-starknet_api = { workspace = true, features = ["testing"] }
+starknet_api = { version = "0.5.0-rc1", features = ["testing"] }
 
 thiserror.workspace = true
 


### PR DESCRIPTION
- Release includes more functional support for v3 txs, and in particular a new version of SN API.
- Lock `native_blockifier`'s blockifier version to the previous rc to break the circular dependency with papyrus. Similarly, lock SN API to the version that was in the previous rc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1092)
<!-- Reviewable:end -->
