### PR TITLE
native_blockifier: Allow querying for `Blockifier` version.

### DIFF
--- a/crates/native_blockifier/src/lib.rs
+++ b/crates/native_blockifier/src/lib.rs
@@ -47,9 +47,19 @@ fn native_blockifier(py: Python<'_>, py_module: &PyModule) -> PyResult<()> {
     py_module.add("UndeclaredClassHashError", py.get_type::<UndeclaredClassHashError>())?;
     add_py_exceptions(py, py_module)?;
 
+    py_module.add_function(wrap_pyfunction!(blockifier_version, py)?)?;
+
     // TODO(Dori, 1/4/2023): If and when supported in the Python build environment, gate this code
     //   with #[cfg(test)].
     py_module.add_function(wrap_pyfunction!(raise_error_for_testing, py)?)?;
 
     Ok(())
+}
+
+/// Returns the version that the `blockifier` and `native_blockifier` crates were built with.
+// Assumption: both `blockifier` and `native_blockifier` use `version.workspace` in the package
+// section of their `Cargo.toml`.
+#[pyfunction]
+pub fn blockifier_version() -> PyResult<String> {
+    Ok(env!("CARGO_PKG_VERSION").to_string())
 }


### PR DESCRIPTION
This allows one to do:
```
import native_blockifier
native_blockifier.blockifier_version()
```
And get the version the native was compiled with.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1249)
<!-- Reviewable:end -->
