### PR TITLE
Convert `OS_RESOURCES` json into a test fixture

### DIFF
--- a/crates/blockifier/src/fee.rs
+++ b/crates/blockifier/src/fee.rs
@@ -3,6 +3,5 @@ pub mod eth_gas_constants;
 pub mod fee_checks;
 pub mod fee_utils;
 pub mod gas_usage;
-pub mod os_resources;
 pub mod os_usage;
 pub mod strk_gas_price;

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -2,6 +2,7 @@ pub mod cached_state;
 pub mod deploy_account;
 pub mod dict_state_reader;
 pub mod invoke;
+pub mod os_resources_fixture;
 pub mod struct_impls;
 
 use std::collections::HashMap;

--- a/crates/blockifier/src/test_utils/os_resources_fixture.rs
+++ b/crates/blockifier/src/test_utils/os_resources_fixture.rs
@@ -1,15 +1,15 @@
+use std::sync::Arc;
+
 use serde_json::json;
 
 use crate::fee::os_usage::OsResources;
 
 #[ctor::ctor]
-pub static OS_RESOURCES: OsResources = {
-    serde_json::from_value(os_resources())
-        .expect("os_resources json does not exist or cannot be deserialized.")
-};
+pub static MOCK_OS_RESOURCES: Arc<OsResources> =
+    Arc::new(OsResources::new(raw_mock_os_resources()).expect("OS resources validation failed."));
 
 // TODO(Arni, 14/6/2023): Update `GetBlockHash` values.
-pub fn os_resources() -> serde_json::Value {
+fn raw_mock_os_resources() -> String {
     json!({
         "execute_syscalls": {
             "CallContract": {
@@ -93,8 +93,6 @@ pub fn os_resources() -> serde_json::Value {
                 "n_memory_holes": 0,
                 "n_steps": 44
             },
-            // The following is the cost of one Keccak round.
-            // TODO(ilya): Consider moving the resources of a keccak round to a seperate dict.
             "Keccak": {
                 "builtin_instance_counter": {
                     "bitwise_builtin": 6,
@@ -244,4 +242,5 @@ pub fn os_resources() -> serde_json::Value {
             }
         }
     })
+    .to_string()
 }

--- a/crates/blockifier/src/test_utils/struct_impls.rs
+++ b/crates/blockifier/src/test_utils/struct_impls.rs
@@ -23,9 +23,9 @@ use crate::execution::contract_class::{ContractClassV0, ContractClassV1};
 use crate::execution::entry_point::{
     CallEntryPoint, EntryPointExecutionContext, EntryPointExecutionResult, ExecutionResources,
 };
-use crate::fee::os_resources;
 use crate::state::state_api::State;
 use crate::test_utils::get_raw_contract_class;
+use crate::test_utils::os_resources_fixture::MOCK_OS_RESOURCES;
 use crate::transaction::objects::{AccountTransactionContext, DeprecatedAccountTransactionContext};
 
 impl CallEntryPoint {
@@ -103,8 +103,7 @@ impl BlockContext {
             },
             invoke_tx_max_n_steps: MAX_STEPS_PER_TX as u32,
             validate_max_n_steps: MAX_VALIDATE_STEPS_PER_TX as u32,
-            os_resources: serde_json::from_value(os_resources::os_resources())
-                .expect("os_resources json does not exist or cannot be deserialized."),
+            os_resources: MOCK_OS_RESOURCES.clone(),
             max_recursion_depth: 50,
         }
     }

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use blockifier::block_context::{BlockContext, FeeTokenAddresses, GasPrices};
-use blockifier::fee::os_resources;
 use blockifier::fee::os_usage::OsResources;
 use blockifier::state::cached_state::GlobalContractCache;
 use pyo3::prelude::*;
@@ -215,9 +214,7 @@ impl PyBlockExecutor {
             max_recursion_depth: 50,
             tx_executor: None,
             global_contract_cache: GlobalContractCache::default(),
-            //  REMOVE ME! get this as a param.
-            os_resources: serde_json::from_value(os_resources::os_resources())
-                .expect("os_resources json does not exist or cannot be deserialized."),
+            os_resources: blockifier::test_utils::os_resources_fixture::MOCK_OS_RESOURCES.clone(),
         }
     }
 }
@@ -241,8 +238,7 @@ impl PyBlockExecutor {
             max_recursion_depth: 50,
             tx_executor: None,
             global_contract_cache: GlobalContractCache::default(),
-            os_resources: serde_json::from_value(os_resources::os_resources())
-                .expect("os_resources json does not exist or cannot be deserialized."),
+            os_resources: blockifier::test_utils::os_resources_fixture::MOCK_OS_RESOURCES.clone(),
         }
     }
 }

--- a/crates/native_blockifier/src/py_validator.rs
+++ b/crates/native_blockifier/src/py_validator.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use blockifier::fee::actual_cost::ActualCost;
 use blockifier::fee::fee_checks::PostValidationReport;
-use blockifier::fee::os_resources;
 use blockifier::fee::os_usage::OsResources;
 use blockifier::state::cached_state::GlobalContractCache;
 use blockifier::state::state_api::StateReader;
@@ -178,8 +177,7 @@ impl PyValidator {
             max_nonce_for_validation_skip: Nonce(StarkFelt::ONE),
             tx_executor: None,
             global_contract_cache: GlobalContractCache::default(),
-            os_resources: serde_json::from_value(os_resources::os_resources())
-                .expect("os_resources json does not exist or cannot be deserialized."),
+            os_resources: blockifier::test_utils::os_resources_fixture::MOCK_OS_RESOURCES.clone(),
         }
     }
 }


### PR DESCRIPTION
- We no longer use this json in production code, since it is passed to
the blockifier during initialization.
- Convert old os_resources into a test fixture.
- Removed TODOs from the old json, these will be added to the Python
code's os_resources.json.
- Removed os_usage_test, these tests are now input validators in
`OsResources.new`.

---

**Stack**:
- #1181 ⬅
- #1180
- #1179
- #1178
- #1177
- #1176
- #1175


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1181)
<!-- Reviewable:end -->
