### PR TITLE
Add Storage mock and test for get_block_id

### DIFF
--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -13,6 +13,7 @@ pub mod py_utils;
 pub mod py_validator;
 pub mod state_readers;
 pub mod storage;
+pub mod test_utils;
 pub mod transaction_executor;
 
 use errors::{add_py_exceptions, UndeclaredClassHashError};

--- a/crates/native_blockifier/src/py_block_executor_test.rs
+++ b/crates/native_blockifier/src/py_block_executor_test.rs
@@ -1,12 +1,18 @@
+use std::collections::HashMap;
+
 use blockifier::state::state_api::State;
 use blockifier::test_utils::{get_test_contract_class, TEST_CLASS_HASH};
 use cached::Cached;
+use pretty_assertions::assert_eq;
 use starknet_api::class_hash;
 use starknet_api::core::ClassHash;
-use starknet_api::hash::StarkHash;
+use starknet_api::hash::{StarkFelt, StarkHash};
 
 use crate::py_block_executor::{PyBlockExecutor, PyGeneralConfig};
 use crate::py_state_diff::PyBlockInfo;
+use crate::py_utils::PyFelt;
+use crate::test_utils::MockStorage;
+
 #[test]
 fn global_contract_cache_update() {
     // Initialize executor and set a contract class on the state.
@@ -36,4 +42,23 @@ fn global_contract_cache_update() {
     block_executor.finalize(is_pending_block);
     assert_eq!(block_executor.global_contract_cache.lock().unwrap().cache_size(), 1);
     block_executor.teardown_block_execution();
+}
+
+#[test]
+fn get_block_id() {
+    let max_class_hash = [
+        0x9, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf,
+        0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf,
+    ];
+    let max_class_hash_vec = Vec::from(max_class_hash);
+    let expected_max_class_hash_as_py_felt = PyFelt(StarkFelt::new(max_class_hash).unwrap());
+
+    let storage =
+        MockStorage { block_number_to_class_hash: HashMap::from([(1138, max_class_hash_vec)]) };
+    let block_executor = PyBlockExecutor::create_for_testing_with_storage(storage);
+
+    assert_eq!(
+        block_executor.get_block_id_at_target(1138).unwrap().unwrap(),
+        expected_max_class_hash_as_py_felt
+    );
 }

--- a/crates/native_blockifier/src/test_utils.rs
+++ b/crates/native_blockifier/src/test_utils.rs
@@ -1,0 +1,58 @@
+use std::collections::HashMap;
+
+use crate::errors::NativeBlockifierResult;
+use crate::storage::Storage;
+
+pub struct MockStorage {
+    pub block_number_to_class_hash: HashMap<u64, Vec<u8>>,
+    // .. Add more as needed.
+}
+
+impl Storage for MockStorage {
+    fn get_block_id(&self, block_number: u64) -> NativeBlockifierResult<Option<Vec<u8>>> {
+        Ok(self.block_number_to_class_hash.get(&block_number).cloned())
+    }
+
+    fn get_state_marker(&self) -> NativeBlockifierResult<u64> {
+        todo!()
+    }
+
+    fn get_header_marker(&self) -> NativeBlockifierResult<u64> {
+        todo!()
+    }
+
+    fn revert_block(&mut self, _block_number: u64) -> NativeBlockifierResult<()> {
+        todo!()
+    }
+
+    fn append_block(
+        &mut self,
+        _block_id: u64,
+        _previous_block_id: Option<crate::py_utils::PyFelt>,
+        _py_block_info: crate::py_state_diff::PyBlockInfo,
+        _py_state_diff: crate::py_state_diff::PyStateDiff,
+        _declared_class_hash_to_class: HashMap<
+            crate::py_utils::PyFelt,
+            (crate::py_utils::PyFelt, String),
+        >,
+        _deprecated_declared_class_hash_to_class: HashMap<crate::py_utils::PyFelt, String>,
+    ) -> NativeBlockifierResult<()> {
+        todo!()
+    }
+
+    fn validate_aligned(&self, _source_block_number: u64) {
+        todo!()
+    }
+
+    fn reader(&self) -> &papyrus_storage::StorageReader {
+        todo!()
+    }
+
+    fn writer(&mut self) -> &mut papyrus_storage::StorageWriter {
+        todo!()
+    }
+
+    fn close(&mut self) {
+        todo!()
+    }
+}


### PR DESCRIPTION
Specifically, when retrieving block_id from a Papyrus snapshot
it can be a large hash, which we had a bug on back when we assumed it
was a u64.

commit-id:979a9b19