### PR TITLE
refacto: state traits take all their args by value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ build
 dist
 target
 */.vscode/*
+*.DS_Store
 
 tmp_venv/*
+

--- a/crates/blockifier/src/abi/abi_utils.rs
+++ b/crates/blockifier/src/abi/abi_utils.rs
@@ -55,6 +55,6 @@ pub fn get_storage_var_address(storage_var_name: &str, args: &[StarkFelt]) -> St
 /// Returns the storage key inside the fee token corresponding to the first storage cell where the
 /// balance of contract_address is stored. Note that the reference implementation of an ERC20 stores
 /// the balance in two consecutive storage cells.
-pub fn get_fee_token_var_address(contract_address: &ContractAddress) -> StorageKey {
+pub fn get_fee_token_var_address(contract_address: ContractAddress) -> StorageKey {
     get_storage_var_address("ERC20_balances", &[*contract_address.0.key()])
 }

--- a/crates/blockifier/src/block_execution.rs
+++ b/crates/blockifier/src/block_execution.rs
@@ -4,7 +4,7 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 
 use crate::abi::constants;
-use crate::state::state_api::State;
+use crate::state::state_api::{State, StateResult};
 
 #[cfg(test)]
 #[path = "block_execution_test.rs"]
@@ -16,7 +16,7 @@ pub mod test;
 pub fn pre_process_block(
     state: &mut dyn State,
     old_block_number_and_hash: Option<(BlockNumber, BlockHash)>,
-) {
+) -> StateResult<()> {
     if let Some((block_number, block_hash)) = old_block_number_and_hash {
         state.set_storage_at(
             ContractAddress::try_from(StarkFelt::from(constants::BLOCK_HASH_CONTRACT_ADDRESS))
@@ -24,6 +24,8 @@ pub fn pre_process_block(
             StorageKey::try_from(StarkFelt::from(block_number.0))
                 .expect("Failed to convert BlockNumber to StorageKey."),
             block_hash.0,
-        );
+        )?;
     }
+
+    Ok(())
 }

--- a/crates/blockifier/src/block_execution_test.rs
+++ b/crates/blockifier/src/block_execution_test.rs
@@ -14,7 +14,8 @@ fn test_pre_process_block() {
 
     let block_number: u64 = 10;
     let block_hash = StarkFelt::from(20u32);
-    pre_process_block(&mut state, Some((BlockNumber(block_number), BlockHash(block_hash))));
+    pre_process_block(&mut state, Some((BlockNumber(block_number), BlockHash(block_hash))))
+        .unwrap();
 
     let written_hash = state.get_storage_at(
         ContractAddress::try_from(StarkFelt::from(constants::BLOCK_HASH_CONTRACT_ADDRESS)).unwrap(),

--- a/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
@@ -199,7 +199,7 @@ fn test_call_contract() {
         calldata: calldata.clone(),
         ..trivial_external_entry_point()
     };
-    let call_info = entry_point_call.clone().execute_directly(&mut state).unwrap();
+    let call_info = entry_point_call.execute_directly(&mut state).unwrap();
 
     let expected_execution = CallExecution { retdata: retdata![value], ..Default::default() };
     let expected_inner_call_info = CallInfo {

--- a/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
@@ -342,7 +342,7 @@ impl<'a> DeprecatedSyscallHintProcessor<'a> {
         value: StarkFelt,
     ) -> DeprecatedSyscallResult<StorageWriteResponse> {
         self.accessed_keys.insert(key);
-        self.state.set_storage_at(self.storage_address, key, value);
+        self.state.set_storage_at(self.storage_address, key, value)?;
 
         Ok(StorageWriteResponse {})
     }

--- a/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
@@ -610,7 +610,7 @@ pub fn replace_class(
     syscall_handler: &mut DeprecatedSyscallHintProcessor<'_>,
 ) -> DeprecatedSyscallResult<ReplaceClassResponse> {
     // Ensure the class is declared (by reading it).
-    syscall_handler.state.get_compiled_contract_class(&request.class_hash)?;
+    syscall_handler.state.get_compiled_contract_class(request.class_hash)?;
     syscall_handler.state.set_class_hash_at(syscall_handler.storage_address, request.class_hash)?;
 
     Ok(ReplaceClassResponse {})

--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -95,7 +95,7 @@ impl CallEntryPoint {
         }
         // Add class hash to the call, that will appear in the output (call info).
         self.class_hash = Some(class_hash);
-        let contract_class = state.get_compiled_contract_class(&class_hash)?;
+        let contract_class = state.get_compiled_contract_class(class_hash)?;
 
         execute_entry_point_call(self, contract_class, state, resources, context).map_err(|error| {
             match error {
@@ -315,7 +315,7 @@ pub fn execute_constructor_entry_point(
     remaining_gas: u64,
 ) -> EntryPointExecutionResult<CallInfo> {
     // Ensure the class is declared (by reading it).
-    let contract_class = state.get_compiled_contract_class(&ctor_context.class_hash)?;
+    let contract_class = state.get_compiled_contract_class(ctor_context.class_hash)?;
     let Some(constructor_selector) = contract_class.constructor_selector() else {
         // Contract has no constructor.
         return handle_empty_constructor(ctor_context, calldata, remaining_gas);

--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -375,7 +375,7 @@ struct RecursionDepthGuard {
 
 impl RecursionDepthGuard {
     fn new(current_depth: Arc<RefCell<usize>>, max_depth: usize) -> Self {
-        Self { current_depth: current_depth.clone(), max_depth }
+        Self { current_depth, max_depth }
     }
 
     // Tries to increment the current recursion depth and returns an error if the maximum depth

--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -526,14 +526,12 @@ fn test_cairo1_entry_point_segment_arena() {
         ..trivial_external_entry_point()
     };
 
-    assert!(
-        entry_point_call
-            .execute_directly(&mut state)
-            .unwrap()
-            .vm_resources
-            .builtin_instance_counter
-            .contains_key(BuiltinName::segment_arena.name())
-    );
+    assert!(entry_point_call
+        .execute_directly(&mut state)
+        .unwrap()
+        .vm_resources
+        .builtin_instance_counter
+        .contains_key(BuiltinName::segment_arena.name()));
 }
 
 #[test]
@@ -560,7 +558,7 @@ fn test_stack_trace() {
     // Fetch PC locations from the compiled contract to compute the expected PC locations in the
     // traceback. Computation is not robust, but as long as the cairo function itself is not edited,
     // this computation should be stable.
-    let contract_class = state.get_compiled_contract_class(&class_hash!(TEST_CLASS_HASH)).unwrap();
+    let contract_class = state.get_compiled_contract_class(class_hash!(TEST_CLASS_HASH)).unwrap();
     let entry_point_offset = match contract_class {
         ContractClass::V0(class) => {
             class

--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -526,12 +526,14 @@ fn test_cairo1_entry_point_segment_arena() {
         ..trivial_external_entry_point()
     };
 
-    assert!(entry_point_call
-        .execute_directly(&mut state)
-        .unwrap()
-        .vm_resources
-        .builtin_instance_counter
-        .contains_key(BuiltinName::segment_arena.name()));
+    assert!(
+        entry_point_call
+            .execute_directly(&mut state)
+            .unwrap()
+            .vm_resources
+            .builtin_instance_counter
+            .contains_key(BuiltinName::segment_arena.name())
+    );
 }
 
 #[test]

--- a/crates/blockifier/src/execution/syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/syscalls/hint_processor.rs
@@ -542,7 +542,7 @@ impl<'a> SyscallHintProcessor<'a> {
         value: StarkFelt,
     ) -> SyscallResult<StorageWriteResponse> {
         self.accessed_keys.insert(key);
-        self.state.set_storage_at(self.storage_address(), key, value);
+        self.state.set_storage_at(self.storage_address(), key, value)?;
 
         Ok(StorageWriteResponse {})
     }

--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -652,8 +652,10 @@ pub fn keccak(
 
     if remainder != 0 {
         return Err(SyscallExecutionError::SyscallError {
-            error_data: vec![StarkFelt::try_from(INVALID_INPUT_LENGTH_ERROR)
-                .map_err(SyscallExecutionError::from)?],
+            error_data: vec![
+                StarkFelt::try_from(INVALID_INPUT_LENGTH_ERROR)
+                    .map_err(SyscallExecutionError::from)?,
+            ],
         });
     }
 

--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -483,7 +483,7 @@ pub fn replace_class(
 ) -> SyscallResult<ReplaceClassResponse> {
     // Ensure the class is declared (by reading it), and of type V1.
     let class_hash = request.class_hash;
-    let class = syscall_handler.state.get_compiled_contract_class(&class_hash)?;
+    let class = syscall_handler.state.get_compiled_contract_class(class_hash)?;
 
     match class {
         ContractClass::V0(_) => {
@@ -652,10 +652,8 @@ pub fn keccak(
 
     if remainder != 0 {
         return Err(SyscallExecutionError::SyscallError {
-            error_data: vec![
-                StarkFelt::try_from(INVALID_INPUT_LENGTH_ERROR)
-                    .map_err(SyscallExecutionError::from)?,
-            ],
+            error_data: vec![StarkFelt::try_from(INVALID_INPUT_LENGTH_ERROR)
+                .map_err(SyscallExecutionError::from)?],
         });
     }
 

--- a/crates/blockifier/src/execution/syscalls/syscalls_test.rs
+++ b/crates/blockifier/src/execution/syscalls/syscalls_test.rs
@@ -159,7 +159,7 @@ fn test_get_block_hash() {
     let key = StorageKey::try_from(block_number).unwrap();
     let block_hash_contract_address =
         ContractAddress::try_from(StarkFelt::from(constants::BLOCK_HASH_CONTRACT_ADDRESS)).unwrap();
-    state.set_storage_at(block_hash_contract_address, key, block_hash);
+    state.set_storage_at(block_hash_contract_address, key, block_hash).unwrap();
 
     // Positive flow.
     let calldata = calldata![block_number];

--- a/crates/blockifier/src/execution/syscalls/syscalls_test.rs
+++ b/crates/blockifier/src/execution/syscalls/syscalls_test.rs
@@ -630,7 +630,7 @@ fn test_replace_class() {
     // Replace with Cairo 0 class hash.
     let v0_class_hash = class_hash!(5678_u16);
     let v0_contract_class = ContractClassV0::from_file(TEST_EMPTY_CONTRACT_CAIRO0_PATH).into();
-    state.set_contract_class(&v0_class_hash, v0_contract_class).unwrap();
+    state.set_contract_class(v0_class_hash, v0_contract_class).unwrap();
 
     let entry_point_call = CallEntryPoint {
         calldata: calldata![v0_class_hash.0],

--- a/crates/blockifier/src/fee/fee_utils.rs
+++ b/crates/blockifier/src/fee/fee_utils.rs
@@ -88,8 +88,8 @@ pub fn get_balance_and_if_covers_fee(
     fee: Fee,
 ) -> TransactionFeeResult<(StarkFelt, StarkFelt, bool)> {
     let (balance_low, balance_high) = state.get_fee_token_balance(
-        &account_tx_context.sender_address(),
-        &block_context.fee_token_address(&account_tx_context.fee_type()),
+        account_tx_context.sender_address(),
+        block_context.fee_token_address(&account_tx_context.fee_type()),
     )?;
     Ok((
         balance_low,

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -226,6 +226,9 @@ impl<S: StateReader> StateReader for CachedState<S> {
         Ok(*class_hash)
     }
 
+    #[allow(clippy::map_entry)]
+    // Clippy solution don't work because it required two mutable ref to self
+    // Could probably be solved with interior mutability
     fn get_compiled_contract_class(&mut self, class_hash: ClassHash) -> StateResult<ContractClass> {
         if !self.class_hash_to_class.contains_key(&class_hash) {
             let contract_class = self.global_class_hash_to_class().cache_get(&class_hash).cloned();

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -271,8 +271,10 @@ impl<S: StateReader> State for CachedState<S> {
         contract_address: ContractAddress,
         key: StorageKey,
         value: StarkFelt,
-    ) {
+    ) -> StateResult<()> {
         self.cache.set_storage_value(contract_address, key, value);
+
+        Ok(())
     }
 
     fn increment_nonce(&mut self, contract_address: ContractAddress) -> StateResult<()> {
@@ -541,7 +543,7 @@ impl<'a, S: State + ?Sized> State for MutRefState<'a, S> {
         contract_address: ContractAddress,
         key: StorageKey,
         value: StarkFelt,
-    ) {
+    ) -> StateResult<()> {
         self.0.set_storage_at(contract_address, key, value)
     }
 

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -139,14 +139,14 @@ fn get_contract_class() {
     let existing_class_hash = class_hash!(TEST_CLASS_HASH);
     let mut state = deprecated_create_test_state();
     assert_eq!(
-        state.get_compiled_contract_class(&existing_class_hash).unwrap(),
+        state.get_compiled_contract_class(existing_class_hash).unwrap(),
         get_test_contract_class()
     );
 
     // Negative flow.
     let missing_class_hash = class_hash!("0x101");
     assert_matches!(
-        state.get_compiled_contract_class(&missing_class_hash).unwrap_err(),
+        state.get_compiled_contract_class(missing_class_hash).unwrap_err(),
         StateError::UndeclaredClassHash(undeclared) if undeclared == missing_class_hash
     );
 }
@@ -380,14 +380,14 @@ fn global_contract_cache_is_used() {
     assert!(state.class_hash_to_class.get(&class_hash).is_none());
 
     // Check state uses the global cache.
-    assert_eq!(state.get_compiled_contract_class(&class_hash).unwrap(), contract_class);
+    assert_eq!(state.get_compiled_contract_class(class_hash).unwrap(), contract_class);
     assert_eq!(global_cache.lock().unwrap().cache_hits().unwrap(), 1);
     assert_eq!(global_cache.lock().unwrap().cache_size(), 1);
     // Verify local cache is also updated.
     assert_eq!(state.class_hash_to_class.get(&class_hash).unwrap(), &contract_class);
 
     // Idempotency: getting the same class again uses the local cache.
-    assert_eq!(state.get_compiled_contract_class(&class_hash).unwrap(), contract_class);
+    assert_eq!(state.get_compiled_contract_class(class_hash).unwrap(), contract_class);
     assert_eq!(global_cache.lock().unwrap().cache_hits().unwrap(), 1);
     assert_eq!(global_cache.lock().unwrap().cache_size(), 1);
 }

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -57,12 +57,12 @@ fn get_and_set_storage_value() {
     assert_eq!(state.get_storage_at(contract_address1, key1).unwrap(), storage_val1);
 
     let modified_storage_value0 = stark_felt!("0xA");
-    state.set_storage_at(contract_address0, key0, modified_storage_value0);
+    state.set_storage_at(contract_address0, key0, modified_storage_value0).unwrap();
     assert_eq!(state.get_storage_at(contract_address0, key0).unwrap(), modified_storage_value0);
     assert_eq!(state.get_storage_at(contract_address1, key1).unwrap(), storage_val1);
 
     let modified_storage_value1 = stark_felt!("0x7");
-    state.set_storage_at(contract_address1, key1, modified_storage_value1);
+    state.set_storage_at(contract_address1, key1, modified_storage_value1).unwrap();
     assert_eq!(state.get_storage_at(contract_address0, key0).unwrap(), modified_storage_value0);
     assert_eq!(state.get_storage_at(contract_address1, key1).unwrap(), modified_storage_value1);
 }
@@ -234,11 +234,11 @@ fn cached_state_state_diff_conversion() {
     state.set_compiled_class_hash(class_hash, compiled_class_hash).unwrap();
 
     // Write the initial value using key contract_address1.
-    state.set_storage_at(contract_address1, key_y, storage_val1);
+    state.set_storage_at(contract_address1, key_y, storage_val1).unwrap();
 
     // Write new values using key contract_address2.
     let new_value = stark_felt!("0x12345678");
-    state.set_storage_at(contract_address2, key_y, new_value);
+    state.set_storage_at(contract_address2, key_y, new_value).unwrap();
     assert!(state.increment_nonce(contract_address2).is_ok());
     let new_class_hash = class_hash!("0x11111111");
     assert!(state.set_class_hash_at(contract_address2, new_class_hash).is_ok());
@@ -267,15 +267,15 @@ fn create_state_changes_for_test<S: StateReader>(
     let storage_val: StarkFelt = stark_felt!("0x1");
 
     state.set_class_hash_at(contract_address, class_hash).unwrap();
-    state.set_storage_at(contract_address, key, storage_val);
+    state.set_storage_at(contract_address, key, storage_val).unwrap();
     state.increment_nonce(contract_address2).unwrap();
     state.set_compiled_class_hash(class_hash, compiled_class_hash).unwrap();
 
     // Assign the existing value to the storage (this shouldn't be considered a change).
     // As the first access:
-    state.set_storage_at(contract_address2, key, StarkFelt::default());
+    state.set_storage_at(contract_address2, key, StarkFelt::default()).unwrap();
     // As the second access:
-    state.set_storage_at(contract_address, key, storage_val);
+    state.set_storage_at(contract_address, key, storage_val).unwrap();
 
     // Return the resulting state changes.
     state
@@ -336,9 +336,15 @@ fn test_state_changes_merge() {
     let new_contract_address = ContractAddress(patricia_key!("0x111"));
 
     // Overwrite existing and new storage values.
-    transactional_state.set_storage_at(contract_address, storage_key, stark_felt!("0x1234"));
-    transactional_state.set_storage_at(contract_address2, storage_key2, stark_felt!("0x4321"));
-    transactional_state.set_storage_at(new_contract_address, storage_key, stark_felt!("0x43210"));
+    transactional_state
+        .set_storage_at(contract_address, storage_key, stark_felt!("0x1234"))
+        .unwrap();
+    transactional_state
+        .set_storage_at(contract_address2, storage_key2, stark_felt!("0x4321"))
+        .unwrap();
+    transactional_state
+        .set_storage_at(new_contract_address, storage_key, stark_felt!("0x43210"))
+        .unwrap();
     transactional_state.increment_nonce(contract_address).unwrap();
     // Get the new state changes and then commit the transactional state.
     let state_changes3 = transactional_state

--- a/crates/blockifier/src/state/state_api.rs
+++ b/crates/blockifier/src/state/state_api.rs
@@ -74,7 +74,7 @@ pub trait State: StateReader {
         contract_address: ContractAddress,
         key: StorageKey,
         value: StarkFelt,
-    );
+    ) -> StateResult<()>;
 
     /// Increments the nonce of the given contract instance.
     fn increment_nonce(&mut self, contract_address: ContractAddress) -> StateResult<()>;

--- a/crates/blockifier/src/state/state_api.rs
+++ b/crates/blockifier/src/state/state_api.rs
@@ -39,8 +39,7 @@ pub trait StateReader {
     fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash>;
 
     /// Returns the contract class of the given class hash.
-    fn get_compiled_contract_class(&mut self, class_hash: &ClassHash)
-    -> StateResult<ContractClass>;
+    fn get_compiled_contract_class(&mut self, class_hash: ClassHash) -> StateResult<ContractClass>;
 
     /// Returns the compiled class hash of the given class hash.
     fn get_compiled_class_hash(&mut self, class_hash: ClassHash) -> StateResult<CompiledClassHash>;
@@ -52,13 +51,13 @@ pub trait StateReader {
     //   once v3 is introduced.
     fn get_fee_token_balance(
         &mut self,
-        contract_address: &ContractAddress,
-        fee_token_address: &ContractAddress,
+        contract_address: ContractAddress,
+        fee_token_address: ContractAddress,
     ) -> Result<(StarkFelt, StarkFelt), StateError> {
         let low_key = get_fee_token_var_address(contract_address);
         let high_key = next_storage_key(&low_key)?;
-        let low = self.get_storage_at(*fee_token_address, low_key)?;
-        let high = self.get_storage_at(*fee_token_address, high_key)?;
+        let low = self.get_storage_at(fee_token_address, low_key)?;
+        let high = self.get_storage_at(fee_token_address, high_key)?;
 
         Ok((low, high))
     }
@@ -92,7 +91,7 @@ pub trait State: StateReader {
     /// Sets the given contract class under the given class hash.
     fn set_contract_class(
         &mut self,
-        class_hash: &ClassHash,
+        class_hash: ClassHash,
         contract_class: ContractClass,
     ) -> StateResult<()>;
 

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -97,13 +97,13 @@ impl Default for CairoVersion {
 
 // Storage keys.
 pub fn test_erc20_sequencer_balance_key() -> StorageKey {
-    get_fee_token_var_address(&contract_address!(TEST_SEQUENCER_ADDRESS))
+    get_fee_token_var_address(contract_address!(TEST_SEQUENCER_ADDRESS))
 }
 pub fn test_erc20_account_balance_key() -> StorageKey {
-    get_fee_token_var_address(&contract_address!(TEST_ACCOUNT_CONTRACT_ADDRESS))
+    get_fee_token_var_address(contract_address!(TEST_ACCOUNT_CONTRACT_ADDRESS))
 }
 pub fn test_erc20_faulty_account_balance_key() -> StorageKey {
-    get_fee_token_var_address(&contract_address!(TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS))
+    get_fee_token_var_address(contract_address!(TEST_FAULTY_ACCOUNT_CONTRACT_ADDRESS))
 }
 
 // The max_fee / resource bounds used for txs in this test.

--- a/crates/blockifier/src/test_utils/dict_state_reader.rs
+++ b/crates/blockifier/src/test_utils/dict_state_reader.rs
@@ -35,14 +35,11 @@ impl StateReader for DictStateReader {
         Ok(nonce)
     }
 
-    fn get_compiled_contract_class(
-        &mut self,
-        class_hash: &ClassHash,
-    ) -> StateResult<ContractClass> {
-        let contract_class = self.class_hash_to_class.get(class_hash).cloned();
+    fn get_compiled_contract_class(&mut self, class_hash: ClassHash) -> StateResult<ContractClass> {
+        let contract_class = self.class_hash_to_class.get(&class_hash).cloned();
         match contract_class {
             Some(contract_class) => Ok(contract_class),
-            _ => Err(StateError::UndeclaredClassHash(*class_hash)),
+            _ => Err(StateError::UndeclaredClassHash(class_hash)),
         }
     }
 

--- a/crates/blockifier/src/test_utils/initial_test_state.rs
+++ b/crates/blockifier/src/test_utils/initial_test_state.rs
@@ -20,7 +20,7 @@ pub fn fund_account(
     state: &mut CachedState<DictStateReader>,
 ) {
     let storage_view = &mut state.state.storage_view;
-    let balance_key = get_fee_token_var_address(&account_address);
+    let balance_key = get_fee_token_var_address(account_address);
     for fee_type in FeeType::iter() {
         storage_view.insert(
             (block_context.fee_token_address(&fee_type), balance_key),

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -697,7 +697,7 @@ impl ValidatableTransaction for AccountTransaction {
 
         // Validate return data.
         let class_hash = state.get_class_hash_at(storage_address)?;
-        let contract_class = state.get_compiled_contract_class(&class_hash)?;
+        let contract_class = state.get_compiled_contract_class(class_hash)?;
         if let ContractClass::V1(_) = contract_class {
             // The account contract class is a Cairo 1.0 contract; the `validate` entry point should
             // return `VALID`.

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -237,10 +237,12 @@ fn test_infinite_recursion(
     if success {
         assert!(tx_execution_info.revert_error.is_none());
     } else {
-        assert!(tx_execution_info
-            .revert_error
-            .unwrap()
-            .contains("RunResources has no remaining steps."));
+        assert!(
+            tx_execution_info
+                .revert_error
+                .unwrap()
+                .contains("RunResources has no remaining steps.")
+        );
     }
 }
 
@@ -939,10 +941,9 @@ fn test_insufficient_max_fee_reverts(
     .unwrap();
     assert!(tx_execution_info3.is_reverted());
     assert!(tx_execution_info3.actual_fee == actual_fee_depth1);
-    assert!(tx_execution_info3
-        .revert_error
-        .unwrap()
-        .contains("RunResources has no remaining steps."));
+    assert!(
+        tx_execution_info3.revert_error.unwrap().contains("RunResources has no remaining steps.")
+    );
 }
 
 #[rstest]
@@ -1089,7 +1090,7 @@ fn test_count_actual_storage_changes(
     let account_tx = account_invoke_tx(InvokeTxArgs {
         nonce: nonce_manager.next(account_address),
         calldata: transfer_calldata,
-        ..invoke_args.clone()
+        ..invoke_args
     });
     let execution_info = account_tx.execute_raw(&mut state, &block_context, true, true).unwrap();
 

--- a/crates/blockifier/src/transaction/execution_flavors_test.rs
+++ b/crates/blockifier/src/transaction/execution_flavors_test.rs
@@ -70,7 +70,7 @@ fn check_balance<S: StateReader>(
     charge_fee: bool,
 ) -> StarkFelt {
     let (new_balance, _) = state
-        .get_fee_token_balance(&account_address, &block_context.fee_token_address(fee_type))
+        .get_fee_token_balance(account_address, block_context.fee_token_address(fee_type))
         .unwrap();
     if charge_fee {
         assert!(new_balance < current_balance);
@@ -377,7 +377,7 @@ fn test_simulate_validate_charge_fee_mid_execution(
 
     // If charge_fee is false, test that balance indeed doesn't change.
     let (current_balance, _) = state
-        .get_fee_token_balance(&account_address, &block_context.fee_token_address(&fee_type))
+        .get_fee_token_balance(account_address, block_context.fee_token_address(&fee_type))
         .unwrap();
 
     // Execution scenarios.
@@ -533,7 +533,7 @@ fn test_simulate_validate_charge_fee_post_execution(
 
     // If charge_fee is false, test that balance indeed doesn't change.
     let (current_balance, _) =
-        state.get_fee_token_balance(&account_address, &fee_token_address).unwrap();
+        state.get_fee_token_balance(account_address, fee_token_address).unwrap();
 
     // Post-execution scenarios:
     // 1. Consumed too many resources (more than resource bounds).
@@ -616,13 +616,11 @@ fn test_simulate_validate_charge_fee_post_execution(
     .unwrap();
     assert_eq!(tx_execution_info.is_reverted(), charge_fee);
     if charge_fee {
-        assert!(
-            tx_execution_info
-                .revert_error
-                .clone()
-                .unwrap()
-                .contains("Insufficient fee token balance.")
-        );
+        assert!(tx_execution_info
+            .revert_error
+            .clone()
+            .unwrap()
+            .contains("Insufficient fee token balance."));
     }
     check_gas_and_fee(
         &block_context,

--- a/crates/blockifier/src/transaction/execution_flavors_test.rs
+++ b/crates/blockifier/src/transaction/execution_flavors_test.rs
@@ -265,7 +265,7 @@ fn test_simulate_validate_charge_fee_pre_validate(
         let result = account_invoke_tx(invoke_tx_args! {
             resource_bounds: l1_resource_bounds(MAX_L1_GAS_AMOUNT, gas_price - 1),
             nonce: nonce_manager.next(account_address),
-            ..pre_validation_base_args.clone()
+            ..pre_validation_base_args
         })
         .execute(&mut state, &block_context, charge_fee, validate);
         if !charge_fee {
@@ -480,7 +480,7 @@ fn test_simulate_validate_charge_fee_mid_execution(
         resource_bounds: l1_resource_bounds(huge_gas_limit, gas_price),
         calldata: recurse_calldata(test_contract_address, false, 10000),
         nonce: nonce_manager.next(account_address),
-        ..execution_base_args.clone()
+        ..execution_base_args
     })
     .execute(&mut state, &low_step_block_context, charge_fee, validate)
     .unwrap();
@@ -616,11 +616,13 @@ fn test_simulate_validate_charge_fee_post_execution(
     .unwrap();
     assert_eq!(tx_execution_info.is_reverted(), charge_fee);
     if charge_fee {
-        assert!(tx_execution_info
-            .revert_error
-            .clone()
-            .unwrap()
-            .contains("Insufficient fee token balance."));
+        assert!(
+            tx_execution_info
+                .revert_error
+                .clone()
+                .unwrap()
+                .contains("Insufficient fee token balance.")
+        );
     }
     check_gas_and_fee(
         &block_context,

--- a/crates/blockifier/src/transaction/post_execution_test.rs
+++ b/crates/blockifier/src/transaction/post_execution_test.rs
@@ -141,8 +141,8 @@ fn test_revert_on_overdraft(
     // Check the current balance, before next transaction.
     let (balance, _) = state
         .get_fee_token_balance(
-            &account_address,
-            &block_context.fee_token_address(&account_tx_context.fee_type()),
+            account_address,
+            block_context.fee_token_address(&account_tx_context.fee_type()),
         )
         .unwrap();
 
@@ -185,8 +185,8 @@ fn test_revert_on_overdraft(
     assert_eq!(
         state
             .get_fee_token_balance(
-                &account_address,
-                &block_context.fee_token_address(&account_tx_context.fee_type()),
+                account_address,
+                block_context.fee_token_address(&account_tx_context.fee_type()),
             )
             .unwrap(),
         (expected_new_balance, stark_felt!(0_u8))
@@ -194,8 +194,8 @@ fn test_revert_on_overdraft(
     assert_eq!(
         state
             .get_fee_token_balance(
-                &recipient_address,
-                &block_context.fee_token_address(&account_tx_context.fee_type())
+                recipient_address,
+                block_context.fee_token_address(&account_tx_context.fee_type())
             )
             .unwrap(),
         (final_received_amount, stark_felt!(0_u8))
@@ -295,9 +295,11 @@ fn test_revert_on_resource_overuse(
 
     // Assert the transaction was reverted with the correct error.
     if is_revertible {
-        assert!(
-            execution_info_result.unwrap().revert_error.unwrap().starts_with(expected_error_prefix)
-        );
+        assert!(execution_info_result
+            .unwrap()
+            .revert_error
+            .unwrap()
+            .starts_with(expected_error_prefix));
     } else {
         assert_matches!(
             execution_info_result.unwrap_err(),

--- a/crates/blockifier/src/transaction/post_execution_test.rs
+++ b/crates/blockifier/src/transaction/post_execution_test.rs
@@ -163,7 +163,7 @@ fn test_revert_on_overdraft(
                 fee_token_address
             ),
             version,
-            resource_bounds: max_resource_bounds.clone(),
+            resource_bounds: max_resource_bounds,
             nonce: nonce_manager.next(account_address),
         },
     )
@@ -245,7 +245,7 @@ fn test_revert_on_resource_overuse(
         &block_context,
         invoke_tx_args! {
             max_fee,
-            resource_bounds: max_resource_bounds.clone(),
+            resource_bounds: max_resource_bounds,
             nonce: nonce_manager.next(account_address),
             calldata: write_a_lot_calldata(),
             ..base_args.clone()
@@ -295,11 +295,9 @@ fn test_revert_on_resource_overuse(
 
     // Assert the transaction was reverted with the correct error.
     if is_revertible {
-        assert!(execution_info_result
-            .unwrap()
-            .revert_error
-            .unwrap()
-            .starts_with(expected_error_prefix));
+        assert!(
+            execution_info_result.unwrap().revert_error.unwrap().starts_with(expected_error_prefix)
+        );
     } else {
         assert_matches!(
             execution_info_result.unwrap_err(),

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -103,7 +103,7 @@ pub fn deploy_and_fund_account(
     // Update the balance of the about-to-be deployed account contract in the erc20 contract, so it
     // can pay for the transaction execution.
     // Set balance in all fee types.
-    let deployed_account_balance_key = get_fee_token_var_address(&account_address);
+    let deployed_account_balance_key = get_fee_token_var_address(account_address);
     for fee_type in FeeType::iter() {
         let fee_token_address = block_context.fee_token_address(&fee_type);
         state.set_storage_at(fee_token_address, deployed_account_balance_key, stark_felt!(BALANCE));

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -106,7 +106,9 @@ pub fn deploy_and_fund_account(
     let deployed_account_balance_key = get_fee_token_var_address(account_address);
     for fee_type in FeeType::iter() {
         let fee_token_address = block_context.fee_token_address(&fee_type);
-        state.set_storage_at(fee_token_address, deployed_account_balance_key, stark_felt!(BALANCE));
+        state
+            .set_storage_at(fee_token_address, deployed_account_balance_key, stark_felt!(BALANCE))
+            .unwrap();
     }
 
     (account_tx, account_address)

--- a/crates/blockifier/src/transaction/transactions.rs
+++ b/crates/blockifier/src/transaction/transactions.rs
@@ -211,7 +211,7 @@ impl<S: State> Executable<S> for DeclareTransaction {
             // No class commitment, so no need to check if the class is already declared.
             starknet_api::transaction::DeclareTransaction::V0(_)
             | starknet_api::transaction::DeclareTransaction::V1(_) => {
-                state.set_contract_class(&class_hash, self.contract_class.clone())?;
+                state.set_contract_class(class_hash, self.contract_class.clone())?;
                 Ok(None)
             }
             starknet_api::transaction::DeclareTransaction::V2(DeclareTransactionV2 {
@@ -222,10 +222,10 @@ impl<S: State> Executable<S> for DeclareTransaction {
                 compiled_class_hash,
                 ..
             }) => {
-                match state.get_compiled_contract_class(&class_hash) {
+                match state.get_compiled_contract_class(class_hash) {
                     Err(StateError::UndeclaredClassHash(_)) => {
                         // Class is undeclared; declare it.
-                        state.set_contract_class(&class_hash, self.contract_class.clone())?;
+                        state.set_contract_class(class_hash, self.contract_class.clone())?;
                         state.set_compiled_class_hash(class_hash, *compiled_class_hash)?;
                         Ok(None)
                     }

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -106,11 +106,7 @@ fn expected_validate_call_info(
             usize::from(entry_point_selector_name == constants::VALIDATE_ENTRY_POINT_NAME)
         }
         CairoVersion::Cairo1 => {
-            if entry_point_selector_name == constants::VALIDATE_ENTRY_POINT_NAME {
-                7
-            } else {
-                2
-            }
+            if entry_point_selector_name == constants::VALIDATE_ENTRY_POINT_NAME { 7 } else { 2 }
         }
     };
     let n_memory_holes = match cairo_version {
@@ -1621,7 +1617,7 @@ fn test_only_query_flag(#[case] only_query: bool) {
         [
             execute_calldata,
             expected_block_info.clone().to_vec(),
-            expected_tx_info.clone(),
+            expected_tx_info,
             expected_call_info,
         ]
         .concat()
@@ -1754,8 +1750,10 @@ fn test_execute_tx_with_invalid_transaction_version() {
     });
 
     let execution_info = account_tx.execute(state, block_context, true, true).unwrap();
-    assert!(execution_info
-        .revert_error
-        .unwrap()
-        .contains(format!("ASSERT_EQ instruction failed: {} != 1.", invalid_version).as_str()));
+    assert!(
+        execution_info
+            .revert_error
+            .unwrap()
+            .contains(format!("ASSERT_EQ instruction failed: {} != 1.", invalid_version).as_str())
+    );
 }

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -106,7 +106,11 @@ fn expected_validate_call_info(
             usize::from(entry_point_selector_name == constants::VALIDATE_ENTRY_POINT_NAME)
         }
         CairoVersion::Cairo1 => {
-            if entry_point_selector_name == constants::VALIDATE_ENTRY_POINT_NAME { 7 } else { 2 }
+            if entry_point_selector_name == constants::VALIDATE_ENTRY_POINT_NAME {
+                7
+            } else {
+                2
+            }
         }
     };
     let n_memory_holes = match cairo_version {
@@ -198,10 +202,10 @@ fn expected_fee_transfer_call_info(
         },
     };
 
-    let sender_balance_key_low = get_fee_token_var_address(&account_address);
+    let sender_balance_key_low = get_fee_token_var_address(account_address);
     let sender_balance_key_high =
         next_storage_key(&sender_balance_key_low).expect("Cannot get sender balance high key.");
-    let sequencer_balance_key_low = get_fee_token_var_address(&block_context.sequencer_address);
+    let sequencer_balance_key_low = get_fee_token_var_address(block_context.sequencer_address);
     let sequencer_balance_key_high = next_storage_key(&sequencer_balance_key_low)
         .expect("Cannot get sequencer balance high key.");
     Some(CallInfo {
@@ -456,7 +460,7 @@ fn test_invoke_tx(
         state,
         block_context,
         expected_actual_fee,
-        get_fee_token_var_address(&account_contract_address),
+        get_fee_token_var_address(account_contract_address),
         fee_type,
         BALANCE,
         BALANCE,
@@ -703,7 +707,7 @@ fn test_state_get_fee_token_balance(
 
     // Get balance from state, and validate.
     let (low, high) =
-        state.get_fee_token_balance(&contract_address!(recipient), &fee_token_address).unwrap();
+        state.get_fee_token_balance(contract_address!(recipient), fee_token_address).unwrap();
 
     assert_eq!(low, mint_low);
     assert_eq!(high, mint_high);
@@ -1064,7 +1068,7 @@ fn test_declare_tx(
 
     // Check state before transaction application.
     assert_matches!(
-        state.get_compiled_contract_class(&class_hash).unwrap_err(),
+        state.get_compiled_contract_class(class_hash).unwrap_err(),
         StateError::UndeclaredClassHash(undeclared_class_hash) if
         undeclared_class_hash == class_hash
     );
@@ -1148,14 +1152,14 @@ fn test_declare_tx(
         state,
         block_context,
         expected_actual_fee,
-        get_fee_token_var_address(&sender_address),
+        get_fee_token_var_address(sender_address),
         fee_type,
         BALANCE,
         BALANCE,
     );
 
     // Verify class declaration.
-    let contract_class_from_state = state.get_compiled_contract_class(&class_hash).unwrap();
+    let contract_class_from_state = state.get_compiled_contract_class(class_hash).unwrap();
     assert_eq!(contract_class_from_state, contract_class);
 }
 
@@ -1186,7 +1190,7 @@ fn test_deploy_account_tx(
 
     // Update the balance of the about to be deployed account contract in the erc20 contract, so it
     // can pay for the transaction execution.
-    let deployed_account_balance_key = get_fee_token_var_address(&deployed_account_address);
+    let deployed_account_balance_key = get_fee_token_var_address(deployed_account_address);
     for fee_type in FeeType::iter() {
         state.set_storage_at(
             block_context.fee_token_address(&fee_type),
@@ -1323,7 +1327,7 @@ fn test_fail_deploy_account_undeclared_class_hash() {
     // Fund account, so as not to fail pre-validation.
     state.set_storage_at(
         block_context.fee_token_address(&FeeType::Eth),
-        get_fee_token_var_address(&deploy_account.contract_address),
+        get_fee_token_var_address(deploy_account.contract_address),
         stark_felt!(BALANCE),
     );
 
@@ -1744,10 +1748,8 @@ fn test_execute_tx_with_invalid_transaction_version() {
     });
 
     let execution_info = account_tx.execute(state, block_context, true, true).unwrap();
-    assert!(
-        execution_info
-            .revert_error
-            .unwrap()
-            .contains(format!("ASSERT_EQ instruction failed: {} != 1.", invalid_version).as_str())
-    );
+    assert!(execution_info
+        .revert_error
+        .unwrap()
+        .contains(format!("ASSERT_EQ instruction failed: {} != 1.", invalid_version).as_str()));
 }

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -687,11 +687,13 @@ fn test_state_get_fee_token_balance(
     let fee_token_address = block_context.fee_token_address(&fee_type);
 
     // Give the account mint privileges.
-    state.set_storage_at(
-        fee_token_address,
-        get_storage_var_address("permitted_minter", &[]),
-        *account_address.0.key(),
-    );
+    state
+        .set_storage_at(
+            fee_token_address,
+            get_storage_var_address("permitted_minter", &[]),
+            *account_address.0.key(),
+        )
+        .unwrap();
 
     // Mint some tokens.
     let execute_calldata =
@@ -1192,11 +1194,13 @@ fn test_deploy_account_tx(
     // can pay for the transaction execution.
     let deployed_account_balance_key = get_fee_token_var_address(deployed_account_address);
     for fee_type in FeeType::iter() {
-        state.set_storage_at(
-            block_context.fee_token_address(&fee_type),
-            deployed_account_balance_key,
-            stark_felt!(BALANCE),
-        );
+        state
+            .set_storage_at(
+                block_context.fee_token_address(&fee_type),
+                deployed_account_balance_key,
+                stark_felt!(BALANCE),
+            )
+            .unwrap();
     }
 
     let account_tx = AccountTransaction::DeployAccount(deploy_account);
@@ -1325,11 +1329,13 @@ fn test_fail_deploy_account_undeclared_class_hash() {
     );
 
     // Fund account, so as not to fail pre-validation.
-    state.set_storage_at(
-        block_context.fee_token_address(&FeeType::Eth),
-        get_fee_token_var_address(deploy_account.contract_address),
-        stark_felt!(BALANCE),
-    );
+    state
+        .set_storage_at(
+            block_context.fee_token_address(&FeeType::Eth),
+            get_fee_token_var_address(deploy_account.contract_address),
+            stark_felt!(BALANCE),
+        )
+        .unwrap();
 
     let account_tx = AccountTransaction::DeployAccount(deploy_account);
     let error = account_tx.execute(state, block_context, true, true).unwrap_err();

--- a/crates/native_blockifier/bench/blockifier_bench.rs
+++ b/crates/native_blockifier/bench/blockifier_bench.rs
@@ -136,7 +136,7 @@ fn prepare_accounts(
         let deployed_account_address = deploy_account_tx.contract_address;
         addresses.push(deployed_account_address);
         nonces.push(1_u64);
-        let deployed_account_balance_key = get_fee_token_var_address(&deployed_account_address);
+        let deployed_account_balance_key = get_fee_token_var_address(deployed_account_address);
         state.set_storage_at(
             block_context.fee_token_addresses.eth_fee_token_address,
             deployed_account_balance_key,

--- a/crates/native_blockifier/bench/blockifier_bench.rs
+++ b/crates/native_blockifier/bench/blockifier_bench.rs
@@ -137,11 +137,13 @@ fn prepare_accounts(
         addresses.push(deployed_account_address);
         nonces.push(1_u64);
         let deployed_account_balance_key = get_fee_token_var_address(deployed_account_address);
-        state.set_storage_at(
-            block_context.fee_token_addresses.eth_fee_token_address,
-            deployed_account_balance_key,
-            stark_felt!(BALANCE * 1000),
-        );
+        state
+            .set_storage_at(
+                block_context.fee_token_addresses.eth_fee_token_address,
+                deployed_account_balance_key,
+                stark_felt!(BALANCE * 1000),
+            )
+            .unwrap();
 
         let account_tx = AccountTransaction::DeployAccount(deploy_account_tx);
         let charge_fee = false;

--- a/crates/native_blockifier/src/py_block_executor_test.rs
+++ b/crates/native_blockifier/src/py_block_executor_test.rs
@@ -26,7 +26,7 @@ fn global_contract_cache_update() {
     block_executor
         .tx_executor()
         .state
-        .set_contract_class(&class_hash, contract_class.clone())
+        .set_contract_class(class_hash, contract_class.clone())
         .unwrap();
 
     // Finalizing a pending block doesn't update the global contract cache.
@@ -37,7 +37,7 @@ fn global_contract_cache_update() {
 
     // Finalizing a non-pending block does update the global cache.
     block_executor.setup_block_execution(PyBlockInfo::default()).unwrap();
-    block_executor.tx_executor().state.set_contract_class(&class_hash, contract_class).unwrap();
+    block_executor.tx_executor().state.set_contract_class(class_hash, contract_class).unwrap();
     let is_pending_block = false;
     block_executor.finalize(is_pending_block);
     assert_eq!(block_executor.global_contract_cache.lock().unwrap().cache_size(), 1);

--- a/crates/native_blockifier/src/state_readers/py_state_reader.rs
+++ b/crates/native_blockifier/src/state_readers/py_state_reader.rs
@@ -62,12 +62,9 @@ impl StateReader for PyStateReader {
         .map_err(|err| StateError::StateReadError(err.to_string()))
     }
 
-    fn get_compiled_contract_class(
-        &mut self,
-        class_hash: &ClassHash,
-    ) -> StateResult<ContractClass> {
+    fn get_compiled_contract_class(&mut self, class_hash: ClassHash) -> StateResult<ContractClass> {
         Python::with_gil(|py| -> Result<ContractClass, PyErr> {
-            let args = (PyFelt::from(*class_hash),);
+            let args = (PyFelt::from(class_hash),);
             let py_raw_compiled_class: PyRawCompiledClass = self
                 .state_reader_proxy
                 .as_ref(py)
@@ -78,7 +75,7 @@ impl StateReader for PyStateReader {
         })
         .map_err(|err| {
             if Python::with_gil(|py| err.is_instance_of::<UndeclaredClassHashError>(py)) {
-                StateError::UndeclaredClassHash(*class_hash)
+                StateError::UndeclaredClassHash(class_hash)
             } else {
                 StateError::StateReadError(err.to_string())
             }

--- a/crates/native_blockifier/src/transaction_executor.rs
+++ b/crates/native_blockifier/src/transaction_executor.rs
@@ -188,7 +188,7 @@ pub fn get_casm_hash_calculation_resources<S: StateReader>(
     let mut casm_hash_computation_resources = VmExecutionResources::default();
 
     for class_hash in newly_executed_class_hashes {
-        let class = state.get_compiled_contract_class(class_hash)?;
+        let class = state.get_compiled_contract_class(*class_hash)?;
         casm_hash_computation_resources += &class.estimate_casm_hash_computation_resources();
     }
 

--- a/crates/native_blockifier/src/transaction_executor.rs
+++ b/crates/native_blockifier/src/transaction_executor.rs
@@ -148,7 +148,7 @@ impl<S: StateReader> TransactionExecutor<S> {
         let old_block_number_and_hash = old_block_number_and_hash
             .map(|(block_number, block_hash)| (BlockNumber(block_number), BlockHash(block_hash.0)));
 
-        pre_process_block(&mut self.state, old_block_number_and_hash);
+        pre_process_block(&mut self.state, old_block_number_and_hash)?;
 
         Ok(())
     }


### PR DESCRIPTION
Following discussions with @giladchase about #1232 I split part of the changes into this PR that presents no functional changes and will therefore be easier to review and merge.

1) the traits' methods signatures were weird. Most args were passed by value but some were by reference. All of those imp Copy, so let's pass them all by value

2) for some reason, the `set_storage_at` method was declared infallible. Which we can't know for sure.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1264)
<!-- Reviewable:end -->
