### PR TITLE
Define and use DeployTxArgs

### DIFF
--- a/crates/blockifier/src/test_utils/declare.rs
+++ b/crates/blockifier/src/test_utils/declare.rs
@@ -14,19 +14,17 @@ use crate::transaction::transactions::DeclareTransaction;
 pub struct DeclareTxArgs {
     pub max_fee: Fee,
     pub signature: TransactionSignature,
-    pub nonce: Nonce,
-    pub class_hash: ClassHash,
     pub sender_address: ContractAddress,
-    pub compiled_class_hash: CompiledClassHash,
+    pub version: TransactionVersion,
     pub resource_bounds: ResourceBoundsMapping,
     pub tip: Tip,
     pub nonce_data_availability_mode: DataAvailabilityMode,
     pub fee_data_availability_mode: DataAvailabilityMode,
     pub paymaster_data: PaymasterData,
     pub account_deployment_data: AccountDeploymentData,
-
-    // Meta fields.
-    pub version: TransactionVersion,
+    pub nonce: Nonce,
+    pub class_hash: ClassHash,
+    pub compiled_class_hash: CompiledClassHash,
     pub tx_hash: TransactionHash,
 }
 

--- a/crates/blockifier/src/test_utils/deploy_account.rs
+++ b/crates/blockifier/src/test_utils/deploy_account.rs
@@ -1,56 +1,69 @@
-use starknet_api::class_hash;
-use starknet_api::core::{calculate_contract_address, ClassHash, ContractAddress};
-use starknet_api::hash::StarkHash;
+use starknet_api::core::{calculate_contract_address, ClassHash, ContractAddress, Nonce};
+use starknet_api::data_availability::DataAvailabilityMode;
 use starknet_api::transaction::{
-    Calldata, ContractAddressSalt, DeployAccountTransactionV1, Fee, TransactionHash,
-    TransactionSignature,
+    Calldata, ContractAddressSalt, DeployAccountTransactionV1, Fee, PaymasterData,
+    ResourceBoundsMapping, Tip, TransactionHash, TransactionSignature, TransactionVersion,
 };
 
+use super::default_testing_resource_bounds;
 use crate::test_utils::NonceManager;
 use crate::transaction::transactions::DeployAccountTransaction;
 
