### PR TITLE
Rust 1.74 refactor: move lints into `Cargo.toml`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,13 +1,3 @@
-[build]
-# Configuration for these lints should be placed in `.clippy.toml` at the crate root.
-rustflags = [
-    "-Dwarnings",
-    "-Dfuture-incompatible",
-    "-Dnonstandard-style",
-    "-Drust-2018-idioms",
-    "-Dunused",
-]
-
 [env]
 # Increase Rust stack size.
 # This should be large enough for `MAX_ENTRY_POINT_RECURSION_DEPTH` recursive entry point calls.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,10 @@ strum_macros = "0.24.3"
 test-case = "2.2.2"
 tempfile = "3.7.0"
 thiserror = "1.0.37"
+
+[workspace.lints.rust]
+warnings = "deny"
+future-incompatible = "deny"
+nonstandard-style = "deny"
+rust-2018-idioms = "deny"
+unused = "deny"

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -6,6 +6,8 @@ repository.workspace = true
 license-file.workspace = true
 description = "The transaction-executing component in the StarkNet sequencer."
 
+[lints]
+workspace = true
 
 [features]
 testing = []

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -12,6 +12,8 @@ description = "A Bridge between the Rust blockifier crate and Python."
 [features]
 extension-module = ["pyo3/extension-module"]
 
+[lints]
+workspace = true
 
 [lib]
 name = "native_blockifier"


### PR DESCRIPTION
**Stack**:
- #1161
- #1160 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1160)
<!-- Reviewable:end -->
