### PR TITLE
`native_blockifier`: add `testing` feature.

### DIFF
--- a/crates/blockifier/BUILD
+++ b/crates/blockifier/BUILD
@@ -2,10 +2,11 @@ load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library")
 
 rust_library(
-    name = "blockifier",
-    srcs = glob(["src/**/*.rs"]),
-    visibility = ["//crates:__subpackages__"],
-    deps = all_crate_deps(),
-    proc_macro_deps = all_crate_deps(proc_macro = True),
-    edition = "2021",
+    name="blockifier",
+    srcs=glob(["src/**/*.rs"]),
+    visibility=["//crates:__subpackages__"],
+    deps=all_crate_deps(),
+    proc_macro_deps=all_crate_deps(proc_macro=True),
+    edition="2021",
+    crate_features=["testing"],
 )

--- a/crates/native_blockifier/BUILD
+++ b/crates/native_blockifier/BUILD
@@ -6,6 +6,7 @@ rust_shared_library(
     name = "native_blockifier",
     srcs = glob(["src/**/*.rs"]),
     visibility = ["//crates:__subpackages__"],
+    crate_features=["testing"],
     deps = all_crate_deps() + ["//crates/blockifier"],
 )
 

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -11,6 +11,7 @@ description = "A Bridge between the Rust blockifier crate and Python."
 # https://pyo3.rs/v0.19.1/faq#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror
 [features]
 extension-module = ["pyo3/extension-module"]
+testing = []
 
 [lints]
 workspace = true

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -195,6 +195,7 @@ impl PyBlockExecutor {
         self.storage.close();
     }
 
+    #[cfg(any(feature = "testing", test))]
     #[pyo3(signature = (general_config, path))]
     #[staticmethod]
     fn create_for_testing(general_config: PyGeneralConfig, path: std::path::PathBuf) -> Self {

--- a/crates/native_blockifier/src/py_validator.rs
+++ b/crates/native_blockifier/src/py_validator.rs
@@ -158,6 +158,7 @@ impl PyValidator {
         Ok(())
     }
 
+    #[cfg(any(feature = "testing", test))]
     #[pyo3(signature = (general_config))]
     #[staticmethod]
     fn create_for_testing(general_config: PyGeneralConfig) -> Self {


### PR DESCRIPTION
- Add `testing` feature to native_blockifier (up until now this feature wasn't available for use in python).
- Compile native_blockifier with the `testing` feature turned on: note that this means that all of blockifier's `create_for_testing` methods will be exposed in production, however in Python that is already the case for the rest of the classes which expose their testing methods.
- Make block_executor/validator testing methods tied to the `testing` feature: this isn't strictly necessary at the moment (since `testing` is default on anyway...), but will become necessary in an upcoming commit which calls a test_utils.rs method, and that one's only available in `any(testing,test)`.

Python: https://reviewable.io/reviews/starkware-industries/starkware/32729

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1170)
<!-- Reviewable:end -->
