### PR TITLE
Get `OsResources` as an external arg

### DIFF
--- a/crates/blockifier/src/block_context.rs
+++ b/crates/blockifier/src/block_context.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::core::{ChainId, ContractAddress};
 
+use crate::fee::os_usage::OsResources;
 use crate::transaction::objects::FeeType;
 
 #[derive(Clone, Debug)]
@@ -17,6 +18,7 @@ pub struct BlockContext {
     pub fee_token_addresses: FeeTokenAddresses,
     pub vm_resource_fee_cost: Arc<HashMap<String, f64>>,
     pub gas_prices: GasPrices,
+    pub os_resources: Arc<OsResources>,
 
     // Limits.
     pub invoke_tx_max_n_steps: u32,

--- a/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
@@ -34,38 +34,73 @@ pub mod hint_processor;
 pub type DeprecatedSyscallResult<T> = Result<T, DeprecatedSyscallExecutionError>;
 pub type WriteResponseResult = DeprecatedSyscallResult<()>;
 
+// TODO: Replace repetitive aliases with alias_all='snake_case' if it ever gets implemented:
+// https://github.com/serde-rs/serde/issues/1530.
+// Another option is to use `rename_all='snake_case'`, but that will prevent deserde from loading
+// PascalCase, which is awkward for a Rust enum.
 #[derive(Clone, Copy, Debug, Deserialize, EnumIter, Eq, Hash, PartialEq)]
 pub enum DeprecatedSyscallSelector {
+    #[serde(alias = "call_contract")]
     CallContract,
+    #[serde(alias = "delegate_call")]
     DelegateCall,
+    #[serde(alias = "delegate_l1_handler")]
     DelegateL1Handler,
+    #[serde(alias = "deploy")]
     Deploy,
+    #[serde(alias = "emit_event")]
     EmitEvent,
+    #[serde(alias = "get_block_hash")]
     GetBlockHash,
+    #[serde(alias = "get_block_number")]
     GetBlockNumber,
+    #[serde(alias = "get_block_timestamp")]
     GetBlockTimestamp,
+    #[serde(alias = "get_caller_address")]
     GetCallerAddress,
+    #[serde(alias = "get_contract_address")]
     GetContractAddress,
+    #[serde(alias = "get_execution_info")]
     GetExecutionInfo,
+    #[serde(alias = "get_sequencer_address")]
     GetSequencerAddress,
+    #[serde(alias = "get_tx_info")]
     GetTxInfo,
+    #[serde(alias = "get_tx_signature")]
     GetTxSignature,
+    #[serde(alias = "keccak")]
     Keccak,
+    #[serde(alias = "library_call")]
     LibraryCall,
+    #[serde(alias = "library_call_l1_handler")]
     LibraryCallL1Handler,
+    #[serde(alias = "replace_class")]
     ReplaceClass,
+    #[serde(alias = "secp256k1_add")]
     Secp256k1Add,
+    #[serde(alias = "secp256k1_get_point_from_x")]
     Secp256k1GetPointFromX,
+    #[serde(alias = "secp256k1_get_xy")]
     Secp256k1GetXy,
+    #[serde(alias = "secp256k1_mul")]
     Secp256k1Mul,
+    #[serde(alias = "secp256k1_new")]
     Secp256k1New,
+    #[serde(alias = "secp256r1_add")]
     Secp256r1Add,
+    #[serde(alias = "secp256r1_get_point_from_x")]
     Secp256r1GetPointFromX,
+    #[serde(alias = "secp256r1_get_xy")]
     Secp256r1GetXy,
+    #[serde(alias = "secp256r1_mul")]
     Secp256r1Mul,
+    #[serde(alias = "secp256r1_new")]
     Secp256r1New,
+    #[serde(alias = "send_message_to_l1")]
     SendMessageToL1,
+    #[serde(alias = "storage_read")]
     StorageRead,
+    #[serde(alias = "storage_write")]
     StorageWrite,
 }
 

--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -18,7 +18,7 @@ use crate::execution::common_hints::ExecutionMode;
 use crate::execution::deprecated_syscalls::hint_processor::SyscallCounter;
 use crate::execution::errors::{EntryPointExecutionError, PreExecutionError};
 use crate::execution::execution_utils::execute_entry_point_call;
-use crate::fee::os_resources::OS_RESOURCES;
+use crate::fee::os_usage::OsResources;
 use crate::state::state_api::State;
 use crate::transaction::objects::{
     AccountTransactionContext, HasRelatedFeeType, TransactionExecutionResult,
@@ -278,13 +278,15 @@ impl EntryPointExecutionContext {
         &mut self,
         validate_call_info: &Option<CallInfo>,
         tx_type: &TransactionType,
+        os_resources: &OsResources,
     ) -> usize {
         let validate_steps = validate_call_info
             .as_ref()
             .map(|call_info| call_info.vm_resources.n_steps)
             .unwrap_or_default();
 
-        let overhead_steps = OS_RESOURCES.resources_for_tx_type(tx_type).n_steps;
+        let overhead_steps = os_resources.resources_for_tx_type(tx_type).n_steps;
+
         self.subtract_steps(validate_steps + overhead_steps)
     }
 

--- a/crates/blockifier/src/fee/gas_usage.rs
+++ b/crates/blockifier/src/fee/gas_usage.rs
@@ -6,7 +6,6 @@ use super::fee_utils::{calculate_tx_l1_gas_usage, get_fee_by_l1_gas_usage};
 use crate::abi::constants;
 use crate::block_context::BlockContext;
 use crate::fee::eth_gas_constants;
-use crate::fee::os_resources::OS_RESOURCES;
 use crate::state::cached_state::StateChangesCount;
 use crate::transaction::account_transaction::AccountTransaction;
 use crate::transaction::objects::{
@@ -143,7 +142,9 @@ pub fn estimate_minimal_l1_gas(
     tx: &AccountTransaction,
 ) -> TransactionPreValidationResult<u128> {
     // TODO(Dori, 1/8/2023): Give names to the constant VM step estimates and regression-test them.
-    let os_steps_for_type = OS_RESOURCES.resources_for_tx_type(&tx.tx_type()).n_steps;
+    let tx_type = &tx.tx_type();
+    let os_steps_for_type = block_context.os_resources.resources_for_tx_type(tx_type).n_steps;
+
     let gas_for_type: usize = match tx {
         // We consider the following state changes: sender balance update (storage update) + nonce
         // increment (contract modification) (we exclude the sequencer balance update and the ERC20

--- a/crates/blockifier/src/fee/os_resources.rs
+++ b/crates/blockifier/src/fee/os_resources.rs
@@ -9,7 +9,7 @@ pub static OS_RESOURCES: OsResources = {
 };
 
 // TODO(Arni, 14/6/2023): Update `GetBlockHash` values.
-fn os_resources() -> serde_json::Value {
+pub fn os_resources() -> serde_json::Value {
     json!({
         "execute_syscalls": {
             "CallContract": {

--- a/crates/blockifier/src/fee/os_usage.rs
+++ b/crates/blockifier/src/fee/os_usage.rs
@@ -1,17 +1,27 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
+use cairo_vm::vm::runners::builtin_runner;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResources;
 use serde::Deserialize;
+use strum::IntoEnumIterator;
+use thiserror::Error;
 
 use crate::execution::deprecated_syscalls::hint_processor::SyscallCounter;
 use crate::execution::deprecated_syscalls::DeprecatedSyscallSelector;
-use crate::fee::os_resources::OS_RESOURCES;
 use crate::transaction::errors::TransactionExecutionError;
 use crate::transaction::transaction_types::TransactionType;
 
-#[cfg(test)]
-#[path = "os_usage_test.rs"]
-pub mod test;
+const KNOWN_BUILTIN_NAMES: [&str; 9] = [
+    builtin_runner::OUTPUT_BUILTIN_NAME,
+    builtin_runner::HASH_BUILTIN_NAME,
+    builtin_runner::RANGE_CHECK_BUILTIN_NAME,
+    builtin_runner::SIGNATURE_BUILTIN_NAME,
+    builtin_runner::BITWISE_BUILTIN_NAME,
+    builtin_runner::EC_OP_BUILTIN_NAME,
+    builtin_runner::KECCAK_BUILTIN_NAME,
+    builtin_runner::POSEIDON_BUILTIN_NAME,
+    builtin_runner::SEGMENT_ARENA_BUILTIN_NAME,
+];
 
 #[derive(Debug, Deserialize)]
 pub struct OsResources {
@@ -24,10 +34,80 @@ pub struct OsResources {
 }
 
 impl OsResources {
+    pub fn new(os_resources: String) -> Result<Self, OsResourcesError> {
+        let os_resources: OsResources = serde_json::from_str(&os_resources)?;
+
+        // Run Validations.
+        os_resources.validate_execute_syscalls_contain_all_syscall_selectors()?;
+        os_resources.validate_execute_txs_inner_contains_all_tx_types()?;
+        os_resources.validate_known_builtins()?;
+
+        Ok(os_resources)
+    }
+
+    pub fn execute_txs_inner(&self) -> &HashMap<TransactionType, VmExecutionResources> {
+        &self.execute_txs_inner
+    }
+
     pub fn resources_for_tx_type(&self, tx_type: &TransactionType) -> &VmExecutionResources {
         self.execute_txs_inner
             .get(tx_type)
             .unwrap_or_else(|| panic!("should contain transaction type '{tx_type:?}'."))
+    }
+
+    // Validations.
+
+    fn validate_execute_syscalls_contain_all_syscall_selectors(
+        &self,
+    ) -> Result<(), OsResourcesError> {
+        let missing_variants: Vec<DeprecatedSyscallSelector> = DeprecatedSyscallSelector::iter()
+            .filter(|variant| !self.execute_syscalls.contains_key(variant))
+            .collect();
+
+        if missing_variants.is_empty() {
+            Ok(())
+        } else {
+            Err(OsResourcesError::ValidationError(format!(
+                "os_resources.execute_syscalls missing syscall selectors: {:?}",
+                missing_variants
+            )))
+        }
+    }
+
+    fn validate_execute_txs_inner_contains_all_tx_types(&self) -> Result<(), OsResourcesError> {
+        let missing_variants: Vec<TransactionType> = TransactionType::iter()
+            .filter(|variant| !self.execute_txs_inner.contains_key(variant))
+            .collect();
+
+        if missing_variants.is_empty() {
+            Ok(())
+        } else {
+            Err(OsResourcesError::ValidationError(format!(
+                "os_resources.execute_txs_inner missing transaction types: {:?}",
+                missing_variants
+            )))
+        }
+    }
+
+    fn validate_known_builtins(&self) -> Result<(), OsResourcesError> {
+        let builtins: HashSet<&str> = self
+            .execute_syscalls
+            .values()
+            .chain(self.execute_txs_inner.values())
+            .flat_map(|resources| resources.builtin_instance_counter.keys())
+            .map(|s| s.as_str())
+            .collect();
+
+        let unknown_builtins: HashSet<&str> =
+            builtins.difference(&KNOWN_BUILTIN_NAMES.iter().cloned().collect()).cloned().collect();
+
+        if unknown_builtins.is_empty() {
+            Ok(())
+        } else {
+            Err(OsResourcesError::ValidationError(format!(
+                "Os resources includes unrecognized builtins: {unknown_builtins:?}",
+            )))
+        }
     }
 }
 
@@ -36,13 +116,14 @@ impl OsResources {
 pub fn get_additional_os_resources(
     syscall_counter: &SyscallCounter,
     tx_type: TransactionType,
+    os_resources: &OsResources,
 ) -> Result<VmExecutionResources, TransactionExecutionError> {
     let mut os_additional_vm_resources = VmExecutionResources::default();
     for (syscall_selector, count) in syscall_counter {
-        let syscall_resources =
-            OS_RESOURCES.execute_syscalls.get(syscall_selector).unwrap_or_else(|| {
-                panic!("OS resources of syscall '{syscall_selector:?}' are unknown.")
-            });
+        let syscall_resources = os_resources
+            .execute_syscalls
+            .get(syscall_selector)
+            .unwrap_or_else(|| panic!("Should contain syscall selector '{syscall_selector:?}'."));
         os_additional_vm_resources += &(syscall_resources * *count);
     }
 
@@ -50,6 +131,14 @@ pub fn get_additional_os_resources(
     // i.e., the resources of the StarkNet OS function `execute_transactions_inner`.
     // Also adds the resources needed for the fee transfer execution, performed in the end·
     // of every transaction.
-    let os_resources = OS_RESOURCES.resources_for_tx_type(&tx_type);
-    Ok(&os_additional_vm_resources + os_resources)
+    let os_resources_for_tx_type = os_resources.resources_for_tx_type(&tx_type);
+    Ok(&os_additional_vm_resources + os_resources_for_tx_type)
+}
+
+#[derive(Debug, Error)]
+pub enum OsResourcesError {
+    #[error(transparent)]
+    SerdeError(#[from] serde_json::Error),
+    #[error("{0}")]
+    ValidationError(String),
 }

--- a/crates/blockifier/src/test_utils/struct_impls.rs
+++ b/crates/blockifier/src/test_utils/struct_impls.rs
@@ -23,6 +23,7 @@ use crate::execution::contract_class::{ContractClassV0, ContractClassV1};
 use crate::execution::entry_point::{
     CallEntryPoint, EntryPointExecutionContext, EntryPointExecutionResult, ExecutionResources,
 };
+use crate::fee::os_resources;
 use crate::state::state_api::State;
 use crate::test_utils::get_raw_contract_class;
 use crate::transaction::objects::{AccountTransactionContext, DeprecatedAccountTransactionContext};
@@ -102,6 +103,8 @@ impl BlockContext {
             },
             invoke_tx_max_n_steps: MAX_STEPS_PER_TX as u32,
             validate_max_n_steps: MAX_VALIDATE_STEPS_PER_TX as u32,
+            os_resources: serde_json::from_value(os_resources::os_resources())
+                .expect("os_resources json does not exist or cannot be deserialized."),
             max_recursion_depth: 50,
         }
     }

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -432,8 +432,11 @@ impl AccountTransaction {
             charge_fee,
         )?;
 
-        let n_allotted_execution_steps = execution_context
-            .subtract_validation_and_overhead_steps(&validate_call_info, &self.tx_type());
+        let n_allotted_execution_steps = execution_context.subtract_validation_and_overhead_steps(
+            &validate_call_info,
+            &self.tx_type(),
+            &block_context.os_resources,
+        );
 
         // Save the state changes resulting from running `validate_tx`, to be used later for
         // resource and fee calculation.
@@ -577,7 +580,12 @@ impl AccountTransaction {
     }
 
     pub fn into_actual_cost_builder(&self, block_context: &BlockContext) -> ActualCostBuilder<'_> {
-        ActualCostBuilder::new(block_context, self.get_account_tx_context(), self.tx_type())
+        ActualCostBuilder::new(
+            block_context,
+            self.get_account_tx_context(),
+            self.tx_type(),
+            block_context.os_resources.clone(),
+        )
     }
 }
 

--- a/crates/blockifier/src/transaction/errors.rs
+++ b/crates/blockifier/src/transaction/errors.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use crate::execution::call_info::Retdata;
 use crate::execution::errors::EntryPointExecutionError;
 use crate::fee::fee_checks::FeeCheckError;
+use crate::fee::os_usage::OsResourcesError;
 use crate::state::errors::StateError;
 
 #[derive(Debug, Error)]
@@ -66,6 +67,8 @@ pub enum TransactionExecutionError {
          {allowed_versions:?}."
     )]
     InvalidVersion { version: TransactionVersion, allowed_versions: Vec<TransactionVersion> },
+    #[error(transparent)]
+    OsResourcesError(#[from] OsResourcesError),
     #[error(transparent)]
     StarknetApiError(#[from] StarknetApiError),
     #[error(transparent)]

--- a/crates/blockifier/src/transaction/transaction_types.rs
+++ b/crates/blockifier/src/transaction/transaction_types.rs
@@ -7,9 +7,13 @@ use crate::transaction::errors::ParseError;
 
 #[derive(Clone, Copy, Debug, Deserialize, EnumIter, Eq, Hash, PartialEq)]
 pub enum TransactionType {
+    #[serde(alias = "DECLARE")]
     Declare,
+    #[serde(alias = "DEPLOY_ACCOUNT")]
     DeployAccount,
+    #[serde(alias = "INVOKE_FUNCTION")]
     InvokeFunction,
+    #[serde(alias = "L1_HANDLER")]
     L1Handler,
 }
 

--- a/crates/blockifier/src/transaction/transaction_utils.rs
+++ b/crates/blockifier/src/transaction/transaction_utils.rs
@@ -8,7 +8,7 @@ use crate::execution::call_info::CallInfo;
 use crate::execution::contract_class::ContractClass;
 use crate::execution::entry_point::ExecutionResources;
 use crate::fee::gas_usage::calculate_tx_gas_usage;
-use crate::fee::os_usage::get_additional_os_resources;
+use crate::fee::os_usage::{get_additional_os_resources, OsResources};
 use crate::state::cached_state::StateChangesCount;
 use crate::transaction::errors::TransactionExecutionError;
 use crate::transaction::objects::{ResourcesMapping, TransactionExecutionResult};
@@ -40,10 +40,15 @@ pub fn calculate_tx_resources(
     execution_resources: &ExecutionResources,
     l1_gas_usage: usize,
     tx_type: TransactionType,
+    os_resources: &OsResources,
 ) -> TransactionExecutionResult<ResourcesMapping> {
     // Add additional Cairo resources needed for the OS to run the transaction.
     let total_vm_usage = &execution_resources.vm_resources
-        + &get_additional_os_resources(&execution_resources.syscall_counter, tx_type)?;
+        + &get_additional_os_resources(
+            &execution_resources.syscall_counter,
+            tx_type,
+            os_resources,
+        )?;
     let mut total_vm_usage = total_vm_usage.filter_unused_builtins();
     // The segment arena" builtin is not part of SHARP (not in any proof layout).
     // Each instance requires approximately 10 steps in the OS.

--- a/crates/native_blockifier/src/errors.rs
+++ b/crates/native_blockifier/src/errors.rs
@@ -1,3 +1,4 @@
+use blockifier::fee::os_usage::OsResourcesError;
 use blockifier::state::errors::StateError;
 use blockifier::transaction::errors::{
     ParseError, TransactionExecutionError, TransactionPreValidationError,
@@ -82,6 +83,8 @@ pub enum NativeBlockifierInputError {
     UnsupportedContractClassVersion { version: usize },
     #[error("Transaction of type {tx_type:?} is unsupported in version {version}.")]
     UnsupportedTransactionVersion { tx_type: TransactionType, version: usize },
+    #[error(transparent)]
+    OsResourcesError(#[from] OsResourcesError),
 }
 
 create_exception!(native_blockifier, UndeclaredClassHashError, PyException);

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -2,13 +2,15 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use blockifier::block_context::{BlockContext, FeeTokenAddresses, GasPrices};
+use blockifier::fee::os_resources;
+use blockifier::fee::os_usage::OsResources;
 use blockifier::state::cached_state::GlobalContractCache;
 use pyo3::prelude::*;
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::core::{ChainId, ContractAddress};
 use starknet_api::hash::StarkFelt;
 
-use crate::errors::NativeBlockifierResult;
+use crate::errors::{NativeBlockifierInputError, NativeBlockifierResult};
 use crate::py_state_diff::{PyBlockInfo, PyStateDiff};
 use crate::py_transaction_execution_info::{PyTransactionExecutionInfo, PyVmExecutionResources};
 use crate::py_utils::{int_to_chain_id, py_attr, PyFelt};
@@ -28,30 +30,35 @@ pub struct PyBlockExecutor {
     /// `Send` trait is required for `pyclass` compatibility as Python objects must be threadsafe.
     pub storage: Box<dyn Storage + Send>,
     pub global_contract_cache: GlobalContractCache,
+    pub os_resources: Arc<OsResources>,
 }
 
 #[pymethods]
 impl PyBlockExecutor {
     #[new]
-    #[pyo3(signature = (general_config, max_recursion_depth, target_storage_config))]
+    #[pyo3(signature = (general_config, max_recursion_depth, target_storage_config,os_resources))]
     pub fn create(
         general_config: PyGeneralConfig,
         max_recursion_depth: usize,
         target_storage_config: StorageConfig,
-    ) -> Self {
+        os_resources: String,
+    ) -> NativeBlockifierResult<Self> {
         log::debug!("Initializing Block Executor...");
         let tx_executor = None;
         let storage =
             PapyrusStorage::new(target_storage_config).expect("Failed to initialize storage");
 
+        let os_resources =
+            OsResources::new(os_resources).map_err(NativeBlockifierInputError::OsResourcesError)?;
         log::debug!("Initialized Block Executor.");
-        Self {
+        Ok(Self {
             general_config,
             max_recursion_depth,
             tx_executor,
             storage: Box::new(storage),
             global_contract_cache: GlobalContractCache::default(),
-        }
+            os_resources: Arc::new(os_resources),
+        })
     }
 
     #[pyo3(signature = (next_block_number))]
@@ -77,6 +84,7 @@ impl PyBlockExecutor {
             next_block_info,
             self.max_recursion_depth,
             self.global_contract_cache.clone(),
+            self.os_resources.clone(),
         )?;
         self.tx_executor = Some(tx_executor);
 
@@ -207,6 +215,9 @@ impl PyBlockExecutor {
             max_recursion_depth: 50,
             tx_executor: None,
             global_contract_cache: GlobalContractCache::default(),
+            //  REMOVE ME! get this as a param.
+            os_resources: serde_json::from_value(os_resources::os_resources())
+                .expect("os_resources json does not exist or cannot be deserialized."),
         }
     }
 }
@@ -230,6 +241,8 @@ impl PyBlockExecutor {
             max_recursion_depth: 50,
             tx_executor: None,
             global_contract_cache: GlobalContractCache::default(),
+            os_resources: serde_json::from_value(os_resources::os_resources())
+                .expect("os_resources json does not exist or cannot be deserialized."),
         }
     }
 }
@@ -288,6 +301,7 @@ pub fn into_block_context(
     general_config: &PyGeneralConfig,
     block_info: PyBlockInfo,
     max_recursion_depth: usize,
+    os_resources: Arc<OsResources>,
 ) -> NativeBlockifierResult<BlockContext> {
     let starknet_os_config = general_config.starknet_os_config.clone();
     let block_number = BlockNumber(block_info.block_number);
@@ -309,6 +323,7 @@ pub fn into_block_context(
             eth_l1_gas_price: block_info.eth_l1_gas_price,
             strk_l1_gas_price: block_info.strk_l1_gas_price,
         },
+        os_resources,
         invoke_tx_max_n_steps: general_config.invoke_tx_max_n_steps,
         validate_max_n_steps: general_config.validate_max_n_steps,
         max_recursion_depth,

--- a/crates/native_blockifier/src/transaction_executor.rs
+++ b/crates/native_blockifier/src/transaction_executor.rs
@@ -1,10 +1,12 @@
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use blockifier::block_context::BlockContext;
 use blockifier::block_execution::pre_process_block;
 use blockifier::execution::call_info::CallInfo;
 use blockifier::execution::entry_point::ExecutionResources;
 use blockifier::fee::actual_cost::ActualCost;
+use blockifier::fee::os_usage::OsResources;
 use blockifier::state::cached_state::{
     CachedState, GlobalContractCache, StagedTransactionalState, TransactionalState,
 };
@@ -46,10 +48,12 @@ impl<S: StateReader> TransactionExecutor<S> {
         block_info: PyBlockInfo,
         max_recursion_depth: usize,
         global_contract_cache: GlobalContractCache,
+        os_resources: Arc<OsResources>,
     ) -> NativeBlockifierResult<Self> {
         log::debug!("Initializing Transaction Executor...");
 
-        let block_context = into_block_context(general_config, block_info, max_recursion_depth)?;
+        let block_context =
+            into_block_context(general_config, block_info, max_recursion_depth, os_resources)?;
         let state = CachedState::new(state_reader, global_contract_cache);
         let executed_class_hashes = HashSet::<ClassHash>::new();
         log::debug!("Initialized Transaction Executor.");


### PR DESCRIPTION
- Don't maintain os_resources inside the blockifier, it is passed from
outside.
- This will be tested in a subsequent commit.

---

**Stack**:
- #1181
- #1180 ⬅
- #1179
- #1178
- #1177
- #1176
- #1175


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1180)
<!-- Reviewable:end -->
