### PR TITLE
fix: remove to_state_diff from StateApi

### DIFF
--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -153,6 +153,27 @@ impl<S: StateReader> CachedState<S> {
 
         Ok(())
     }
+
+    pub fn to_state_diff(&mut self) -> CommitmentStateDiff {
+        type StorageDiff = IndexMap<ContractAddress, IndexMap<StorageKey, StarkFelt>>;
+
+        // TODO(Gilad): Consider returning an error here, would require changing the API though.
+        self.update_initial_values_of_write_only_access()
+            .unwrap_or_else(|_| panic!("Cannot convert stateDiff to CommitmentStateDiff."));
+
+        let state_cache = self.cache.borrow();
+        let class_hash_updates = state_cache.get_class_hash_updates();
+        let storage_diffs = state_cache.get_storage_updates();
+        let nonces = state_cache.get_nonce_updates();
+        let declared_classes = state_cache.compiled_class_hash_writes.clone();
+
+        CommitmentStateDiff {
+            address_to_class_hash: IndexMap::from_iter(class_hash_updates),
+            storage_updates: StorageDiff::from(StorageView(storage_diffs)),
+            class_hash_to_compiled_class_hash: IndexMap::from_iter(declared_classes),
+            address_to_nonce: IndexMap::from_iter(nonces),
+        }
+    }
 }
 
 #[cfg(any(feature = "testing", test))]
@@ -310,27 +331,6 @@ impl<S: StateReader> State for CachedState<S> {
     ) -> StateResult<()> {
         self.cache.get_mut().set_compiled_class_hash_write(class_hash, compiled_class_hash);
         Ok(())
-    }
-
-    fn to_state_diff(&mut self) -> CommitmentStateDiff {
-        type StorageDiff = IndexMap<ContractAddress, IndexMap<StorageKey, StarkFelt>>;
-
-        // TODO(Gilad): Consider returning an error here, would require changing the API though.
-        self.update_initial_values_of_write_only_access()
-            .unwrap_or_else(|_| panic!("Cannot convert stateDiff to CommitmentStateDiff."));
-
-        let state_cache = self.cache.borrow();
-        let class_hash_updates = state_cache.get_class_hash_updates();
-        let storage_diffs = state_cache.get_storage_updates();
-        let nonces = state_cache.get_nonce_updates();
-        let declared_classes = state_cache.compiled_class_hash_writes.clone();
-
-        CommitmentStateDiff {
-            address_to_class_hash: IndexMap::from_iter(class_hash_updates),
-            storage_updates: StorageDiff::from(StorageView(storage_diffs)),
-            class_hash_to_compiled_class_hash: IndexMap::from_iter(declared_classes),
-            address_to_nonce: IndexMap::from_iter(nonces),
-        }
     }
 
     fn add_visited_pcs(&mut self, class_hash: ClassHash, pcs: &HashSet<usize>) {
@@ -565,10 +565,6 @@ impl<'a, S: State + ?Sized> State for MutRefState<'a, S> {
         contract_class: ContractClass,
     ) -> StateResult<()> {
         self.0.set_contract_class(class_hash, contract_class)
-    }
-
-    fn to_state_diff(&mut self) -> CommitmentStateDiff {
-        self.0.to_state_diff()
     }
 
     fn set_compiled_class_hash(

--- a/crates/blockifier/src/state/state_api.rs
+++ b/crates/blockifier/src/state/state_api.rs
@@ -7,7 +7,6 @@ use starknet_api::state::StorageKey;
 use crate::abi::abi_utils::get_fee_token_var_address;
 use crate::abi::sierra_types::next_storage_key;
 use crate::execution::contract_class::ContractClass;
-use crate::state::cached_state::CommitmentStateDiff;
 use crate::state::errors::StateError;
 
 pub type StateResult<T> = Result<T, StateError>;
@@ -103,8 +102,6 @@ pub trait State: StateReader {
         class_hash: ClassHash,
         compiled_class_hash: CompiledClassHash,
     ) -> StateResult<()>;
-
-    fn to_state_diff(&mut self) -> CommitmentStateDiff;
 
     /// Marks the given set of PC values as visited for the given class hash.
     // TODO(lior): Once we have a BlockResources object, move this logic there. Make sure reverted


### PR DESCRIPTION
`to_state_diff` pre-supposes two states, one before and one after, to build the difference.
This has no reason to be part of `StateReader` trait, whose only concern is to read the current state. There should be no requirement for the struct implementing it to keep a record of the changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1326)
<!-- Reviewable:end -->
