### PR TITLE
Fix broken merge

### DIFF
--- a/crates/blockifier/src/test_utils/prices.rs
+++ b/crates/blockifier/src/test_utils/prices.rs
@@ -46,11 +46,13 @@ fn fee_transfer_resources(
     let token_address = block_context.fee_token_address(&fee_type);
 
     // Fund the account so we don't hit an error.
-    state.set_storage_at(
-        token_address,
-        get_fee_token_var_address(&account_contract_address),
-        stark_felt!(BALANCE),
-    );
+    state
+        .set_storage_at(
+            token_address,
+            get_fee_token_var_address(account_contract_address),
+            stark_felt!(BALANCE),
+        )
+        .unwrap();
 
     // Execute a fee transfer call and return the VM resources used.
     let fee_transfer_call = CallEntryPoint {

--- a/crates/blockifier/src/transaction/objects.rs
+++ b/crates/blockifier/src/transaction/objects.rs
@@ -176,9 +176,7 @@ impl TransactionExecutionInfo {
     /// Returns the set of storage entries visited during this transaction execution.
     pub fn get_visited_storage_entries(&self) -> HashSet<StorageEntry> {
         concat(
-            self.non_optional_call_infos()
-                .into_iter()
-                .map(|call_info| call_info.get_visited_storage_entries()),
+            self.non_optional_call_infos().map(|call_info| call_info.get_visited_storage_entries()),
         )
     }
 


### PR DESCRIPTION
Fix merge failure after an old test was run without rebasing and testing first.

Changes:
a) set_storage_at now returns a result in case of failure to write. This can be unwrapped in test_utils.
b) non_optional_callinfos now returns an iterator, so no need to call into_iter

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1309)
<!-- Reviewable:end -->
