### PR TITLE
Revert "Don't iterate over `HashMap/HashSet` (#1164)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,7 +2611,6 @@ checksum = "e681a6cfdc4adcc93b4d3cf993749a4552018ee0a9b65fc0ccfad74352c72a38"
 dependencies = [
  "cfg-if",
  "hashbrown 0.14.2",
- "indexmap 1.9.3",
  "indoc 1.0.9",
  "libc",
  "memoffset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,3 @@ future-incompatible = "deny"
 nonstandard-style = "deny"
 rust-2018-idioms = "deny"
 unused = "deny"
-
-[workspace.lints.clippy]
-# Uncomment once rust stable becomes >= 1.75.
-# iter_over_hash_type = "deny"

--- a/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
@@ -16,7 +16,6 @@ use cairo_vm::vm::errors::memory_errors::MemoryError;
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
 use cairo_vm::vm::runners::cairo_runner::{ResourceTracker, RunResources};
 use cairo_vm::vm::vm_core::VirtualMachine;
-use indexmap::IndexMap;
 use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector};
 use starknet_api::deprecated_contract_class::EntryPointType;
 use starknet_api::hash::StarkFelt;
@@ -50,7 +49,7 @@ use crate::execution::hint_code;
 use crate::state::errors::StateError;
 use crate::state::state_api::State;
 
