### PR TITLE
Add util `OsResources.resources_for_tx_type`

### DIFF
--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -284,12 +284,7 @@ impl EntryPointExecutionContext {
             .map(|call_info| call_info.vm_resources.n_steps)
             .unwrap_or_default();
 
-        let overhead_steps = OS_RESOURCES
-            .execute_txs_inner()
-            .get(tx_type)
-            .expect("`OS_RESOURCES` must contain all transaction types.")
-            .n_steps;
-
+        let overhead_steps = OS_RESOURCES.resources_for_tx_type(tx_type).n_steps;
         self.subtract_steps(validate_steps + overhead_steps)
     }
 

--- a/crates/blockifier/src/fee/gas_usage.rs
+++ b/crates/blockifier/src/fee/gas_usage.rs
@@ -143,11 +143,7 @@ pub fn estimate_minimal_l1_gas(
     tx: &AccountTransaction,
 ) -> TransactionPreValidationResult<u128> {
     // TODO(Dori, 1/8/2023): Give names to the constant VM step estimates and regression-test them.
-    let os_steps_for_type = OS_RESOURCES
-        .execute_txs_inner()
-        .get(&tx.tx_type())
-        .expect("`OS_RESOURCES` must contain all transaction types.")
-        .n_steps;
+    let os_steps_for_type = OS_RESOURCES.resources_for_tx_type(&tx.tx_type()).n_steps;
     let gas_for_type: usize = match tx {
         // We consider the following state changes: sender balance update (storage update) + nonce
         // increment (contract modification) (we exclude the sequencer balance update and the ERC20

--- a/crates/blockifier/src/fee/os_usage.rs
+++ b/crates/blockifier/src/fee/os_usage.rs
@@ -24,8 +24,10 @@ pub struct OsResources {
 }
 
 impl OsResources {
-    pub fn execute_txs_inner(&self) -> &HashMap<TransactionType, VmExecutionResources> {
-        &self.execute_txs_inner
+    pub fn resources_for_tx_type(&self, tx_type: &TransactionType) -> &VmExecutionResources {
+        self.execute_txs_inner
+            .get(tx_type)
+            .unwrap_or_else(|| panic!("should contain transaction type '{tx_type:?}'."))
     }
 }
 
@@ -48,9 +50,6 @@ pub fn get_additional_os_resources(
     // i.e., the resources of the StarkNet OS function `execute_transactions_inner`.
     // Also adds the resources needed for the fee transfer execution, performed in the end·
     // of every transaction.
-    let os_resources = OS_RESOURCES
-        .execute_txs_inner
-        .get(&tx_type)
-        .expect("`OS_RESOURCES` must contain all transaction types.");
+    let os_resources = OS_RESOURCES.resources_for_tx_type(&tx_type);
     Ok(&os_additional_vm_resources + os_resources)
 }


### PR DESCRIPTION
Replaces common idiom. Also move getter after `new`, which should be the
first function.

commit-id:026d5d94