### PR TITLE
Make `native_blockifier.Storage` testable + 1 use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,6 +2110,7 @@ dependencies = [
  "log",
  "num-bigint",
  "papyrus_storage",
+ "pretty_assertions",
  "pyo3",
  "pyo3-log",
  "serde_json",

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -38,8 +38,9 @@ thiserror.workspace = true
 
 [dev-dependencies]
 cached.workspace = true
-tempfile.workspace = true
 criterion = { version = "0.3", features = ["html_reports"] }
+pretty_assertions.workspace = true
+tempfile.workspace = true
 
 [[bench]]
 path = "bench/blockifier_bench.rs"

--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -14,6 +14,7 @@ pub mod py_validator;
 pub mod state_readers;
 pub mod storage;
 pub mod transaction_executor;
+pub mod test_utils;
 
 use errors::{add_py_exceptions, UndeclaredClassHashError};
 use py_block_executor::PyBlockExecutor;

--- a/crates/native_blockifier/src/py_block_executor_test.rs
+++ b/crates/native_blockifier/src/py_block_executor_test.rs
@@ -1,12 +1,18 @@
+use std::collections::HashMap;
+
 use blockifier::state::state_api::State;
 use blockifier::test_utils::{get_test_contract_class, TEST_CLASS_HASH};
 use cached::Cached;
+use pretty_assertions::assert_eq;
 use starknet_api::class_hash;
 use starknet_api::core::ClassHash;
-use starknet_api::hash::StarkHash;
+use starknet_api::hash::{StarkFelt, StarkHash};
 
 use crate::py_block_executor::{PyBlockExecutor, PyGeneralConfig};
 use crate::py_state_diff::PyBlockInfo;
+use crate::py_utils::PyFelt;
+use crate::test_utils::FakeStorage;
+
 #[test]
 fn global_contract_cache_update() {
     // Initialize executor and set a contract class on the state.
@@ -36,4 +42,28 @@ fn global_contract_cache_update() {
     block_executor.finalize(is_pending_block);
     assert_eq!(block_executor.global_contract_cache.lock().unwrap().cache_size(), 1);
     block_executor.teardown_block_execution();
+}
+
+#[test]
+fn get_block_id_with_large_hash_value() {
+    let mut max_class_hash = [0xF; 32];
+    max_class_hash[0] = 9;
+    let max_class_hash = Vec::from(max_class_hash);
+
+    let expected_max_class_hash_as_py_felt = PyFelt(
+        StarkFelt::new([
+            0x9, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf,
+            0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf,
+        ])
+        .unwrap(),
+    );
+
+    let storage =
+        FakeStorage { block_number_to_class_hash: HashMap::from([(1138, max_class_hash)]) };
+    let block_executor = PyBlockExecutor::create_for_testing_with_storage(storage);
+
+    assert_eq!(
+        block_executor.get_block_id_at_target(1138).unwrap().unwrap(),
+        expected_max_class_hash_as_py_felt
+    );
 }

--- a/crates/native_blockifier/src/py_utils.rs
+++ b/crates/native_blockifier/src/py_utils.rs
@@ -10,7 +10,7 @@ use starknet_api::state::StorageKey;
 
 use crate::errors::NativeBlockifierResult;
 
-#[derive(Clone, Copy, Default, Eq, FromPyObject, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, FromPyObject, Hash, PartialEq)]
 pub struct PyFelt(#[pyo3(from_py_with = "int_to_stark_felt")] pub StarkFelt);
 
 impl IntoPy<PyObject> for PyFelt {

--- a/crates/native_blockifier/src/storage.rs
+++ b/crates/native_blockifier/src/storage.rs
@@ -24,13 +24,13 @@ const GENESIS_BLOCK_ID: u64 = u64::MAX;
 // Invariant: Only one instance of this struct should exist.
 // Reader and writer fields must be cleared before the struct goes out of scope in Python;
 // to prevent possible memory leaks (TODO: see if this is indeed necessary).
-pub struct Storage {
+pub struct PapyrusStorage {
     reader: Option<papyrus_storage::StorageReader>,
     writer: Option<papyrus_storage::StorageWriter>,
 }
 
-impl Storage {
-    pub fn new(config: StorageConfig) -> NativeBlockifierResult<Storage> {
+impl PapyrusStorage {
+    pub fn new(config: StorageConfig) -> NativeBlockifierResult<PapyrusStorage> {
         log::debug!("Initializing Blockifier storage...");
         let db_config = papyrus_storage::db::DbConfig {
             path_prefix: config.path_prefix,
@@ -53,29 +53,39 @@ impl Storage {
         let (reader, writer) = papyrus_storage::open_storage(storage_config)?;
         log::debug!("Initialized Blockifier storage.");
 
-        Ok(Storage { reader: Some(reader), writer: Some(writer) })
+        Ok(PapyrusStorage { reader: Some(reader), writer: Some(writer) })
     }
 
     /// Manually drops the storage reader and writer.
     /// Python does not necessarily drop them even if instance is no longer live.
-    pub fn close(&mut self) {
-        log::debug!("Closing Blockifier storage.");
-        self.reader = None;
-        self.writer = None;
-    }
+    pub fn new_for_testing(path_prefix: PathBuf, chain_id: &ChainId) -> PapyrusStorage {
+        let db_config = papyrus_storage::db::DbConfig {
+            path_prefix,
+            chain_id: chain_id.clone(),
+            min_size: 1 << 20,    // 1MB
+            max_size: 1 << 35,    // 32GB
+            growth_step: 1 << 26, // 64MB
+        };
+        let storage_config = papyrus_storage::StorageConfig { db_config, ..Default::default() };
+        let (reader, writer) = papyrus_storage::open_storage(storage_config).unwrap();
 
+        PapyrusStorage { reader: Some(reader), writer: Some(writer) }
+    }
+}
+
+impl Storage for PapyrusStorage {
     /// Returns the next block number, for which state diff was not yet appended.
-    pub fn get_state_marker(&self) -> NativeBlockifierResult<u64> {
+    fn get_state_marker(&self) -> NativeBlockifierResult<u64> {
         let block_number = self.reader().begin_ro_txn()?.get_state_marker()?;
         Ok(block_number.0)
     }
 
-    pub fn get_header_marker(&self) -> NativeBlockifierResult<u64> {
+    fn get_header_marker(&self) -> NativeBlockifierResult<u64> {
         let block_number = self.reader().begin_ro_txn()?.get_header_marker()?;
         Ok(block_number.0)
     }
 
-    pub fn get_block_id(&self, block_number: u64) -> NativeBlockifierResult<Option<Vec<u8>>> {
+    fn get_block_id(&self, block_number: u64) -> NativeBlockifierResult<Option<Vec<u8>>> {
         let block_number = BlockNumber(block_number);
         let block_hash = self
             .reader()
@@ -85,7 +95,7 @@ impl Storage {
         Ok(block_hash)
     }
 
-    pub fn revert_block(&mut self, block_number: u64) -> NativeBlockifierResult<()> {
+    fn revert_block(&mut self, block_number: u64) -> NativeBlockifierResult<()> {
         log::debug!("Reverting state diff for {block_number:?}.");
         let block_number = BlockNumber(block_number);
         let revert_txn = self.writer().begin_rw_txn()?;
@@ -97,7 +107,7 @@ impl Storage {
     }
 
     // TODO(Gilad): Refactor.
-    pub fn append_block(
+    fn append_block(
         &mut self,
         block_id: u64,
         previous_block_id: Option<PyFelt>,
@@ -205,21 +215,7 @@ impl Storage {
         Ok(())
     }
 
-    pub fn new_for_testing(path_prefix: PathBuf, chain_id: &ChainId) -> Storage {
-        let db_config = papyrus_storage::db::DbConfig {
-            path_prefix,
-            chain_id: chain_id.clone(),
-            min_size: 1 << 20,    // 1MB
-            max_size: 1 << 35,    // 32GB
-            growth_step: 1 << 26, // 64MB
-        };
-        let storage_config = papyrus_storage::StorageConfig { db_config, ..Default::default() };
-        let (reader, writer) = papyrus_storage::open_storage(storage_config).unwrap();
-
-        Storage { reader: Some(reader), writer: Some(writer) }
-    }
-
-    pub fn validate_aligned(&self, source_block_number: u64) {
+    fn validate_aligned(&self, source_block_number: u64) {
         let header_marker = self.get_header_marker().expect("Should have a header marker");
         let state_marker = self.get_state_marker().expect("Should have a state marker");
 
@@ -236,12 +232,18 @@ impl Storage {
         );
     }
 
-    pub fn reader(&self) -> &papyrus_storage::StorageReader {
+    fn reader(&self) -> &papyrus_storage::StorageReader {
         self.reader.as_ref().expect("Storage should be initialized.")
     }
 
-    pub fn writer(&mut self) -> &mut papyrus_storage::StorageWriter {
+    fn writer(&mut self) -> &mut papyrus_storage::StorageWriter {
         self.writer.as_mut().expect("Storage should be initialized.")
+    }
+
+    fn close(&mut self) {
+        log::debug!("Closing Blockifier storage.");
+        self.reader = None;
+        self.writer = None;
     }
 }
 
@@ -264,4 +266,23 @@ impl StorageConfig {
     ) -> Self {
         Self { path_prefix, chain_id, max_size }
     }
+}
+pub trait Storage {
+    fn get_state_marker(&self) -> NativeBlockifierResult<u64>;
+    fn get_header_marker(&self) -> NativeBlockifierResult<u64>;
+    fn get_block_id(&self, block_number: u64) -> NativeBlockifierResult<Option<Vec<u8>>>;
+    fn revert_block(&mut self, block_number: u64) -> NativeBlockifierResult<()>;
+    fn append_block(
+        &mut self,
+        block_id: u64,
+        previous_block_id: Option<PyFelt>,
+        py_block_info: PyBlockInfo,
+        py_state_diff: PyStateDiff,
+        declared_class_hash_to_class: HashMap<PyFelt, (PyFelt, String)>,
+        deprecated_declared_class_hash_to_class: HashMap<PyFelt, String>,
+    ) -> NativeBlockifierResult<()>;
+    fn validate_aligned(&self, source_block_number: u64);
+    fn reader(&self) -> &papyrus_storage::StorageReader;
+    fn writer(&mut self) -> &mut papyrus_storage::StorageWriter;
+    fn close(&mut self);
 }

--- a/crates/native_blockifier/src/test_utils.rs
+++ b/crates/native_blockifier/src/test_utils.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+
+use crate::errors::NativeBlockifierResult;
+use crate::storage::Storage;
+
+pub struct FakeStorage {
+    pub block_number_to_class_hash: HashMap<u64, Vec<u8>>,
+    // .. Add more as needed.
+}
+impl Storage for FakeStorage {
+    fn get_block_id(&self, block_number: u64) -> NativeBlockifierResult<Option<Vec<u8>>> {
+        Ok(self.block_number_to_class_hash.get(&block_number).cloned())
+    }
+
+    fn get_state_marker(&self) -> NativeBlockifierResult<u64> {
+        todo!()
+    }
+
+    fn get_header_marker(&self) -> NativeBlockifierResult<u64> {
+        todo!()
+    }
+
+    fn revert_block(&mut self, _block_number: u64) -> NativeBlockifierResult<()> {
+        todo!()
+    }
+
+    fn append_block(
+        &mut self,
+        _block_id: u64,
+        _previous_block_id: Option<crate::py_utils::PyFelt>,
+        _py_block_info: crate::py_state_diff::PyBlockInfo,
+        _py_state_diff: crate::py_state_diff::PyStateDiff,
+        _declared_class_hash_to_class: HashMap<
+            crate::py_utils::PyFelt,
+            (crate::py_utils::PyFelt, String),
+        >,
+        _deprecated_declared_class_hash_to_class: HashMap<crate::py_utils::PyFelt, String>,
+    ) -> NativeBlockifierResult<()> {
+        todo!()
+    }
+
+    fn validate_aligned(&self, _source_block_number: u64) {
+        todo!()
+    }
+
+    fn reader(&self) -> &papyrus_storage::StorageReader {
+        todo!()
+    }
+
+    fn writer(&mut self) -> &mut papyrus_storage::StorageWriter {
+        todo!()
+    }
+
+    fn close(&mut self) {
+        todo!()
+    }
+}


### PR DESCRIPTION
- Traitify `Storage`, so that it can be mocked as `FakeStorage`.
- Previous `Storage` became `PapyrusStorage` and methods moved to `impl trait`, no logic changes.
- Add test for get_block_id: tests the state the system is when loading from a `papyrus` snapshot, which will return a `StarkHash` (this hit a bug in the past, when we assumed it was `u64`)

Python: https://reviewable.io/reviews/starkware-industries/starkware/32665

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1149)
<!-- Reviewable:end -->
