### PR TITLE
Clear global_contract_cache on revert block.

### DIFF
--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -115,10 +115,8 @@ impl<S: StateReader> CachedState<S> {
     // store. The Guard will panic only if the Mutex panics during the lock operation, but
     // this shouldn't happen in our flow.
     // Note: `&mut` is used since the LRU cache updates internal counters on reads.
-    pub fn global_class_hash_to_class(
-        &mut self,
-    ) -> MutexGuard<'_, SizedCache<ClassHash, ContractClass>> {
-        self.global_class_hash_to_class.lock().expect("Global contract cache is poisoned.")
+    pub fn global_class_hash_to_class(&mut self) -> LockedContractClassCache<'_> {
+        self.global_class_hash_to_class.lock()
     }
 
     pub fn update_cache(&mut self, cache_updates: StateCache) {
@@ -684,14 +682,25 @@ impl From<&StateChanges> for StateChangesCount {
 
 // Note: `ContractClassLRUCache` key-value types must align with `ContractClassMapping`.
 type ContractClassLRUCache = SizedCache<ClassHash, ContractClass>;
-#[derive(Debug, Clone, derive_more::Deref, derive_more::DerefMut)]
+type LockedContractClassCache<'a> = MutexGuard<'a, ContractClassLRUCache>;
+#[derive(Debug, Clone)]
 // Thread-safe LRU cache for contract classes, optimized for inter-language sharing when
 // `blockifier` compiles as a shared library.
 pub struct GlobalContractCache(pub Arc<Mutex<ContractClassLRUCache>>);
 
 impl GlobalContractCache {
-    // TODO: make this configurable via a CachedState constructor argument.
+    // TODO(Arni, 7/1/2024): make this configurable via a CachedState constructor argument.
     const CACHE_SIZE: usize = 100;
+
+    /// Locks the cache for atomic access. Although conceptually shared, writing to this cache is
+    /// only possible for one writer at a time.
+    pub fn lock(&mut self) -> LockedContractClassCache<'_> {
+        self.0.lock().expect("Global contract cache is poisoned.")
+    }
+
+    pub fn clear(&mut self) {
+        self.lock().cache_clear();
+    }
 }
 
 impl Default for GlobalContractCache {

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -370,11 +370,11 @@ fn test_state_changes_merge() {
 fn global_contract_cache_is_used() {
     // Initialize the global cache with a single class, and initialize an empty state with this
     // cache.
-    let global_cache = GlobalContractCache::default();
+    let mut global_cache = GlobalContractCache::default();
     let class_hash = class_hash!(TEST_CLASS_HASH);
     let contract_class = get_test_contract_class();
-    global_cache.lock().unwrap().cache_set(class_hash, contract_class.clone());
-    assert_eq!(global_cache.lock().unwrap().cache_size(), 1);
+    global_cache.lock().cache_set(class_hash, contract_class.clone());
+    assert_eq!(global_cache.lock().cache_size(), 1);
     let mut state = CachedState::new(DictStateReader::default(), global_cache.clone());
 
     // Assert local cache is initialized empty even if global cache is not empty.
@@ -382,13 +382,13 @@ fn global_contract_cache_is_used() {
 
     // Check state uses the global cache.
     assert_eq!(state.get_compiled_contract_class(&class_hash).unwrap(), contract_class);
-    assert_eq!(global_cache.lock().unwrap().cache_hits().unwrap(), 1);
-    assert_eq!(global_cache.lock().unwrap().cache_size(), 1);
+    assert_eq!(global_cache.lock().cache_hits().unwrap(), 1);
+    assert_eq!(global_cache.lock().cache_size(), 1);
     // Verify local cache is also updated.
     assert_eq!(state.class_hash_to_class.get(&class_hash).unwrap(), &contract_class);
 
     // Idempotency: getting the same class again uses the local cache.
     assert_eq!(state.get_compiled_contract_class(&class_hash).unwrap(), contract_class);
-    assert_eq!(global_cache.lock().unwrap().cache_hits().unwrap(), 1);
-    assert_eq!(global_cache.lock().unwrap().cache_size(), 1);
+    assert_eq!(global_cache.lock().cache_hits().unwrap(), 1);
+    assert_eq!(global_cache.lock().cache_size(), 1);
 }

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -180,6 +180,8 @@ impl PyBlockExecutor {
     /// (this is true for every partial existence of information at tables).
     #[pyo3(signature = (block_number))]
     pub fn revert_block(&mut self, block_number: u64) -> NativeBlockifierResult<()> {
+        // Clear global class cache, to peroperly revert classes declared in the reverted block.
+        self.global_contract_cache.clear();
         self.storage.revert_block(block_number)
     }
 

--- a/crates/native_blockifier/src/py_block_executor_test.rs
+++ b/crates/native_blockifier/src/py_block_executor_test.rs
@@ -26,7 +26,7 @@ fn global_contract_cache_update() {
     // Finalizing a pending block doesn't update the global contract cache.
     let is_pending_block = true;
     block_executor.finalize(is_pending_block);
-    assert_eq!(block_executor.global_contract_cache.lock().unwrap().cache_size(), 0);
+    assert_eq!(block_executor.global_contract_cache.lock().cache_size(), 0);
     block_executor.teardown_block_execution();
 
     // Finalizing a non-pending block does update the global cache.
@@ -34,6 +34,6 @@ fn global_contract_cache_update() {
     block_executor.tx_executor().state.set_contract_class(&class_hash, contract_class).unwrap();
     let is_pending_block = false;
     block_executor.finalize(is_pending_block);
-    assert_eq!(block_executor.global_contract_cache.lock().unwrap().cache_size(), 1);
+    assert_eq!(block_executor.global_contract_cache.lock().cache_size(), 1);
     block_executor.teardown_block_execution();
 }


### PR DESCRIPTION
Tested against: https://github.com/starkware-industries/starkware/tree/arni/blockifier_revert_bug/poc/declare_v2 with a local repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1295)
<!-- Reviewable:end -->
