### PR TITLE
Add Storage mock and test for get_block_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,6 +2110,7 @@ dependencies = [
  "log",
  "num-bigint",
  "papyrus_storage",
+ "pretty_assertions",
  "pyo3",
  "pyo3-log",
  "serde_json",

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -38,8 +38,9 @@ thiserror.workspace = true
 
 [dev-dependencies]
 cached.workspace = true
-tempfile.workspace = true
 criterion = { version = "0.3", features = ["html_reports"] }
+pretty_assertions.workspace = true
+tempfile.workspace = true
 
 [[bench]]
 path = "bench/blockifier_bench.rs"

--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -14,6 +14,7 @@ pub mod py_validator;
 pub mod state_readers;
 pub mod storage;
 pub mod transaction_executor;
+pub mod test_utils;
 
 use errors::{add_py_exceptions, UndeclaredClassHashError};
 use py_block_executor::PyBlockExecutor;

--- a/crates/native_blockifier/src/py_block_executor_test.rs
+++ b/crates/native_blockifier/src/py_block_executor_test.rs
@@ -1,12 +1,18 @@
+use std::collections::HashMap;
+
 use blockifier::state::state_api::State;
 use blockifier::test_utils::{get_test_contract_class, TEST_CLASS_HASH};
 use cached::Cached;
+use pretty_assertions::assert_eq;
 use starknet_api::class_hash;
 use starknet_api::core::ClassHash;
-use starknet_api::hash::StarkHash;
+use starknet_api::hash::{StarkFelt, StarkHash};
 
 use crate::py_block_executor::{PyBlockExecutor, PyGeneralConfig};
 use crate::py_state_diff::PyBlockInfo;
+use crate::py_utils::PyFelt;
+use crate::test_utils::FakeStorage;
+
 #[test]
 fn global_contract_cache_update() {
     // Initialize executor and set a contract class on the state.
@@ -36,4 +42,28 @@ fn global_contract_cache_update() {
     block_executor.finalize(is_pending_block);
     assert_eq!(block_executor.global_contract_cache.lock().unwrap().cache_size(), 1);
     block_executor.teardown_block_execution();
+}
+
+#[test]
+fn get_block_id_with_large_hash_value() {
+    let mut max_class_hash = [0xF; 32];
+    max_class_hash[0] = 9;
+    let max_class_hash = Vec::from(max_class_hash);
+
+    let expected_max_class_hash_as_py_felt = PyFelt(
+        StarkFelt::new([
+            0x9, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf,
+            0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf,
+        ])
+        .unwrap(),
+    );
+
+    let storage =
+        FakeStorage { block_number_to_class_hash: HashMap::from([(1138, max_class_hash)]) };
+    let block_executor = PyBlockExecutor::create_for_testing_with_storage(storage);
+
+    assert_eq!(
+        block_executor.get_block_id_at_target(1138).unwrap().unwrap(),
+        expected_max_class_hash_as_py_felt
+    );
 }

--- a/crates/native_blockifier/src/test_utils.rs
+++ b/crates/native_blockifier/src/test_utils.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+
+use crate::errors::NativeBlockifierResult;
+use crate::storage::Storage;
+
+pub struct FakeStorage {
+    pub block_number_to_class_hash: HashMap<u64, Vec<u8>>,
+    // .. Add more as needed.
+}
+impl Storage for FakeStorage {
+    fn get_block_id(&self, block_number: u64) -> NativeBlockifierResult<Option<Vec<u8>>> {
+        Ok(self.block_number_to_class_hash.get(&block_number).cloned())
+    }
+
+    fn get_state_marker(&self) -> NativeBlockifierResult<u64> {
+        todo!()
+    }
+
+    fn get_header_marker(&self) -> NativeBlockifierResult<u64> {
+        todo!()
+    }
+
+    fn revert_block(&mut self, _block_number: u64) -> NativeBlockifierResult<()> {
+        todo!()
+    }
+
+    fn append_block(
+        &mut self,
+        _block_id: u64,
+        _previous_block_id: Option<crate::py_utils::PyFelt>,
+        _py_block_info: crate::py_state_diff::PyBlockInfo,
+        _py_state_diff: crate::py_state_diff::PyStateDiff,
+        _declared_class_hash_to_class: HashMap<
+            crate::py_utils::PyFelt,
+            (crate::py_utils::PyFelt, String),
+        >,
+        _deprecated_declared_class_hash_to_class: HashMap<crate::py_utils::PyFelt, String>,
+    ) -> NativeBlockifierResult<()> {
+        todo!()
+    }
+
+    fn validate_aligned(&self, _source_block_number: u64) {
+        todo!()
+    }
+
+    fn reader(&self) -> &papyrus_storage::StorageReader {
+        todo!()
+    }
+
+    fn writer(&mut self) -> &mut papyrus_storage::StorageWriter {
+        todo!()
+    }
+
+    fn close(&mut self) {
+        todo!()
+    }
+}


### PR DESCRIPTION
Specifically, when retrieving block_id from a Papyrus snapshot
it can be a large hash, which we had a bug on back when we assumed it
was a u64.

---

**Stack**:
- #1154 ⬅
- #1153


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1154)
<!-- Reviewable:end -->
