### PR TITLE
Add github nightly job that checks that dependencies are not broken

### DIFF
--- a/.github/workflows/verify-deps.yml
+++ b/.github/workflows/verify-deps.yml
@@ -1,0 +1,23 @@
+name: Nightly Latest Dependencies Check
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs at 00:00 UTC every day
+
+jobs:
+  latest_deps:
+    name: Latest Dependencies
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Update Dependencies
+        run: cargo update --verbose
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo test --verbose


### PR DESCRIPTION
Based on [this](https://doc.rust-lang.org/nightly/cargo/guide/continuous-integration.html#verifying-latest-dependencies)
recommendation from The Cargo Book.

This will give us a heads-up against a future `genco` problem from one of our deps.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1093)
<!-- Reviewable:end -->
