### PR TITLE
refacto: cleanup state traits, CachedState interior mutability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ target
 *.DS_Store
 
 tmp_venv/*
-

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -18,37 +19,38 @@ use crate::utils::subtract_mappings;
 #[path = "cached_state_test.rs"]
 mod test;
 
-pub type ContractClassMapping = HashMap<ClassHash, ContractClass>;
-
 /// Caches read and write requests.
 ///
 /// Writer functionality is builtin, whereas Reader functionality is injected through
 /// initialization.
-#[derive(Debug)]
 pub struct CachedState<S: StateReader> {
     pub state: S,
-    // Invariant: read/write access is managed by CachedState.
-    cache: StateCache,
-    class_hash_to_class: ContractClassMapping,
-    // Invariant: managed by CachedState.
-    global_class_hash_to_class: GlobalContractCache,
+    // StateChache internaly manages multiple source of data
+    // and copy from one to the other as it is read from.
+    // It therefore needs interior mutability in order keep doing that while
+    // implementing the `StateReader` trait.
+    // Whenever you own a mutable reference to self, there is no trouble:
+    // `let cache = self.cache.get_mut();`
+    // But then you don't, do the following :
+    // ```
+    // let mut cache = self.cache.take();
+    // // Execute your logic here. You fully own cache.
+    // // Before returning, don't forget to store the cache back into `self`.
+    // self.cache.set(cache);
+    // ```
+    cache: Cell<StateCache>,
 }
 
 impl<S: StateReader> CachedState<S> {
     pub fn new(state: S, global_class_hash_to_class: GlobalContractCache) -> Self {
-        Self {
-            state,
-            cache: StateCache::default(),
-            class_hash_to_class: HashMap::default(),
-            global_class_hash_to_class,
-        }
+        Self { state, cache: Cell::new(StateCache::new(global_class_hash_to_class)) }
     }
 
     /// Creates a transactional instance from the given cached state.
     /// It allows performing buffered modifying actions on the given state, which
     /// will either all happen (will be committed) or none of them (will be discarded).
     pub fn create_transactional(state: &mut CachedState<S>) -> TransactionalState<'_, S> {
-        let global_class_hash_to_class = state.global_class_hash_to_class.clone();
+        let global_class_hash_to_class = state.cache.get_mut().global_class_hash_to_class.clone();
         CachedState::new(MutRefState::new(state), global_class_hash_to_class)
     }
 
@@ -61,22 +63,23 @@ impl<S: StateReader> CachedState<S> {
         sender_address: Option<ContractAddress>,
     ) -> StateResult<StateChanges> {
         self.update_initial_values_of_write_only_access()?;
+        let cache = self.cache.get_mut();
 
         // Storage Update.
-        let storage_updates = &mut self.cache.get_storage_updates();
+        let mut storage_updates = cache.get_storage_updates();
         let mut modified_contracts: HashSet<ContractAddress> =
             storage_updates.keys().map(|address_key_pair| address_key_pair.0).collect();
 
         // Class hash Update (deployed contracts + replace_class syscall).
-        let class_hash_updates = &self.cache.get_class_hash_updates();
+        let class_hash_updates = cache.get_class_hash_updates();
         modified_contracts.extend(class_hash_updates.keys());
 
         // Nonce updates.
-        let nonce_updates = &self.cache.get_nonce_updates();
+        let nonce_updates = cache.get_nonce_updates();
         modified_contracts.extend(nonce_updates.keys());
 
         // Compiled class hash updates (declare Cairo 1 contract).
-        let compiled_class_hash_updates = &self.cache.get_compiled_class_hash_updates();
+        let compiled_class_hash_updates = cache.get_compiled_class_hash_updates();
 
         // For account transactions, we need to compute the transaction fee before we can execute
         // the fee transfer, and the fee should cover the state changes that happen in the
@@ -99,31 +102,12 @@ impl<S: StateReader> CachedState<S> {
             storage_updates: storage_updates.clone(),
             modified_contracts,
             class_hash_updates: class_hash_updates.clone(),
-            compiled_class_hash_updates: compiled_class_hash_updates.clone(),
+            compiled_class_hash_updates,
         })
     }
 
-    /// Drains contract-class cache collected during execution and updates the global cache.
     pub fn move_classes_to_global_cache(&mut self) {
-        let contract_class_updates: Vec<_> = self.class_hash_to_class.drain().collect();
-        for (key, value) in contract_class_updates {
-            self.global_class_hash_to_class().cache_set(key, value);
-        }
-    }
-
-    // Locks the Mutex and unwraps the MutexGuard, thus exposing the internal cache
-    // store. The Guard will panic only if the Mutex panics during the lock operation, but
-    // this shouldn't happen in our flow.
-    // Note: `&mut` is used since the LRU cache updates internal counters on reads.
-    pub fn global_class_hash_to_class(&mut self) -> LockedContractClassCache<'_> {
-        self.global_class_hash_to_class.lock()
-    }
-
-    pub fn update_cache(&mut self, cache_updates: StateCache) {
-        self.cache.nonce_writes.extend(cache_updates.nonce_writes);
-        self.cache.class_hash_writes.extend(cache_updates.class_hash_writes);
-        self.cache.storage_writes.extend(cache_updates.storage_writes);
-        self.cache.compiled_class_hash_writes.extend(cache_updates.compiled_class_hash_writes);
+        self.cache.get_mut().move_classes_to_global_cache();
     }
 
     pub fn update_contract_class_caches(
@@ -131,8 +115,17 @@ impl<S: StateReader> CachedState<S> {
         local_contract_cache_updates: ContractClassMapping,
         global_contract_cache: GlobalContractCache,
     ) {
-        self.class_hash_to_class.extend(local_contract_cache_updates);
-        self.global_class_hash_to_class = global_contract_cache;
+        self.cache
+            .get_mut()
+            .update_contract_class_caches(local_contract_cache_updates, global_contract_cache);
+    }
+
+    pub fn update_cache(&mut self, cache_updates: StateCache) {
+        let cache = self.cache.get_mut();
+        cache.nonce_writes.extend(cache_updates.nonce_writes);
+        cache.class_hash_writes.extend(cache_updates.class_hash_writes);
+        cache.storage_writes.extend(cache_updates.storage_writes);
+        cache.compiled_class_hash_writes.extend(cache_updates.compiled_class_hash_writes);
     }
 
     /// Updates cache with initial cell values for write-only access.
@@ -143,29 +136,31 @@ impl<S: StateReader> CachedState<S> {
     fn update_initial_values_of_write_only_access(&mut self) -> StateResult<()> {
         // Eliminate storage writes that are identical to the initial value (no change). Assumes
         // that `set_storage_at` does not affect the state field.
-        for contract_storage_key in self.cache.storage_writes.keys() {
-            if !self.cache.storage_initial_values.contains_key(contract_storage_key) {
+        let cache = self.cache.get_mut();
+
+        for contract_storage_key in cache.storage_writes.keys() {
+            if !cache.storage_initial_values.contains_key(contract_storage_key) {
                 // First access to this cell was write; cache initial value.
-                self.cache.storage_initial_values.insert(
+                cache.storage_initial_values.insert(
                     *contract_storage_key,
                     self.state.get_storage_at(contract_storage_key.0, contract_storage_key.1)?,
                 );
             }
         }
 
-        for contract_address in self.cache.class_hash_writes.keys() {
-            if !self.cache.class_hash_initial_values.contains_key(contract_address) {
+        for contract_address in cache.class_hash_writes.keys() {
+            if !cache.class_hash_initial_values.contains_key(contract_address) {
                 // First access to this cell was write; cache initial value.
-                self.cache
+                cache
                     .class_hash_initial_values
                     .insert(*contract_address, self.state.get_class_hash_at(*contract_address)?);
             }
         }
 
-        for contract_address in self.cache.nonce_writes.keys() {
-            if !self.cache.nonce_initial_values.contains_key(contract_address) {
+        for contract_address in cache.nonce_writes.keys() {
+            if !cache.nonce_initial_values.contains_key(contract_address) {
                 // First access to this cell was write; cache initial value.
-                self.cache
+                cache
                     .nonce_initial_values
                     .insert(*contract_address, self.state.get_nonce_at(*contract_address)?);
             }
@@ -183,86 +178,124 @@ impl<S: StateReader> From<S> for CachedState<S> {
 
 impl<S: StateReader> StateReader for CachedState<S> {
     fn get_storage_at(
-        &mut self,
+        &self,
         contract_address: ContractAddress,
         key: StorageKey,
     ) -> StateResult<StarkFelt> {
-        if self.cache.get_storage_at(contract_address, key).is_none() {
-            let storage_value = self.state.get_storage_at(contract_address, key)?;
-            self.cache.set_storage_initial_value(contract_address, key, storage_value);
-        }
+        let mut cache = self.cache.take();
 
-        let value = self.cache.get_storage_at(contract_address, key).unwrap_or_else(|| {
-            panic!("Cannot retrieve '{contract_address:?}' and '{key:?}' from the cache.")
-        });
-        Ok(*value)
+        let mut closure_get_storage = || {
+            let storage_value =
+                if let Some(storage_value) = cache.get_opt_storage_at(contract_address, key) {
+                    *storage_value
+                } else {
+                    let storage_value = self.state.get_storage_at(contract_address, key)?;
+                    cache.set_storage_initial_value(contract_address, key, storage_value);
+                    storage_value
+                };
+
+            Ok(storage_value)
+        };
+        let res_storage_value = closure_get_storage();
+
+        self.cache.set(cache);
+        res_storage_value
     }
 
-    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
-        if self.cache.get_nonce_at(contract_address).is_none() {
-            let nonce = self.state.get_nonce_at(contract_address)?;
-            self.cache.set_nonce_initial_value(contract_address, nonce);
-        }
+    fn get_nonce_at(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
+        let mut cache = self.cache.take();
 
-        let nonce = self
-            .cache
-            .get_nonce_at(contract_address)
-            .unwrap_or_else(|| panic!("Cannot retrieve '{contract_address:?}' from the cache."));
-        Ok(*nonce)
+        let mut closure_get_nonce = || {
+            let nonce = if let Some(nonce) = cache.get_opt_nonce_at(contract_address) {
+                *nonce
+            } else {
+                let nonce = self.state.get_nonce_at(contract_address)?;
+                cache.set_nonce_initial_value(contract_address, nonce);
+                nonce
+            };
+
+            Ok(nonce)
+        };
+
+        let res_nonce = closure_get_nonce();
+        self.cache.set(cache);
+        res_nonce
     }
 
-    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
-        if self.cache.get_class_hash_at(contract_address).is_none() {
-            let class_hash = self.state.get_class_hash_at(contract_address)?;
-            self.cache.set_class_hash_initial_value(contract_address, class_hash);
-        }
+    fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
+        let mut cache = self.cache.take();
 
-        let class_hash = self
-            .cache
-            .get_class_hash_at(contract_address)
-            .unwrap_or_else(|| panic!("Cannot retrieve '{contract_address:?}' from the cache."));
-        Ok(*class_hash)
+        let mut closure_get_class_at = || {
+            let class_hash =
+                if let Some(class_hash) = cache.get_opt_class_hash_at(contract_address).cloned() {
+                    class_hash
+                } else {
+                    let class_hash = self.state.get_class_hash_at(contract_address)?;
+                    cache.set_class_hash_initial_value(contract_address, class_hash);
+                    class_hash
+                };
+
+            Ok(class_hash)
+        };
+        let res_class_hash = closure_get_class_at();
+
+        self.cache.set(cache);
+        res_class_hash
     }
 
-    #[allow(clippy::map_entry)]
-    // Clippy solution don't work because it required two mutable ref to self
-    // Could probably be solved with interior mutability
-    fn get_compiled_contract_class(&mut self, class_hash: ClassHash) -> StateResult<ContractClass> {
-        if !self.class_hash_to_class.contains_key(&class_hash) {
-            let contract_class = self.global_class_hash_to_class().cache_get(&class_hash).cloned();
+    fn get_compiled_contract_class(&self, class_hash: ClassHash) -> StateResult<ContractClass> {
+        let mut cache = self.cache.take();
 
-            match contract_class {
+        let mut closure_get_contract_class = || {
+            if let Some(contract_class) = cache.class_hash_to_class.get(&class_hash) {
+                return Ok(contract_class.clone());
+            }
+
+            let contract_class = {
+                let mut global_class_hash_to_class = cache.global_class_hash_to_class();
+                global_class_hash_to_class.cache_get(&class_hash).cloned()
+            };
+
+            let contract_class = match contract_class {
                 Some(contract_class_from_global_cache) => {
-                    self.class_hash_to_class.insert(class_hash, contract_class_from_global_cache);
+                    cache
+                        .class_hash_to_class
+                        .insert(class_hash, contract_class_from_global_cache.clone());
+                    contract_class_from_global_cache
                 }
                 None => {
                     let contract_class_from_db =
                         self.state.get_compiled_contract_class(class_hash)?;
-                    self.class_hash_to_class.insert(class_hash, contract_class_from_db);
+                    cache.class_hash_to_class.insert(class_hash, contract_class_from_db.clone());
+                    contract_class_from_db
                 }
-            }
-        }
+            };
+            Ok(contract_class)
+        };
+        let res_contract_class = closure_get_contract_class();
 
-        let contract_class = self
-            .class_hash_to_class
-            .get(&class_hash)
-            .cloned()
-            .expect("The class hash must appear in the cache.");
-
-        Ok(contract_class)
+        self.cache.set(cache);
+        res_contract_class
     }
 
-    fn get_compiled_class_hash(&mut self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
-        if self.cache.get_compiled_class_hash(class_hash).is_none() {
-            let compiled_class_hash = self.state.get_compiled_class_hash(class_hash)?;
-            self.cache.set_compiled_class_hash_initial_value(class_hash, compiled_class_hash);
-        }
+    fn get_compiled_class_hash(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
+        let mut cache = self.cache.take();
 
-        let compiled_class_hash = self
-            .cache
-            .get_compiled_class_hash(class_hash)
-            .unwrap_or_else(|| panic!("Cannot retrieve '{class_hash:?}' from the cache."));
-        Ok(*compiled_class_hash)
+        let mut closure_get_class_hash = || {
+            let compiled_class_hash =
+                if let Some(compiled_class_hash) = cache.get_opt_compiled_class_hash(class_hash) {
+                    *compiled_class_hash
+                } else {
+                    let compiled_class_hash = self.state.get_compiled_class_hash(class_hash)?;
+                    cache.set_compiled_class_hash_initial_value(class_hash, compiled_class_hash);
+                    compiled_class_hash
+                };
+            Ok(compiled_class_hash)
+        };
+        let res_class_hash = closure_get_class_hash();
+
+        self.cache.set(cache);
+        res_class_hash
     }
 }
 
@@ -273,9 +306,7 @@ impl<S: StateReader> State for CachedState<S> {
         key: StorageKey,
         value: StarkFelt,
     ) -> StateResult<()> {
-        self.cache.set_storage_value(contract_address, key, value);
-
-        Ok(())
+        self.cache.get_mut().set_storage_at(contract_address, key, value)
     }
 
     fn increment_nonce(&mut self, contract_address: ContractAddress) -> StateResult<()> {
@@ -283,7 +314,7 @@ impl<S: StateReader> State for CachedState<S> {
         let current_nonce_as_u64 = usize::try_from(current_nonce.0)? as u64;
         let next_nonce_val = 1_u64 + current_nonce_as_u64;
         let next_nonce = Nonce(StarkFelt::from(next_nonce_val));
-        self.cache.set_nonce_value(contract_address, next_nonce);
+        self.cache.get_mut().set_nonce_value(contract_address, next_nonce);
 
         Ok(())
     }
@@ -297,7 +328,8 @@ impl<S: StateReader> State for CachedState<S> {
             return Err(StateError::OutOfRangeContractAddress);
         }
 
-        self.cache.set_class_hash_write(contract_address, class_hash);
+        self.cache.get_mut().set_class_hash_write(contract_address, class_hash);
+
         Ok(())
     }
 
@@ -306,8 +338,7 @@ impl<S: StateReader> State for CachedState<S> {
         class_hash: ClassHash,
         contract_class: ContractClass,
     ) -> StateResult<()> {
-        self.class_hash_to_class.insert(class_hash, contract_class);
-        Ok(())
+        self.cache.get_mut().set_contract_class(class_hash, contract_class)
     }
 
     fn set_compiled_class_hash(
@@ -315,18 +346,19 @@ impl<S: StateReader> State for CachedState<S> {
         class_hash: ClassHash,
         compiled_class_hash: CompiledClassHash,
     ) -> StateResult<()> {
-        self.cache.set_compiled_class_hash_write(class_hash, compiled_class_hash);
-        Ok(())
+        self.cache.get_mut().set_compiled_class_hash(class_hash, compiled_class_hash)
     }
+}
 
-    fn to_state_diff(&mut self) -> CommitmentStateDiff {
+impl<S: StateReader> CachedState<S> {
+    pub fn cached_state_diff(&mut self) -> CommitmentStateDiff {
         type StorageDiff = IndexMap<ContractAddress, IndexMap<StorageKey, StarkFelt>>;
 
         // TODO(Gilad): Consider returning an error here, would require changing the API though.
         self.update_initial_values_of_write_only_access()
             .unwrap_or_else(|_| panic!("Cannot convert stateDiff to CommitmentStateDiff."));
 
-        let state_cache = &self.cache;
+        let state_cache = self.cache.get_mut();
         let class_hash_updates = state_cache.get_class_hash_updates();
         let storage_diffs = state_cache.get_storage_updates();
         let nonces =
@@ -345,12 +377,7 @@ impl<S: StateReader> State for CachedState<S> {
 #[cfg(any(feature = "testing", test))]
 impl Default for CachedState<crate::test_utils::dict_state_reader::DictStateReader> {
     fn default() -> Self {
-        Self {
-            state: Default::default(),
-            cache: Default::default(),
-            class_hash_to_class: Default::default(),
-            global_class_hash_to_class: Default::default(),
-        }
+        Self { state: Default::default(), cache: Default::default() }
     }
 }
 
@@ -376,12 +403,18 @@ impl From<StorageView> for IndexMap<ContractAddress, IndexMap<StorageKey, StarkF
     }
 }
 
+pub type ContractClassMapping = HashMap<ClassHash, ContractClass>;
+
 /// Caches read and write requests.
 /// The tracked changes are needed for block state commitment.
 
 // Invariant: keys cannot be deleted from fields (only used internally by the cached state).
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default)]
 pub struct StateCache {
+    class_hash_to_class: ContractClassMapping,
+    // Invariant: managed by CachedState.
+    global_class_hash_to_class: GlobalContractCache,
+
     // Reader's cached information; initial values, read before any write operation (per cell).
     nonce_initial_values: HashMap<ContractAddress, Nonce>,
     class_hash_initial_values: HashMap<ContractAddress, ClassHash>,
@@ -395,22 +428,134 @@ pub struct StateCache {
     compiled_class_hash_writes: HashMap<ClassHash, CompiledClassHash>,
 }
 
-impl StateCache {
+impl StateReader for StateCache {
     fn get_storage_at(
         &self,
         contract_address: ContractAddress,
         key: StorageKey,
-    ) -> Option<&StarkFelt> {
-        let contract_storage_key = (contract_address, key);
-        self.storage_writes
-            .get(&contract_storage_key)
-            .or_else(|| self.storage_initial_values.get(&contract_storage_key))
+    ) -> StateResult<StarkFelt> {
+        let storage_value =
+            self.get_opt_storage_at(contract_address, key).cloned().unwrap_or(StarkFelt::ZERO);
+
+        Ok(storage_value)
     }
 
-    fn get_nonce_at(&self, contract_address: ContractAddress) -> Option<&Nonce> {
-        self.nonce_writes
-            .get(&contract_address)
-            .or_else(|| self.nonce_initial_values.get(&contract_address))
+    fn get_nonce_at(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
+        let nonce =
+            self.get_opt_nonce_at(contract_address).cloned().unwrap_or(Nonce(StarkFelt::ZERO));
+
+        Ok(nonce)
+    }
+
+    fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
+        let class_hash = self
+            .get_opt_class_hash_at(contract_address)
+            .cloned()
+            .unwrap_or(ClassHash(StarkFelt::ZERO));
+
+        Ok(class_hash)
+    }
+
+    fn get_compiled_contract_class(&self, class_hash: ClassHash) -> StateResult<ContractClass> {
+        self.get_opt_compiled_contract_class(class_hash)
+            .ok_or(StateError::UndeclaredClassHash(class_hash))
+    }
+
+    fn get_compiled_class_hash(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
+        self.get_opt_compiled_class_hash(class_hash)
+            .cloned()
+            .ok_or(StateError::UndeclaredClassHash(class_hash))
+    }
+}
+
+impl State for StateCache {
+    fn set_storage_at(
+        &mut self,
+        contract_address: ContractAddress,
+        key: StorageKey,
+        value: StarkFelt,
+    ) -> StateResult<()> {
+        let contract_storage_key = (contract_address, key);
+        self.storage_writes.insert(contract_storage_key, value);
+        Ok(())
+    }
+
+    fn increment_nonce(&mut self, contract_address: ContractAddress) -> StateResult<()> {
+        let current_nonce = self.get_nonce_at(contract_address)?;
+        let new_nonce = u64::try_from(current_nonce.0)? + 1;
+        self.set_nonce_value(contract_address, Nonce(new_nonce.into()));
+
+        Ok(())
+    }
+
+    fn set_class_hash_at(
+        &mut self,
+        contract_address: ContractAddress,
+        class_hash: ClassHash,
+    ) -> StateResult<()> {
+        self.set_class_hash_write(contract_address, class_hash);
+        Ok(())
+    }
+
+    fn set_contract_class(
+        &mut self,
+        class_hash: ClassHash,
+        contract_class: ContractClass,
+    ) -> StateResult<()> {
+        self.set_contract_class_write(class_hash, contract_class);
+        Ok(())
+    }
+
+    fn set_compiled_class_hash(
+        &mut self,
+        class_hash: ClassHash,
+        compiled_class_hash: CompiledClassHash,
+    ) -> StateResult<()> {
+        self.set_compiled_class_hash_write(class_hash, compiled_class_hash);
+        Ok(())
+    }
+}
+
+impl StateCache {
+    pub fn new(global_class_hash_to_class: GlobalContractCache) -> Self {
+        Self {
+            class_hash_to_class: Default::default(),
+            global_class_hash_to_class,
+            nonce_initial_values: Default::default(),
+            class_hash_initial_values: Default::default(),
+            storage_initial_values: Default::default(),
+            compiled_class_hash_initial_values: Default::default(),
+            nonce_writes: Default::default(),
+            class_hash_writes: Default::default(),
+            storage_writes: Default::default(),
+            compiled_class_hash_writes: Default::default(),
+        }
+    }
+
+    /// Drains contract-class cache collected during execution and updates the global cache.
+    fn move_classes_to_global_cache(&mut self) {
+        let contract_class_updates: Vec<_> = self.class_hash_to_class.drain().collect();
+        for (key, value) in contract_class_updates {
+            self.global_class_hash_to_class().cache_set(key, value);
+        }
+    }
+
+    // Locks the Mutex and unwraps the MutexGuard, thus exposing the internal cache
+    // store. The Guard will panic only if the Mutex panics during the lock operation, but
+    // this shouldn't happen in our flow.
+    pub fn global_class_hash_to_class(
+        &self,
+    ) -> MutexGuard<'_, SizedCache<ClassHash, ContractClass>> {
+        self.global_class_hash_to_class.lock()
+    }
+
+    fn update_contract_class_caches(
+        &mut self,
+        local_contract_cache_updates: ContractClassMapping,
+        global_contract_cache: GlobalContractCache,
+    ) {
+        self.class_hash_to_class.extend(local_contract_cache_updates);
+        self.global_class_hash_to_class = global_contract_cache;
     }
 
     pub fn set_storage_initial_value(
@@ -423,14 +568,40 @@ impl StateCache {
         self.storage_initial_values.insert(contract_storage_key, value);
     }
 
-    fn set_storage_value(
-        &mut self,
+    fn get_opt_storage_at(
+        &self,
         contract_address: ContractAddress,
         key: StorageKey,
-        value: StarkFelt,
-    ) {
+    ) -> Option<&StarkFelt> {
         let contract_storage_key = (contract_address, key);
-        self.storage_writes.insert(contract_storage_key, value);
+        self.storage_writes
+            .get(&contract_storage_key)
+            .or_else(|| self.storage_initial_values.get(&contract_storage_key))
+    }
+
+    fn get_opt_nonce_at(&self, contract_address: ContractAddress) -> Option<&Nonce> {
+        self.nonce_writes
+            .get(&contract_address)
+            .or_else(|| self.nonce_initial_values.get(&contract_address))
+    }
+
+    fn get_opt_class_hash_at(&self, contract_address: ContractAddress) -> Option<&ClassHash> {
+        self.class_hash_writes
+            .get(&contract_address)
+            .or_else(|| self.class_hash_initial_values.get(&contract_address))
+    }
+
+    fn get_opt_compiled_class_hash(&self, class_hash: ClassHash) -> Option<&CompiledClassHash> {
+        self.compiled_class_hash_writes
+            .get(&class_hash)
+            .or_else(|| self.compiled_class_hash_initial_values.get(&class_hash))
+    }
+
+    fn get_opt_compiled_contract_class(&self, class_hash: ClassHash) -> Option<ContractClass> {
+        self.class_hash_to_class
+            .get(&class_hash)
+            .cloned()
+            .or_else(|| self.global_class_hash_to_class().cache_get(&class_hash).cloned())
     }
 
     fn set_nonce_initial_value(&mut self, contract_address: ContractAddress, nonce: Nonce) {
@@ -439,12 +610,6 @@ impl StateCache {
 
     fn set_nonce_value(&mut self, contract_address: ContractAddress, nonce: Nonce) {
         self.nonce_writes.insert(contract_address, nonce);
-    }
-
-    fn get_class_hash_at(&self, contract_address: ContractAddress) -> Option<&ClassHash> {
-        self.class_hash_writes
-            .get(&contract_address)
-            .or_else(|| self.class_hash_initial_values.get(&contract_address))
     }
 
     fn set_class_hash_initial_value(
@@ -457,12 +622,6 @@ impl StateCache {
 
     fn set_class_hash_write(&mut self, contract_address: ContractAddress, class_hash: ClassHash) {
         self.class_hash_writes.insert(contract_address, class_hash);
-    }
-
-    fn get_compiled_class_hash(&self, class_hash: ClassHash) -> Option<&CompiledClassHash> {
-        self.compiled_class_hash_writes
-            .get(&class_hash)
-            .or_else(|| self.compiled_class_hash_initial_values.get(&class_hash))
     }
 
     fn set_compiled_class_hash_initial_value(
@@ -479,6 +638,10 @@ impl StateCache {
         compiled_class_hash: CompiledClassHash,
     ) {
         self.compiled_class_hash_writes.insert(class_hash, compiled_class_hash);
+    }
+
+    fn set_contract_class_write(&mut self, class_hash: ClassHash, contract_class: ContractClass) {
+        self.class_hash_to_class.insert(class_hash, contract_class);
     }
 
     fn get_storage_updates(&self) -> HashMap<StorageEntry, StarkFelt> {
@@ -514,26 +677,26 @@ impl<'a, S: State + ?Sized> MutRefState<'a, S> {
 /// Proxies inner object to expose `State` functionality.
 impl<'a, S: State + ?Sized> StateReader for MutRefState<'a, S> {
     fn get_storage_at(
-        &mut self,
+        &self,
         contract_address: ContractAddress,
         key: StorageKey,
     ) -> StateResult<StarkFelt> {
         self.0.get_storage_at(contract_address, key)
     }
 
-    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
+    fn get_nonce_at(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
         self.0.get_nonce_at(contract_address)
     }
 
-    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
+    fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
         self.0.get_class_hash_at(contract_address)
     }
 
-    fn get_compiled_contract_class(&mut self, class_hash: ClassHash) -> StateResult<ContractClass> {
+    fn get_compiled_contract_class(&self, class_hash: ClassHash) -> StateResult<ContractClass> {
         self.0.get_compiled_contract_class(class_hash)
     }
 
-    fn get_compiled_class_hash(&mut self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
+    fn get_compiled_class_hash(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
         self.0.get_compiled_class_hash(class_hash)
     }
 }
@@ -568,10 +731,6 @@ impl<'a, S: State + ?Sized> State for MutRefState<'a, S> {
         self.0.set_contract_class(class_hash, contract_class)
     }
 
-    fn to_state_diff(&mut self) -> CommitmentStateDiff {
-        self.0.to_state_diff()
-    }
-
     fn set_compiled_class_hash(
         &mut self,
         class_hash: ClassHash,
@@ -583,7 +742,6 @@ impl<'a, S: State + ?Sized> State for MutRefState<'a, S> {
 
 pub type TransactionalState<'a, S> = CachedState<MutRefState<'a, CachedState<S>>>;
 
-/// Adds the ability to perform a transactional execution.
 impl<'a, S: StateReader> TransactionalState<'a, S> {
     // Detach `state`, moving the instance to a pending state, which can be committed or aborted.
     pub fn stage(
@@ -591,8 +749,12 @@ impl<'a, S: StateReader> TransactionalState<'a, S> {
         tx_executed_class_hashes: HashSet<ClassHash>,
         tx_visited_storage_entries: HashSet<StorageEntry>,
     ) -> StagedTransactionalState {
-        let TransactionalState { cache, class_hash_to_class, global_class_hash_to_class, .. } =
-            self;
+        let TransactionalState { cache, .. } = self;
+        let cache = cache.into_inner();
+
+        let class_hash_to_class = cache.class_hash_to_class.clone();
+        let global_class_hash_to_class = cache.global_class_hash_to_class.clone();
+
         StagedTransactionalState {
             cache,
             class_hash_to_class,
@@ -605,10 +767,19 @@ impl<'a, S: StateReader> TransactionalState<'a, S> {
     /// Commits changes in the child (wrapping) state to its parent.
     pub fn commit(self) {
         let state = self.state.0;
-        let child_cache = self.cache;
-        state.update_cache(child_cache);
+        let cache = self.cache.into_inner();
+
+        let class_hash_to_class = cache.class_hash_to_class.clone();
+        let global_class_hash_to_class = cache.global_class_hash_to_class.clone();
+
+        // Write wrapper cache to state
+        state.update_cache(cache);
+
+        // Write wrapper contract class to state
         state
-            .update_contract_class_caches(self.class_hash_to_class, self.global_class_hash_to_class)
+            .cache
+            .get_mut()
+            .update_contract_class_caches(class_hash_to_class, global_class_hash_to_class)
     }
 
     /// Drops `self`.
@@ -701,7 +872,7 @@ impl GlobalContractCache {
 
     /// Locks the cache for atomic access. Although conceptually shared, writing to this cache is
     /// only possible for one writer at a time.
-    pub fn lock(&mut self) -> LockedContractClassCache<'_> {
+    pub fn lock(&self) -> LockedContractClassCache<'_> {
         self.0.lock().expect("Global contract cache is poisoned.")
     }
 

--- a/crates/blockifier/src/state/state_api.rs
+++ b/crates/blockifier/src/state/state_api.rs
@@ -5,7 +5,6 @@ use starknet_api::state::StorageKey;
 use crate::abi::abi_utils::get_fee_token_var_address;
 use crate::abi::sierra_types::next_storage_key;
 use crate::execution::contract_class::ContractClass;
-use crate::state::cached_state::CommitmentStateDiff;
 use crate::state::errors::StateError;
 
 pub type StateResult<T> = Result<T, StateError>;
@@ -25,24 +24,24 @@ pub trait StateReader {
     /// its address).
     /// Default: 0 for an uninitialized contract address.
     fn get_storage_at(
-        &mut self,
+        &self,
         contract_address: ContractAddress,
         key: StorageKey,
     ) -> StateResult<StarkFelt>;
 
     /// Returns the nonce of the given contract instance.
     /// Default: 0 for an uninitialized contract address.
-    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce>;
+    fn get_nonce_at(&self, contract_address: ContractAddress) -> StateResult<Nonce>;
 
     /// Returns the class hash of the contract class at the given contract instance.
     /// Default: 0 (uninitialized class hash) for an uninitialized contract address.
-    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash>;
+    fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateResult<ClassHash>;
 
     /// Returns the contract class of the given class hash.
-    fn get_compiled_contract_class(&mut self, class_hash: ClassHash) -> StateResult<ContractClass>;
+    fn get_compiled_contract_class(&self, class_hash: ClassHash) -> StateResult<ContractClass>;
 
     /// Returns the compiled class hash of the given class hash.
-    fn get_compiled_class_hash(&mut self, class_hash: ClassHash) -> StateResult<CompiledClassHash>;
+    fn get_compiled_class_hash(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash>;
 
     /// Returns the storage value representing the balance (in fee token) at the given address.
     // TODO(Dori, 1/7/2023): When a standard representation for large integers is set, change the
@@ -50,7 +49,7 @@ pub trait StateReader {
     // TODO(Dori, 1/9/2023): NEW_TOKEN_SUPPORT Determine fee token address based on tx version,
     //   once v3 is introduced.
     fn get_fee_token_balance(
-        &mut self,
+        &self,
         contract_address: ContractAddress,
         fee_token_address: ContractAddress,
     ) -> Result<(StarkFelt, StarkFelt), StateError> {
@@ -101,6 +100,4 @@ pub trait State: StateReader {
         class_hash: ClassHash,
         compiled_class_hash: CompiledClassHash,
     ) -> StateResult<()>;
-
-    fn to_state_diff(&mut self) -> CommitmentStateDiff;
 }

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -26,7 +26,7 @@ use starknet_api::transaction::{
 use starknet_api::{calldata, contract_address, patricia_key, stark_felt};
 
 use crate::abi::abi_utils::{get_fee_token_var_address, selector_from_name};
-use crate::abi::constants::{self};
+use crate::abi::constants;
 use crate::execution::contract_class::{ContractClass, ContractClassV0};
 use crate::execution::entry_point::{CallEntryPoint, CallType};
 use crate::execution::execution_utils::felt_to_stark_felt;

--- a/crates/blockifier/src/test_utils/dict_state_reader.rs
+++ b/crates/blockifier/src/test_utils/dict_state_reader.rs
@@ -21,7 +21,7 @@ pub struct DictStateReader {
 
 impl StateReader for DictStateReader {
     fn get_storage_at(
-        &mut self,
+        &self,
         contract_address: ContractAddress,
         key: StorageKey,
     ) -> StateResult<StarkFelt> {
@@ -30,12 +30,12 @@ impl StateReader for DictStateReader {
         Ok(value)
     }
 
-    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
+    fn get_nonce_at(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
         let nonce = self.address_to_nonce.get(&contract_address).copied().unwrap_or_default();
         Ok(nonce)
     }
 
-    fn get_compiled_contract_class(&mut self, class_hash: ClassHash) -> StateResult<ContractClass> {
+    fn get_compiled_contract_class(&self, class_hash: ClassHash) -> StateResult<ContractClass> {
         let contract_class = self.class_hash_to_class.get(&class_hash).cloned();
         match contract_class {
             Some(contract_class) => Ok(contract_class),
@@ -43,14 +43,14 @@ impl StateReader for DictStateReader {
         }
     }
 
-    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
+    fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
         let class_hash =
             self.address_to_class_hash.get(&contract_address).copied().unwrap_or_default();
         Ok(class_hash)
     }
 
     fn get_compiled_class_hash(
-        &mut self,
+        &self,
         class_hash: ClassHash,
     ) -> StateResult<starknet_api::core::CompiledClassHash> {
         let compiled_class_hash =

--- a/crates/native_blockifier/src/state_readers/papyrus_state.rs
+++ b/crates/native_blockifier/src/state_readers/papyrus_state.rs
@@ -36,7 +36,7 @@ impl PapyrusReader {
 // Currently unused - will soon replace the same `impl` for `PapyrusStateReader`.
 impl StateReader for PapyrusReader {
     fn get_storage_at(
-        &mut self,
+        &self,
         contract_address: ContractAddress,
         key: StorageKey,
     ) -> StateResult<StarkFelt> {
@@ -47,7 +47,7 @@ impl StateReader for PapyrusReader {
             .map_err(|error| StateError::StateReadError(error.to_string()))
     }
 
-    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
+    fn get_nonce_at(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
         let state_number = StateNumber(self.latest_block);
         match self
             .reader()?
@@ -60,7 +60,7 @@ impl StateReader for PapyrusReader {
         }
     }
 
-    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
+    fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
         let state_number = StateNumber(self.latest_block);
         match self
             .reader()?
@@ -75,7 +75,7 @@ impl StateReader for PapyrusReader {
 
     /// Returns a V1 contract if found, or a V0 contract if a V1 contract is not
     /// found, or an `Error` otherwise.
-    fn get_compiled_contract_class(&mut self, class_hash: ClassHash) -> StateResult<ContractClass> {
+    fn get_compiled_contract_class(&self, class_hash: ClassHash) -> StateResult<ContractClass> {
         let state_number = StateNumber(self.latest_block);
         let class_declaration_block_number = self
             .reader()?
@@ -112,10 +112,7 @@ impl StateReader for PapyrusReader {
         }
     }
 
-    fn get_compiled_class_hash(
-        &mut self,
-        _class_hash: ClassHash,
-    ) -> StateResult<CompiledClassHash> {
+    fn get_compiled_class_hash(&self, _class_hash: ClassHash) -> StateResult<CompiledClassHash> {
         todo!()
     }
 }

--- a/crates/native_blockifier/src/state_readers/py_state_reader.rs
+++ b/crates/native_blockifier/src/state_readers/py_state_reader.rs
@@ -32,7 +32,7 @@ impl PyStateReader {
 
 impl StateReader for PyStateReader {
     fn get_storage_at(
-        &mut self,
+        &self,
         contract_address: ContractAddress,
         key: StorageKey,
     ) -> StateResult<StarkFelt> {
@@ -44,7 +44,7 @@ impl StateReader for PyStateReader {
         .map_err(|err| StateError::StateReadError(err.to_string()))
     }
 
-    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
+    fn get_nonce_at(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
         Python::with_gil(|py| -> PyResult<PyFelt> {
             let args = (ON_CHAIN_STORAGE_DOMAIN, PyFelt::from(contract_address));
             self.state_reader_proxy.as_ref(py).call_method1("get_nonce_at", args)?.extract()
@@ -53,7 +53,7 @@ impl StateReader for PyStateReader {
         .map_err(|err| StateError::StateReadError(err.to_string()))
     }
 
-    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
+    fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
         Python::with_gil(|py| -> PyResult<PyFelt> {
             let args = (PyFelt::from(contract_address),);
             self.state_reader_proxy.as_ref(py).call_method1("get_class_hash_at", args)?.extract()
@@ -62,7 +62,7 @@ impl StateReader for PyStateReader {
         .map_err(|err| StateError::StateReadError(err.to_string()))
     }
 
-    fn get_compiled_contract_class(&mut self, class_hash: ClassHash) -> StateResult<ContractClass> {
+    fn get_compiled_contract_class(&self, class_hash: ClassHash) -> StateResult<ContractClass> {
         Python::with_gil(|py| -> Result<ContractClass, PyErr> {
             let args = (PyFelt::from(class_hash),);
             let py_raw_compiled_class: PyRawCompiledClass = self
@@ -82,7 +82,7 @@ impl StateReader for PyStateReader {
         })
     }
 
-    fn get_compiled_class_hash(&mut self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
+    fn get_compiled_class_hash(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
         Python::with_gil(|py| -> PyResult<PyFelt> {
             let args = (PyFelt::from(class_hash),);
             self.state_reader_proxy

--- a/crates/native_blockifier/src/transaction_executor.rs
+++ b/crates/native_blockifier/src/transaction_executor.rs
@@ -159,7 +159,7 @@ impl<S: StateReader> TransactionExecutor<S> {
             self.state.move_classes_to_global_cache();
         }
 
-        PyStateDiff::from(self.state.to_state_diff())
+        PyStateDiff::from(self.state.cached_state_diff())
     }
 
     // Block pre-processing; see `block_execution::pre_process_block` documentation.


### PR DESCRIPTION
In this PR:
- `StateReader` doesn't require a mutable reference to self anymore
- therefore, `CachedState` uses a `Cell` to have interior mutability for it's cache
- All state traits arguments are given by value, not ref, as they all impl `Copy`
- All state traits methods return a `StateResult` as we don't know for sure all impl will be infallible
- The method to compute state diff is taken out of the state traits, and into `impl CachedState`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1232)
<!-- Reviewable:end -->
