### PR TITLE
Added test test_count_actual_storage_changes in rust

### DIFF
--- a/crates/blockifier/feature_contracts/cairo0/compiled/test_contract_compiled.json
+++ b/crates/blockifier/feature_contracts/cairo0/compiled/test_contract_compiled.json
@@ -485,6 +485,12 @@
             "name": "test_tx_version",
             "outputs": [],
             "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "test_count_actual_storage_changes",
+            "outputs": [],
+            "type": "function"
         }
     ],
     "entry_points_by_type": {
@@ -506,6 +512,10 @@
             {
                 "offset": 433,
                 "selector": "0xad451bd0dba3d8d97104e1bfc474f88605ccc7acbe1c846839a120fdf30d95"
+            },
+            {
+                "offset": 1258,
+                "selector": "0xd47144c49bce05b6de6bce9d5ff0cc8da9420f8945453e20ef779cbea13ad4"
             },
             {
                 "offset": 757,
@@ -1853,6 +1863,36 @@
             "0x480680017fff8000",
             "0x0",
             "0x48127ffa7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffc7fff8000",
+            "0x480680017fff8000",
+            "0xf",
+            "0x480680017fff8000",
+            "0x0",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffb84",
+            "0x480680017fff8000",
+            "0xf",
+            "0x480680017fff8000",
+            "0x1",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffb7e",
+            "0x480a7ffd7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x402b7ffd7ffc7ffd",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffef",
+            "0x40780017fff7fff",
+            "0x1",
+            "0x48127ffd7fff8000",
+            "0x48127ffd7fff8000",
+            "0x480280027ffb8000",
+            "0x480280037ffb8000",
+            "0x480680017fff8000",
+            "0x0",
+            "0x48127ffa7fff8000",
             "0x208b7fff7fff7ffe"
         ],
         "debug_info": null,
@@ -2634,6 +2674,24 @@
                         "reference_ids": {}
                     }
                 }
+            ],
+            "1263": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.test_count_actual_storage_changes"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 105,
+                            "offset": 18
+                        },
+                        "reference_ids": {}
+                    }
+                }
             ]
         },
         "identifiers": {
@@ -3300,6 +3358,46 @@
             "__main__.test_contract_address.SIZEOF_LOCALS": {
                 "type": "const",
                 "value": 0
+            },
+            "__main__.test_count_actual_storage_changes": {
+                "decorators": [
+                    "external"
+                ],
+                "pc": 1243,
+                "type": "function"
+            },
+            "__main__.test_count_actual_storage_changes.Args": {
+                "full_name": "__main__.test_count_actual_storage_changes.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.test_count_actual_storage_changes.ImplicitArgs": {
+                "full_name": "__main__.test_count_actual_storage_changes.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.test_count_actual_storage_changes.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.test_count_actual_storage_changes.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.test_count_actual_storage_changes.address": {
+                "type": "const",
+                "value": 15
             },
             "__main__.test_deploy": {
                 "decorators": [
@@ -4421,6 +4519,41 @@
                 "value": 1
             },
             "__wrappers__.test_contract_address_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__wrappers__.test_count_actual_storage_changes": {
+                "decorators": [
+                    "external"
+                ],
+                "pc": 1258,
+                "type": "function"
+            },
+            "__wrappers__.test_count_actual_storage_changes.Args": {
+                "full_name": "__wrappers__.test_count_actual_storage_changes.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.test_count_actual_storage_changes.ImplicitArgs": {
+                "full_name": "__wrappers__.test_count_actual_storage_changes.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.test_count_actual_storage_changes.Return": {
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, bitwise_ptr: felt, size: felt, retdata: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.test_count_actual_storage_changes.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.test_count_actual_storage_changes.__wrapped_func": {
+                "destination": "__main__.test_count_actual_storage_changes",
+                "type": "alias"
+            },
+            "__wrappers__.test_count_actual_storage_changes_encode_return.memcpy": {
                 "destination": "starkware.cairo.common.memcpy.memcpy",
                 "type": "alias"
             },

--- a/crates/blockifier/feature_contracts/cairo0/test_contract.cairo
+++ b/crates/blockifier/feature_contracts/cairo0/test_contract.cairo
@@ -315,11 +315,18 @@ func test_get_tx_info{syscall_ptr: felt*, range_check_ptr}(
     return ();
 }
 
-
 @external
 func test_tx_version{syscall_ptr: felt*}(expected_version: felt) {
     let (tx_info: TxInfo*) = get_tx_info();
     assert tx_info.version = expected_version;
 
+    return ();
+}
+
+@external
+func test_count_actual_storage_changes{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*}() {
+    const address = 15;
+    storage_write(address=address, value=0);
+    storage_write(address=address, value=1);
     return ();
 }


### PR DESCRIPTION
Added test _test_count_actual_storage_changes_ in Rust to test the actual number of storage changes for a fee when:
1. Writing a new value to a contract cell
2. Rewriting the same value to the cell
3. Transfering 1 ETH to another account

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1253)
<!-- Reviewable:end -->