-pub type SyscallCounter = IndexMap<DeprecatedSyscallSelector, usize>;
+pub type SyscallCounter = HashMap<DeprecatedSyscallSelector, usize>;
 
 #[derive(Debug, Error)]
 pub enum DeprecatedSyscallExecutionError {

--- a/crates/blockifier/src/fee/os_usage_test.rs
+++ b/crates/blockifier/src/fee/os_usage_test.rs
@@ -1,5 +1,6 @@
+use std::collections::HashSet;
+
 use cairo_vm::vm::runners::builtin_runner;
-use indexmap::IndexSet;
 use strum::IntoEnumIterator;
 
 use crate::execution::deprecated_syscalls::DeprecatedSyscallSelector;
@@ -18,7 +19,7 @@ fn test_resources_entries() {
 
 #[test]
 fn test_resource_name_consistency() {
-    let known_builtin_names: IndexSet<&str> = IndexSet::from([
+    let known_builtin_names: HashSet<&str> = HashSet::from([
         builtin_runner::OUTPUT_BUILTIN_NAME,
         builtin_runner::HASH_BUILTIN_NAME,
         builtin_runner::RANGE_CHECK_BUILTIN_NAME,
@@ -32,7 +33,7 @@ fn test_resource_name_consistency() {
     for resources in
         OS_RESOURCES.execute_syscalls.values().chain(OS_RESOURCES.execute_txs_inner.values())
     {
-        for builtin_name in Vec::from_iter(resources.builtin_instance_counter.keys()) {
+        for builtin_name in resources.builtin_instance_counter.keys() {
             assert!(known_builtin_names.contains(builtin_name.as_str()));
         }
     }

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use cached::{Cached, SizedCache};
 use derive_more::IntoIterator;
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexMap;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
@@ -64,7 +64,7 @@ impl<S: StateReader> CachedState<S> {
 
         // Storage Update.
         let storage_updates = &mut self.cache.get_storage_updates();
-        let mut modified_contracts: IndexSet<ContractAddress> =
+        let mut modified_contracts: HashSet<ContractAddress> =
             storage_updates.keys().map(|address_key_pair| address_key_pair.0).collect();
 
         // Class hash Update (deployed contracts + replace_class syscall).
@@ -357,7 +357,7 @@ impl Default for CachedState<crate::test_utils::DictStateReader> {
 pub type ContractStorageKey = (ContractAddress, StorageKey);
 
 #[derive(Debug, Default, IntoIterator)]
-pub struct StorageView(pub IndexMap<ContractStorageKey, StarkFelt>);
+pub struct StorageView(pub HashMap<ContractStorageKey, StarkFelt>);
 
 /// Converts a `CachedState`'s storage mapping into a `StateDiff`'s storage mapping.
 impl From<StorageView> for IndexMap<ContractAddress, IndexMap<StorageKey, StarkFelt>> {
@@ -389,10 +389,10 @@ pub struct StateCache {
     compiled_class_hash_initial_values: HashMap<ClassHash, CompiledClassHash>,
 
     // Writer's cached information.
-    nonce_writes: IndexMap<ContractAddress, Nonce>,
-    class_hash_writes: IndexMap<ContractAddress, ClassHash>,
-    storage_writes: IndexMap<ContractStorageKey, StarkFelt>,
-    compiled_class_hash_writes: IndexMap<ClassHash, CompiledClassHash>,
+    nonce_writes: HashMap<ContractAddress, Nonce>,
+    class_hash_writes: HashMap<ContractAddress, ClassHash>,
+    storage_writes: HashMap<ContractStorageKey, StarkFelt>,
+    compiled_class_hash_writes: HashMap<ClassHash, CompiledClassHash>,
 }
 
 impl StateCache {
@@ -481,19 +481,19 @@ impl StateCache {
         self.compiled_class_hash_writes.insert(class_hash, compiled_class_hash);
     }
 
-    fn get_storage_updates(&self) -> IndexMap<ContractStorageKey, StarkFelt> {
+    fn get_storage_updates(&self) -> HashMap<ContractStorageKey, StarkFelt> {
         subtract_mappings(&self.storage_writes, &self.storage_initial_values)
     }
 
-    fn get_class_hash_updates(&self) -> IndexMap<ContractAddress, ClassHash> {
+    fn get_class_hash_updates(&self) -> HashMap<ContractAddress, ClassHash> {
         subtract_mappings(&self.class_hash_writes, &self.class_hash_initial_values)
     }
 
-    fn get_nonce_updates(&self) -> IndexMap<ContractAddress, Nonce> {
+    fn get_nonce_updates(&self) -> HashMap<ContractAddress, Nonce> {
         subtract_mappings(&self.nonce_writes, &self.nonce_initial_values)
     }
 
-    fn get_compiled_class_hash_updates(&self) -> IndexMap<ClassHash, CompiledClassHash> {
+    fn get_compiled_class_hash_updates(&self) -> HashMap<ClassHash, CompiledClassHash> {
         subtract_mappings(
             &self.compiled_class_hash_writes,
             &self.compiled_class_hash_initial_values,
@@ -589,7 +589,7 @@ pub type TransactionalState<'a, S> = CachedState<MutRefState<'a, CachedState<S>>
 /// Adds the ability to perform a transactional execution.
 impl<'a, S: StateReader> TransactionalState<'a, S> {
     // Detach `state`, moving the instance to a pending state, which can be committed or aborted.
-    pub fn stage(self, tx_executed_class_hashes: IndexSet<ClassHash>) -> StagedTransactionalState {
+    pub fn stage(self, tx_executed_class_hashes: HashSet<ClassHash>) -> StagedTransactionalState {
         let TransactionalState { cache, class_hash_to_class, global_class_hash_to_class, .. } =
             self;
         StagedTransactionalState {
@@ -620,7 +620,7 @@ pub struct StagedTransactionalState {
     pub cache: StateCache,
     pub class_hash_to_class: ContractClassMapping,
     pub global_class_hash_to_class: GlobalContractCache,
-    pub tx_executed_class_hashes: IndexSet<ClassHash>,
+    pub tx_executed_class_hashes: HashSet<ClassHash>,
 }
 
 /// Holds uncommitted changes induced on StarkNet contracts.
@@ -638,10 +638,10 @@ pub struct CommitmentStateDiff {
 /// Holds the state changes.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct StateChanges {
-    pub storage_updates: IndexMap<(ContractAddress, StorageKey), StarkFelt>,
-    pub class_hash_updates: IndexMap<ContractAddress, ClassHash>,
-    pub compiled_class_hash_updates: IndexMap<ClassHash, CompiledClassHash>,
-    pub modified_contracts: IndexSet<ContractAddress>,
+    pub storage_updates: HashMap<(ContractAddress, StorageKey), StarkFelt>,
+    pub class_hash_updates: HashMap<ContractAddress, ClassHash>,
+    pub compiled_class_hash_updates: HashMap<ClassHash, CompiledClassHash>,
+    pub modified_contracts: HashSet<ContractAddress>,
 }
 
 impl StateChanges {

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -81,7 +81,7 @@ fn cast_between_storage_mapping_types() {
     let storage_val1: StarkFelt = stark_felt!("0x5");
     let storage_val2: StarkFelt = stark_felt!("0xa");
 
-    let storage_map = StorageView(IndexMap::from([
+    let storage_map = StorageView(HashMap::from([
         ((contract_address0, key0), storage_val0),
         ((contract_address0, key1), storage_val1),
         ((contract_address1, key0), storage_val2),

--- a/crates/blockifier/src/utils.rs
+++ b/crates/blockifier/src/utils.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use indexmap::IndexMap;
-
 #[cfg(test)]
 #[path = "utils_test.rs"]
 pub mod test;
@@ -9,7 +7,7 @@ pub mod test;
 /// Returns a `HashMap` containing key-value pairs from `a` that are not included in `b` (if
 /// a key appears in `b` with a different value, it will be part of the output).
 /// Usage: Get updated items from a mapping.
-pub fn subtract_mappings<K, V>(lhs: &IndexMap<K, V>, rhs: &HashMap<K, V>) -> IndexMap<K, V>
+pub fn subtract_mappings<K, V>(lhs: &HashMap<K, V>, rhs: &HashMap<K, V>) -> HashMap<K, V>
 where
     K: Clone + Eq + std::hash::Hash,
     V: Clone + PartialEq,

--- a/crates/blockifier/src/utils_test.rs
+++ b/crates/blockifier/src/utils_test.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use indexmap::IndexMap;
 use pretty_assertions::assert_eq;
 
 use crate::utils::subtract_mappings;
@@ -8,17 +7,14 @@ use crate::utils::subtract_mappings;
 #[test]
 fn test_subtract_mappings() {
     let not_empty = HashMap::from([("foo", "bar")]);
-    let empty = IndexMap::default();
+    let empty = HashMap::default();
 
     assert_eq!(empty, subtract_mappings(&empty, &not_empty));
-
-    let not_empty = IndexMap::from([("foo", "bar")]);
-    let empty = HashMap::default();
     assert_eq!(not_empty, subtract_mappings(&not_empty, &empty));
 
-    let map1 = IndexMap::from([("red", 1), ("green", 2), ("blue", 3)]);
+    let map1 = HashMap::from([("red", 1), ("green", 2), ("blue", 3)]);
     let map2 = HashMap::from([("yellow", 1), ("green", 2), ("blue", 4)]);
 
-    let expected = IndexMap::from([("red", 1), ("blue", 3)]);
+    let expected = HashMap::from([("red", 1), ("blue", 3)]);
     assert_eq!(expected, subtract_mappings(&map1, &map2));
 }

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -33,7 +33,7 @@ indexmap.workspace = true
 log.workspace = true
 num-bigint.workspace = true
 papyrus_storage = { workspace = true, features = ["testing"] }
-pyo3 = { workspace = true, features = ["num-bigint", "hashbrown", "indexmap"] }
+pyo3 = { workspace = true, features = ["num-bigint", "hashbrown"] }
 pyo3-log.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 starknet_api = { workspace = true, features = ["testing"] }

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use blockifier::block_context::{BlockContext, FeeTokenAddresses, GasPrices};
 use blockifier::state::cached_state::GlobalContractCache;
-use indexmap::IndexMap;
 use pyo3::prelude::*;
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::core::{ChainId, ContractAddress};
@@ -141,8 +140,8 @@ impl PyBlockExecutor {
         previous_block_id: Option<PyFelt>,
         py_block_info: PyBlockInfo,
         py_state_diff: PyStateDiff,
-        declared_class_hash_to_class: IndexMap<PyFelt, (PyFelt, String)>,
-        deprecated_declared_class_hash_to_class: IndexMap<PyFelt, String>,
+        declared_class_hash_to_class: HashMap<PyFelt, (PyFelt, String)>,
+        deprecated_declared_class_hash_to_class: HashMap<PyFelt, String>,
     ) -> NativeBlockifierResult<()> {
         self.storage.append_block(
             block_id,

--- a/crates/native_blockifier/src/py_state_diff.rs
+++ b/crates/native_blockifier/src/py_state_diff.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use blockifier::state::cached_state::CommitmentStateDiff;
@@ -14,13 +15,13 @@ use crate::py_utils::PyFelt;
 // TODO: Add support for returning the `declared_classes` to python.
 pub struct PyStateDiff {
     #[pyo3(get)]
-    pub address_to_class_hash: IndexMap<PyFelt, PyFelt>,
+    pub address_to_class_hash: HashMap<PyFelt, PyFelt>,
     #[pyo3(get)]
-    pub address_to_nonce: IndexMap<PyFelt, PyFelt>,
+    pub address_to_nonce: HashMap<PyFelt, PyFelt>,
     #[pyo3(get)]
-    pub storage_updates: IndexMap<PyFelt, IndexMap<PyFelt, PyFelt>>,
+    pub storage_updates: HashMap<PyFelt, HashMap<PyFelt, PyFelt>>,
     #[pyo3(get)]
-    pub class_hash_to_compiled_class_hash: IndexMap<PyFelt, PyFelt>,
+    pub class_hash_to_compiled_class_hash: HashMap<PyFelt, PyFelt>,
 }
 
 impl TryFrom<PyStateDiff> for StateDiff {

--- a/crates/native_blockifier/src/storage.rs
+++ b/crates/native_blockifier/src/storage.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::path::PathBuf;
 
@@ -112,8 +113,8 @@ impl Storage for PapyrusStorage {
         previous_block_id: Option<PyFelt>,
         py_block_info: PyBlockInfo,
         py_state_diff: PyStateDiff,
-        declared_class_hash_to_class: IndexMap<PyFelt, (PyFelt, String)>,
-        deprecated_declared_class_hash_to_class: IndexMap<PyFelt, String>,
+        declared_class_hash_to_class: HashMap<PyFelt, (PyFelt, String)>,
+        deprecated_declared_class_hash_to_class: HashMap<PyFelt, String>,
     ) -> NativeBlockifierResult<()> {
         log::debug!(
             "Appending state diff with {block_id:?} for block_number: {}.",
@@ -158,7 +159,7 @@ impl Storage for PapyrusStorage {
         }
         let mut py_state_diff = py_state_diff;
         replaced_classes.keys().for_each(|&address| {
-            py_state_diff.address_to_class_hash.remove(&PyFelt::from(address));
+            py_state_diff.address_to_class_hash.remove(&address.into());
         });
 
         let mut declared_classes = IndexMap::<ClassHash, (CompiledClassHash, ContractClass)>::new();
@@ -279,8 +280,8 @@ pub trait Storage {
         previous_block_id: Option<PyFelt>,
         py_block_info: PyBlockInfo,
         py_state_diff: PyStateDiff,
-        declared_class_hash_to_class: IndexMap<PyFelt, (PyFelt, String)>,
-        deprecated_declared_class_hash_to_class: IndexMap<PyFelt, String>,
+        declared_class_hash_to_class: HashMap<PyFelt, (PyFelt, String)>,
+        deprecated_declared_class_hash_to_class: HashMap<PyFelt, String>,
     ) -> NativeBlockifierResult<()>;
 
     fn validate_aligned(&self, source_block_number: u64);

--- a/crates/native_blockifier/src/test_utils.rs
+++ b/crates/native_blockifier/src/test_utils.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use indexmap::IndexMap;
-
 use crate::errors::NativeBlockifierResult;
 use crate::storage::Storage;
 
@@ -33,11 +31,11 @@ impl Storage for MockStorage {
         _previous_block_id: Option<crate::py_utils::PyFelt>,
         _py_block_info: crate::py_state_diff::PyBlockInfo,
         _py_state_diff: crate::py_state_diff::PyStateDiff,
-        _declared_class_hash_to_class: IndexMap<
+        _declared_class_hash_to_class: HashMap<
             crate::py_utils::PyFelt,
             (crate::py_utils::PyFelt, String),
         >,
-        _deprecated_declared_class_hash_to_class: IndexMap<crate::py_utils::PyFelt, String>,
+        _deprecated_declared_class_hash_to_class: HashMap<crate::py_utils::PyFelt, String>,
     ) -> NativeBlockifierResult<()> {
         todo!()
     }


### PR DESCRIPTION
This reverts commit 4e1817be67211468fbdef57ed983ab7f30eb83c7.

The change in `native_blockifier` should be made more delicately, looks like Pyo3 has some issues with indexmap>1.9.3 (even though they stated that they support < 3.0.0.

Will reenable soon after sidestepping this issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1184)
<!-- Reviewable:end -->
