### PR TITLE
Hoist Python-to-Rust casts into bridge modules

### DIFF
--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -3,14 +3,16 @@ use std::sync::Arc;
 
 use blockifier::block_context::{BlockContext, FeeTokenAddresses, GasPrices};
 use blockifier::state::cached_state::GlobalContractCache;
+use blockifier::transaction::transaction_execution::Transaction;
 use pyo3::prelude::*;
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::core::{ChainId, ContractAddress};
 
 use crate::errors::NativeBlockifierResult;
 use crate::py_state_diff::{PyBlockInfo, PyStateDiff};
+use crate::py_transaction::py_tx;
 use crate::py_transaction_execution_info::{PyTransactionExecutionInfo, PyVmExecutionResources};
-use crate::py_utils::{int_to_chain_id, py_attr, PyFelt};
+use crate::py_utils::{int_to_chain_id, py_attr, py_enum_name, PyFelt};
 use crate::state_readers::papyrus_state::PapyrusReader;
 use crate::storage::{Storage, StorageConfig};
 use crate::transaction_executor::TransactionExecutor;
@@ -90,8 +92,10 @@ impl PyBlockExecutor {
         tx: &PyAny,
         raw_contract_class: Option<&str>,
     ) -> NativeBlockifierResult<(PyTransactionExecutionInfo, PyVmExecutionResources)> {
+        let tx_type: String = py_enum_name(tx, "tx_type")?;
+        let tx: Transaction = py_tx(&tx_type, tx, raw_contract_class)?;
         let charge_fee = true;
-        self.tx_executor().execute(tx, raw_contract_class, charge_fee)
+        self.tx_executor().execute(tx, charge_fee)
     }
 
     pub fn finalize(&mut self, is_pending_block: bool) -> PyStateDiff {

--- a/crates/native_blockifier/src/transaction_executor.rs
+++ b/crates/native_blockifier/src/transaction_executor.rs
@@ -9,10 +9,10 @@ use blockifier::state::cached_state::{
     CachedState, GlobalContractCache, StagedTransactionalState, TransactionalState,
 };
 use blockifier::state::state_api::{State, StateReader};
+use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::{ExecutableTransaction, ValidatableTransaction};
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResources;
-use pyo3::prelude::*;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::ClassHash;
 use starknet_api::transaction::Fee;
@@ -20,9 +20,8 @@ use starknet_api::transaction::Fee;
 use crate::errors::{NativeBlockifierError, NativeBlockifierResult};
 use crate::py_block_executor::{into_block_context, PyGeneralConfig};
 use crate::py_state_diff::{PyBlockInfo, PyStateDiff};
-use crate::py_transaction::py_tx;
 use crate::py_transaction_execution_info::{PyTransactionExecutionInfo, PyVmExecutionResources};
-use crate::py_utils::{py_enum_name, PyFelt};
+use crate::py_utils::PyFelt;
 
 pub struct TransactionExecutor<S: StateReader> {
     pub block_context: BlockContext,
@@ -61,13 +60,9 @@ impl<S: StateReader> TransactionExecutor<S> {
     /// (used for counting purposes).
     pub fn execute(
         &mut self,
-        tx: &PyAny,
-        raw_contract_class: Option<&str>,
+        tx: Transaction,
         charge_fee: bool,
     ) -> NativeBlockifierResult<(PyTransactionExecutionInfo, PyVmExecutionResources)> {
-        let tx_type: String = py_enum_name(tx, "tx_type")?;
-        let tx: Transaction = py_tx(&tx_type, tx, raw_contract_class)?;
-
         let mut tx_executed_class_hashes = HashSet::<ClassHash>::new();
         let mut transactional_state = CachedState::create_transactional(&mut self.state);
         let validate = true;
@@ -98,16 +93,9 @@ impl<S: StateReader> TransactionExecutor<S> {
 
     pub fn validate(
         &mut self,
-        tx: &PyAny,
+        account_tx: AccountTransaction,
         mut remaining_gas: u64,
-        raw_contract_class: Option<&str>,
     ) -> NativeBlockifierResult<(Option<CallInfo>, Fee)> {
-        let tx_type: String = py_enum_name(tx, "tx_type")?;
-        let Transaction::AccountTransaction(account_tx) = py_tx(&tx_type, tx, raw_contract_class)?
-        else {
-            panic!("L1 handlers should not be validated separately, only as part of execution")
-        };
-
         let mut execution_resources = ExecutionResources::default();
         let account_tx_context = account_tx.get_account_tx_context();
 


### PR DESCRIPTION
Enables greater versatility for upcoming pre and post-validation actions, orchestrated by PyValidator.

As a nice, unrelated side effect, this purifies `TransactionExecutor` from direct `PyO3` dependencies, making it a pure Rust module.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1095)
<!-- Reviewable:end -->
