### PR TITLE
Add a dynamic salt option to test_validate_accounts_tx to improve the…

### DIFF
--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -19,7 +19,9 @@ use starknet_api::deprecated_contract_class::{
 };
 use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::state::StorageKey;
-use starknet_api::transaction::{Calldata, Resource, ResourceBounds, ResourceBoundsMapping};
+use starknet_api::transaction::{
+    Calldata, ContractAddressSalt, Resource, ResourceBounds, ResourceBoundsMapping,
+};
 use starknet_api::{calldata, contract_address, patricia_key, stark_felt};
 
 use crate::abi::abi_utils::{get_fee_token_var_address, selector_from_name};
@@ -146,6 +148,19 @@ impl NonceManager {
         if !current.is_zero() {
             self.next_nonce.insert(account_address, current - 1);
         }
+    }
+}
+
+#[derive(Default)]
+pub struct SaltManager {
+    next_salt: u8,
+}
+
+impl SaltManager {
+    pub fn next_salt(&mut self) -> ContractAddressSalt {
+        let next_contract_address_salt = ContractAddressSalt(stark_felt!(self.next_salt));
+        self.next_salt += 1;
+        next_contract_address_salt
     }
 }
 

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -551,10 +551,8 @@ fn test_fail_deploy_account(
 ) {
     let mut state = create_state_with_falliable_validation_account();
 
-    let deployed_account_instance_id = 0;
     let faulty_account_feature_contract = FeatureContract::FaultyAccount(cairo_version);
-    let deployed_account_address =
-        faulty_account_feature_contract.get_instance_address(deployed_account_instance_id);
+    let deployed_account_address = faulty_account_feature_contract.get_instance_address(0);
 
     // Create and execute (failing) deploy account transaction.
     let deploy_account_tx = create_account_tx_for_validate_test(
@@ -563,7 +561,8 @@ fn test_fail_deploy_account(
         None,
         &mut NonceManager::default(),
         faulty_account_feature_contract,
-        deployed_account_instance_id,
+        deployed_account_address,
+        ContractAddressSalt::default(),
     );
     let fee_token_address = block_context.fee_token_address(&deploy_account_tx.fee_type());
 

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -289,15 +289,18 @@ pub fn create_state_with_falliable_validation_account() -> CachedState<DictState
     )
 }
 
+/// Creates an account transaction to test the 'validate' method of account transactions. These
+/// transactions should be used for unit tests. For example, it is not intended to deploy a contract
+/// and later call it.
 pub fn create_account_tx_for_validate_test(
     tx_type: TransactionType,
     scenario: u64,
     additional_data: Option<StarkFelt>,
     nonce_manager: &mut NonceManager,
     faulty_account: FeatureContract,
-    instance_id: u8,
+    sender_address: ContractAddress,
+    contract_address_salt: ContractAddressSalt,
 ) -> AccountTransaction {
-    let sender_address = faulty_account.get_instance_address(instance_id);
     // The first felt of the signature is used to set the scenario. If the scenario is
     // `CALL_CONTRACT` the second felt is used to pass the contract address.
     let signature = TransactionSignature(vec![
@@ -330,6 +333,7 @@ pub fn create_account_tx_for_validate_test(
                     class_hash: faulty_account.get_class_hash(),
                     constructor_calldata: calldata![stark_felt!(constants::FELT_FALSE)],
                     signature,
+                    contract_address_salt,
                 },
                 nonce_manager,
             );


### PR DESCRIPTION
Add a dynamic salt option to test_validate_accounts_tx to improve the readability of deploy.
It also allows for a more straightforward addition of positive flows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1258)
<!-- Reviewable:end -->