-pub fn deploy_account_tx(
-    class_hash: &str,
-    max_fee: Fee,
-    constructor_calldata: Option<Calldata>,
-    signature: Option<TransactionSignature>,
-    nonce_manager: &mut NonceManager,
-) -> DeployAccountTransaction {
-    deploy_account_tx_with_salt(
-        class_hash,
-        max_fee,
-        constructor_calldata,
-        ContractAddressSalt::default(),
-        signature,
-        nonce_manager,
-    )
+#[derive(Clone)]
+pub struct DeployTxArgs {
+    pub max_fee: Fee,
+    pub signature: TransactionSignature,
+    pub deployer_address: ContractAddress,
+    pub version: TransactionVersion,
+    pub resource_bounds: ResourceBoundsMapping,
+    pub tip: Tip,
+    pub nonce_data_availability_mode: DataAvailabilityMode,
+    pub fee_data_availability_mode: DataAvailabilityMode,
+    pub paymaster_data: PaymasterData,
+    pub nonce: Nonce,
+    pub class_hash: ClassHash,
+    pub contract_address_salt: ContractAddressSalt,
+    pub constructor_calldata: Calldata,
 }
 
-pub fn deploy_account_tx_with_salt(
-    class_hash: &str,
-    max_fee: Fee,
-    constructor_calldata: Option<Calldata>,
-    contract_address_salt: ContractAddressSalt,
-    signature: Option<TransactionSignature>,
+impl Default for DeployTxArgs {
+    fn default() -> Self {
+        DeployTxArgs {
+            max_fee: Fee::default(),
+            signature: TransactionSignature::default(),
+            deployer_address: ContractAddress::default(),
+            version: TransactionVersion::ONE,
+            resource_bounds: default_testing_resource_bounds(),
+            tip: Tip::default(),
+            nonce_data_availability_mode: DataAvailabilityMode::L1,
+            fee_data_availability_mode: DataAvailabilityMode::L1,
+            paymaster_data: PaymasterData::default(),
+            nonce: Nonce::default(),
+            class_hash: ClassHash::default(),
+            contract_address_salt: ContractAddressSalt::default(),
+            constructor_calldata: Calldata::default(),
+        }
+    }
+}
+
+pub fn deploy_account_tx(
+    deploy_tx_args: DeployTxArgs,
     nonce_manager: &mut NonceManager,
 ) -> DeployAccountTransaction {
-    let class_hash = class_hash!(class_hash);
-    let deployer_address = ContractAddress::default();
-    let constructor_calldata = constructor_calldata.unwrap_or_default();
     let contract_address = calculate_contract_address(
-        contract_address_salt,
-        class_hash,
-        &constructor_calldata,
-        deployer_address,
+        deploy_tx_args.contract_address_salt,
+        deploy_tx_args.class_hash,
+        &deploy_tx_args.constructor_calldata,
+        deploy_tx_args.deployer_address,
     )
     .unwrap();
 
     let tx = starknet_api::transaction::DeployAccountTransaction::V1(DeployAccountTransactionV1 {
-        max_fee,
-        signature: signature.unwrap_or_default(),
-        class_hash,
-        contract_address_salt,
-        constructor_calldata,
+        max_fee: deploy_tx_args.max_fee,
+        signature: deploy_tx_args.signature,
+        class_hash: deploy_tx_args.class_hash,
+        contract_address_salt: deploy_tx_args.contract_address_salt,
+        constructor_calldata: deploy_tx_args.constructor_calldata,
         nonce: nonce_manager.next(contract_address),
     });
 

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -22,7 +22,7 @@ use crate::fee::gas_usage::estimate_minimal_l1_gas;
 use crate::invoke_tx_args;
 use crate::state::state_api::{State, StateReader};
 use crate::test_utils::declare::{declare_tx, DeclareTxArgs};
-use crate::test_utils::deploy_account::deploy_account_tx;
+use crate::test_utils::deploy_account::{deploy_account_tx, DeployTxArgs};
 use crate::test_utils::invoke::InvokeTxArgs;
 use crate::test_utils::{
     create_calldata, NonceManager, BALANCE, DEFAULT_STRK_L1_GAS_PRICE,
@@ -62,10 +62,11 @@ fn block_context() -> BlockContext {
 fn test_fee_enforcement(block_context: BlockContext, #[case] max_fee: Fee) {
     let mut state = create_state(block_context.clone());
     let deploy_account_tx = deploy_account_tx(
-        TEST_ACCOUNT_CONTRACT_CLASS_HASH,
-        max_fee,
-        None,
-        None,
+        DeployTxArgs {
+            class_hash: class_hash!(TEST_ACCOUNT_CONTRACT_CLASS_HASH),
+            max_fee,
+            ..Default::default()
+        },
         &mut NonceManager::default(),
     );
 
@@ -302,9 +303,12 @@ fn test_max_fee_limit_validate(
         &mut state,
         &mut NonceManager::default(),
         &block_context,
-        TEST_GRINDY_ACCOUNT_CONTRACT_CLASS_HASH,
-        max_fee,
-        Some(calldata![stark_felt!(1_u8)]), // Grind in deploy phase.
+        DeployTxArgs {
+            class_hash: class_hash!(TEST_GRINDY_ACCOUNT_CONTRACT_CLASS_HASH),
+            max_fee,
+            constructor_calldata: calldata![stark_felt!(1_u8)], // Grind in deploy phase.
+            ..Default::default()
+        },
     );
     let error = deploy_account_tx.execute(&mut state, &block_context, true, true).unwrap_err();
     assert_matches!(
@@ -320,9 +324,12 @@ fn test_max_fee_limit_validate(
         &mut state,
         &mut nonce_manager,
         &block_context,
-        TEST_GRINDY_ACCOUNT_CONTRACT_CLASS_HASH,
-        max_fee,
-        Some(calldata![stark_felt!(0_u8)]), // Do not grind in deploy phase.
+        DeployTxArgs {
+            class_hash: class_hash!(TEST_GRINDY_ACCOUNT_CONTRACT_CLASS_HASH),
+            max_fee,
+            constructor_calldata: calldata![stark_felt!(0_u8)], // Do not grind in deploy phase.
+            ..Default::default()
+        },
     );
     deploy_account_tx.execute(&mut state, &block_context, true, true).unwrap();
 
@@ -455,10 +462,11 @@ fn test_revert_invoke(block_context: BlockContext, max_fee: Fee) {
     let fee_token_address = block_context.fee_token_addresses.eth_fee_token_address;
     // Deploy an account contract.
     let deploy_account_tx = deploy_account_tx(
-        TEST_ACCOUNT_CONTRACT_CLASS_HASH,
-        max_fee,
-        None,
-        None,
+        DeployTxArgs {
+            class_hash: class_hash!(TEST_ACCOUNT_CONTRACT_CLASS_HASH),
+            max_fee,
+            ..Default::default()
+        },
         &mut nonce_manager,
     );
     let deployed_account_address = deploy_account_tx.contract_address;

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -20,7 +20,7 @@ use crate::invoke_tx_args;
 use crate::state::cached_state::CachedState;
 use crate::state::state_api::State;
 use crate::test_utils::declare::{declare_tx, DeclareTxArgs};
-use crate::test_utils::deploy_account::deploy_account_tx;
+use crate::test_utils::deploy_account::{deploy_account_tx, DeployTxArgs};
 use crate::test_utils::dict_state_reader::DictStateReader;
 use crate::test_utils::invoke::{invoke_tx, InvokeTxArgs};
 use crate::test_utils::{
@@ -77,13 +77,10 @@ pub fn deploy_and_fund_account(
     state: &mut CachedState<DictStateReader>,
     nonce_manager: &mut NonceManager,
     block_context: &BlockContext,
-    class_hash: &str,
-    max_fee: Fee,
-    constructor_calldata: Option<Calldata>,
+    deploy_tx_args: DeployTxArgs,
 ) -> (AccountTransaction, ContractAddress) {
     // Deploy an account contract.
-    let deploy_account_tx =
-        deploy_account_tx(class_hash, max_fee, constructor_calldata, None, nonce_manager);
+    let deploy_account_tx = deploy_account_tx(deploy_tx_args, nonce_manager);
     let account_address = deploy_account_tx.contract_address;
     let account_tx = AccountTransaction::DeployAccount(deploy_account_tx);
 
@@ -139,9 +136,11 @@ pub fn create_test_init_data(max_fee: Fee, block_context: BlockContext) -> TestI
         &mut state,
         &mut nonce_manager,
         &block_context,
-        TEST_ACCOUNT_CONTRACT_CLASS_HASH,
-        max_fee,
-        None,
+        DeployTxArgs {
+            class_hash: class_hash!(TEST_ACCOUNT_CONTRACT_CLASS_HASH),
+            max_fee,
+            ..Default::default()
+        },
     );
     account_tx.execute(&mut state, &block_context, true, true).unwrap();
 
@@ -308,7 +307,6 @@ pub fn create_account_tx_for_validate_test(
                 DeclareTxArgs {
                     class_hash: class_hash!(TEST_ACCOUNT_CONTRACT_CLASS_HASH),
                     sender_address,
-                    max_fee: Fee(0),
                     signature,
                     ..Default::default()
                 },
@@ -317,10 +315,12 @@ pub fn create_account_tx_for_validate_test(
         }
         TransactionType::DeployAccount => {
             let deploy_account_tx = crate::test_utils::deploy_account::deploy_account_tx(
-                TEST_FAULTY_ACCOUNT_CONTRACT_CLASS_HASH,
-                Fee(0),
-                Some(calldata![stark_felt!(constants::FELT_FALSE)]),
-                Some(signature),
+                DeployTxArgs {
+                    class_hash: class_hash!(TEST_FAULTY_ACCOUNT_CONTRACT_CLASS_HASH),
+                    constructor_calldata: calldata![stark_felt!(constants::FELT_FALSE)],
+                    signature,
+                    ..Default::default()
+                },
                 nonce_manager,
             );
             AccountTransaction::DeployAccount(deploy_account_tx)

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -36,6 +36,7 @@ use crate::state::cached_state::{CachedState, StateChangesCount};
 use crate::state::errors::StateError;
 use crate::state::state_api::{State, StateReader};
 use crate::test_utils::declare::{declare_tx, DeclareTxArgs};
+use crate::test_utils::deploy_account::DeployTxArgs;
 use crate::test_utils::dict_state_reader::DictStateReader;
 use crate::test_utils::invoke::{invoke_tx, InvokeTxArgs};
 use crate::test_utils::{
@@ -891,10 +892,13 @@ fn deploy_account_tx(
     nonce_manager: &mut NonceManager,
 ) -> DeployAccountTransaction {
     crate::test_utils::deploy_account::deploy_account_tx(
-        account_class_hash,
-        Fee(MAX_FEE),
-        constructor_calldata,
-        signature,
+        DeployTxArgs {
+            class_hash: class_hash!(account_class_hash),
+            max_fee: Fee(MAX_FEE),
+            constructor_calldata: constructor_calldata.unwrap_or_default(),
+            signature: signature.unwrap_or_default(),
+            ..Default::default()
+        },
         nonce_manager,
     )
 }
@@ -1129,14 +1133,16 @@ fn test_validate_accounts_tx(#[case] tx_type: TransactionType) {
         // constructor (forbidden).
 
         let deploy_account_tx = crate::test_utils::deploy_account::deploy_account_tx(
-            TEST_FAULTY_ACCOUNT_CONTRACT_CLASS_HASH,
-            Fee(0),
-            Some(calldata![stark_felt!(constants::FELT_TRUE)]),
-            // run faulty_validate() in the constructor.
-            Some(TransactionSignature(vec![
-                stark_felt!(CALL_CONTRACT),
-                stark_felt!(TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS),
-            ])),
+            DeployTxArgs {
+                class_hash: class_hash!(TEST_FAULTY_ACCOUNT_CONTRACT_CLASS_HASH),
+                constructor_calldata: calldata![stark_felt!(constants::FELT_TRUE)],
+                // Run faulty_validate() in the constructor.
+                signature: TransactionSignature(vec![
+                    stark_felt!(CALL_CONTRACT),
+                    stark_felt!(TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS),
+                ]),
+                ..Default::default()
+            },
             &mut NonceManager::default(),
         );
         let account_tx = AccountTransaction::DeployAccount(deploy_account_tx);

--- a/crates/native_blockifier/bench/blockifier_bench.rs
+++ b/crates/native_blockifier/bench/blockifier_bench.rs
@@ -15,7 +15,7 @@ use blockifier::execution::contract_class::ContractClassV0;
 use blockifier::invoke_tx_args;
 use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::State;
-use blockifier::test_utils::deploy_account::deploy_account_tx_with_salt;
+use blockifier::test_utils::deploy_account::{deploy_account_tx, DeployTxArgs};
 use blockifier::test_utils::dict_state_reader::DictStateReader;
 use blockifier::test_utils::invoke::{invoke_tx, InvokeTxArgs};
 use blockifier::test_utils::{
@@ -26,9 +26,9 @@ use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
 use criterion::{criterion_group, criterion_main, Criterion};
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
-use starknet_api::hash::StarkFelt;
+use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::transaction::{Calldata, ContractAddressSalt, Fee, TransactionVersion};
-use starknet_api::{calldata, stark_felt};
+use starknet_api::{calldata, class_hash, stark_felt};
 
 const N_ACCOUNTS: usize = 10000;
 
@@ -121,16 +121,15 @@ fn prepare_accounts(
         // Deploy an account contract.
         let class_hash = TEST_ACCOUNT_CONTRACT_CLASS_HASH;
         let max_fee = Fee(MAX_FEE);
-        let constructor_calldata = None;
         let constructor_address_salt = ContractAddressSalt(stark_felt!(account_salt as u64));
-        let signature = None;
         let nonce_manager = &mut NonceManager::default();
-        let deploy_account_tx = deploy_account_tx_with_salt(
-            class_hash,
-            max_fee,
-            constructor_calldata,
-            constructor_address_salt,
-            signature,
+        let deploy_account_tx = deploy_account_tx(
+            DeployTxArgs {
+                class_hash: class_hash!(class_hash),
+                max_fee,
+                contract_address_salt: constructor_address_salt,
+                ..Default::default()
+            },
             nonce_manager,
         );
 


### PR DESCRIPTION
Same idea as `InvokeTxArgs` - will allow easier construction of `DeployAccount` transactions, and soon we will be able to vary over version

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1194)
<!-- Reviewable:end -->
