### PR TITLE
Extract from `BlockInfo` into `ChainInfo`

### DIFF
--- a/crates/blockifier/src/block_context.rs
+++ b/crates/blockifier/src/block_context.rs
@@ -9,23 +9,16 @@ use crate::transaction::objects::FeeType;
 #[derive(Clone, Debug)]
 pub struct BlockContext {
     pub block_info: BlockInfo,
-}
-
-impl BlockContext {
-    pub fn fee_token_address(&self, fee_type: &FeeType) -> ContractAddress {
-        self.block_info.fee_token_addresses.get_by_fee_type(fee_type)
-    }
+    pub chain_info: ChainInfo,
 }
 
 #[derive(Clone, Debug)]
 pub struct BlockInfo {
-    pub chain_id: ChainId,
     pub block_number: BlockNumber,
     pub block_timestamp: BlockTimestamp,
 
     // Fee-related.
     pub sequencer_address: ContractAddress,
-    pub fee_token_addresses: FeeTokenAddresses,
     pub vm_resource_fee_cost: Arc<HashMap<String, f64>>,
     pub gas_prices: GasPrices,
     pub use_kzg_da: bool,
@@ -34,6 +27,18 @@ pub struct BlockInfo {
     pub invoke_tx_max_n_steps: u32,
     pub validate_max_n_steps: u32,
     pub max_recursion_depth: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct ChainInfo {
+    pub chain_id: ChainId,
+    pub fee_token_addresses: FeeTokenAddresses,
+}
+
+impl ChainInfo {
+    pub fn fee_token_address(&self, fee_type: &FeeType) -> ContractAddress {
+        self.fee_token_addresses.get_by_fee_type(fee_type)
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/blockifier/src/execution/contract_address_test.rs
+++ b/crates/blockifier/src/execution/contract_address_test.rs
@@ -6,7 +6,7 @@ use starknet_api::{calldata, stark_felt};
 
 use crate::abi::abi_utils::selector_from_name;
 use crate::abi::constants;
-use crate::block_context::BlockContext;
+use crate::block_context::ChainInfo;
 use crate::execution::call_info::{CallExecution, Retdata};
 use crate::execution::entry_point::CallEntryPoint;
 use crate::retdata;
@@ -18,9 +18,9 @@ use crate::test_utils::{CairoVersion, BALANCE};
 
 #[rstest]
 fn test_calculate_contract_address() {
-    let block_context = &BlockContext::create_for_account_testing();
+    let chain_info = &ChainInfo::create_for_testing();
     let test_contract = FeatureContract::TestContract(CairoVersion::Cairo0);
-    let mut state = test_state(block_context, BALANCE, &[(test_contract, 1)]);
+    let mut state = test_state(chain_info, BALANCE, &[(test_contract, 1)]);
 
     fn run_test(
         salt: ContractAddressSalt,

--- a/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
@@ -317,7 +317,7 @@ impl<'a> DeprecatedSyscallHintProcessor<'a> {
             tx_signature_length.into(),
             tx_signature_start_ptr.into(),
             stark_felt_to_felt(account_tx_context.transaction_hash().0).into(),
-            Felt252::from_bytes_be(self.context.block_context.block_info.chain_id.0.as_bytes())
+            Felt252::from_bytes_be(self.context.block_context.chain_info.chain_id.0.as_bytes())
                 .into(),
             stark_felt_to_felt(account_tx_context.nonce().0).into(),
         ];

--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -12,7 +12,7 @@ use starknet_api::{calldata, class_hash, contract_address, patricia_key, stark_f
 
 use crate::abi::abi_utils::{get_storage_var_address, selector_from_name};
 use crate::abi::constants;
-use crate::block_context::BlockContext;
+use crate::block_context::ChainInfo;
 use crate::execution::call_info::{CallExecution, CallInfo, Retdata};
 use crate::execution::contract_class::ContractClass;
 use crate::execution::entry_point::CallEntryPoint;
@@ -216,9 +216,9 @@ fn run_security_test(
 
 #[test]
 fn test_vm_execution_security_failures() {
-    let block_context = BlockContext::create_for_testing();
+    let chain_info = ChainInfo::create_for_testing();
     let security_contract = FeatureContract::SecurityTests;
-    let state = &mut test_state(&block_context, BALANCE, &[(security_contract, 1)]);
+    let state = &mut test_state(&chain_info, BALANCE, &[(security_contract, 1)]);
 
     run_security_test(
         state,
@@ -301,9 +301,9 @@ fn test_vm_execution_security_failures() {
 
 #[test]
 fn test_builtin_execution_security_failures() {
-    let block_context = BlockContext::create_for_testing();
+    let chain_info = ChainInfo::create_for_testing();
     let security_contract = FeatureContract::SecurityTests;
-    let state = &mut test_state(&block_context, BALANCE, &[(security_contract, 1)]);
+    let state = &mut test_state(&chain_info, BALANCE, &[(security_contract, 1)]);
 
     run_security_test(
         state,
@@ -356,9 +356,9 @@ fn test_builtin_execution_security_failures() {
 
 #[test]
 fn test_syscall_execution_security_failures() {
-    let block_context = BlockContext::create_for_testing();
+    let chain_info = ChainInfo::create_for_testing();
     let security_contract = FeatureContract::SecurityTests;
-    let state = &mut test_state(&block_context, BALANCE, &[(security_contract, 1)]);
+    let state = &mut test_state(&chain_info, BALANCE, &[(security_contract, 1)]);
 
     for perform_inner_call_to_foo in 0..2 {
         // TODO(Ori, 1/2/2024): Write an indicative expect message explaining why the conversion
@@ -420,9 +420,9 @@ fn test_syscall_execution_security_failures() {
 
 #[test]
 fn test_post_run_validation_security_failure() {
-    let block_context = BlockContext::create_for_testing();
+    let chain_info = ChainInfo::create_for_testing();
     let security_contract = FeatureContract::SecurityTests;
-    let state = &mut test_state(&block_context, BALANCE, &[(security_contract, 1)]);
+    let state = &mut test_state(&chain_info, BALANCE, &[(security_contract, 1)]);
 
     run_security_test(
         state,

--- a/crates/blockifier/src/execution/syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/syscalls/hint_processor.rs
@@ -476,7 +476,7 @@ impl<'a> SyscallHintProcessor<'a> {
             tx_signature_start_ptr.into(),
             tx_signature_end_ptr.into(),
             stark_felt_to_felt((self.context.account_tx_context).transaction_hash().0).into(),
-            Felt252::from_bytes_be(self.context.block_context.block_info.chain_id.0.as_bytes())
+            Felt252::from_bytes_be(self.context.block_context.chain_info.chain_id.0.as_bytes())
                 .into(),
             stark_felt_to_felt((self.context.account_tx_context).nonce().0).into(),
         ];

--- a/crates/blockifier/src/execution/syscalls/syscalls_test.rs
+++ b/crates/blockifier/src/execution/syscalls/syscalls_test.rs
@@ -24,7 +24,7 @@ use test_case::test_case;
 
 use crate::abi::abi_utils::selector_from_name;
 use crate::abi::constants;
-use crate::block_context::BlockContext;
+use crate::block_context::ChainInfo;
 use crate::execution::call_info::{
     CallExecution, CallInfo, MessageToL1, OrderedEvent, OrderedL2ToL1Message, Retdata,
 };
@@ -281,7 +281,7 @@ fn test_get_execution_info(
     let legacy_contract = FeatureContract::LegacyTestContract;
     let test_contract = FeatureContract::TestContract(CairoVersion::Cairo1);
     let state = &mut test_state(
-        &BlockContext::create_for_testing(),
+        &ChainInfo::create_for_testing(),
         BALANCE,
         &[(legacy_contract, 1), (test_contract, 1)],
     );

--- a/crates/blockifier/src/fee/actual_cost.rs
+++ b/crates/blockifier/src/fee/actual_cost.rs
@@ -98,7 +98,7 @@ impl<'a> ActualCostBuilder<'a> {
         state: &mut CachedState<impl StateReader>,
     ) -> StateResult<Self> {
         let fee_token_address =
-            self.block_context.fee_token_address(&self.account_tx_context.fee_type());
+            self.block_context.chain_info.fee_token_address(&self.account_tx_context.fee_type());
 
         let new_state_changes = state
             .get_actual_state_changes_for_fee_charge(fee_token_address, self.sender_address)?;

--- a/crates/blockifier/src/fee/fee_checks.rs
+++ b/crates/blockifier/src/fee/fee_checks.rs
@@ -2,7 +2,7 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::Fee;
 use thiserror::Error;
 
-use crate::block_context::{BlockContext, BlockInfo};
+use crate::block_context::{BlockContext, BlockInfo, ChainInfo};
 use crate::fee::actual_cost::ActualCost;
 use crate::fee::fee_utils::{
     calculate_tx_l1_gas_usage, get_balance_and_if_covers_fee, get_fee_by_l1_gas_usage,
@@ -123,13 +123,13 @@ impl FeeCheckReport {
     /// If the actual cost exceeds the sender's balance, returns a fee check error.
     fn check_can_pay_fee<S: StateReader>(
         state: &mut S,
-        block_context: &BlockContext,
+        chain_info: &ChainInfo,
         account_tx_context: &AccountTransactionContext,
         actual_cost: &ActualCost,
     ) -> TransactionExecutionResult<()> {
         let ActualCost { actual_fee, .. } = actual_cost;
         let (balance_low, balance_high, can_pay) =
-            get_balance_and_if_covers_fee(state, account_tx_context, block_context, *actual_fee)?;
+            get_balance_and_if_covers_fee(state, account_tx_context, chain_info, *actual_fee)?;
         if can_pay {
             return Ok(());
         }
@@ -213,7 +213,7 @@ impl PostExecutionReport {
         // cost for sure.
         let can_pay_fee_result = FeeCheckReport::check_can_pay_fee(
             state,
-            block_context,
+            &block_context.chain_info,
             account_tx_context,
             actual_cost,
         );

--- a/crates/blockifier/src/fee/fee_utils.rs
+++ b/crates/blockifier/src/fee/fee_utils.rs
@@ -4,7 +4,7 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::Fee;
 
 use crate::abi::constants;
-use crate::block_context::{BlockContext, BlockInfo};
+use crate::block_context::{BlockContext, BlockInfo, ChainInfo};
 use crate::state::state_api::StateReader;
 use crate::transaction::errors::TransactionFeeError;
 use crate::transaction::objects::{
@@ -84,12 +84,12 @@ pub fn calculate_tx_fee(
 pub fn get_balance_and_if_covers_fee(
     state: &mut dyn StateReader,
     account_tx_context: &AccountTransactionContext,
-    block_context: &BlockContext,
+    chain_info: &ChainInfo,
     fee: Fee,
 ) -> TransactionFeeResult<(StarkFelt, StarkFelt, bool)> {
     let (balance_low, balance_high) = state.get_fee_token_balance(
         account_tx_context.sender_address(),
-        block_context.fee_token_address(&account_tx_context.fee_type()),
+        chain_info.fee_token_address(&account_tx_context.fee_type()),
     )?;
     Ok((
         balance_low,
@@ -105,7 +105,7 @@ pub fn get_balance_and_if_covers_fee(
 pub fn verify_can_pay_committed_bounds(
     state: &mut dyn StateReader,
     account_tx_context: &AccountTransactionContext,
-    block_context: &BlockContext,
+    chain_info: &ChainInfo,
 ) -> TransactionFeeResult<()> {
     let committed_fee = match account_tx_context {
         AccountTransactionContext::Current(context) => {
@@ -118,7 +118,7 @@ pub fn verify_can_pay_committed_bounds(
         AccountTransactionContext::Deprecated(context) => context.max_fee,
     };
     let (balance_low, balance_high, can_pay) =
-        get_balance_and_if_covers_fee(state, account_tx_context, block_context, committed_fee)?;
+        get_balance_and_if_covers_fee(state, account_tx_context, chain_info, committed_fee)?;
     if can_pay {
         Ok(())
     } else {

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -305,7 +305,7 @@ fn test_state_changes_merge() {
     let mut state: CachedState<DictStateReader> = CachedState::default();
     let mut transactional_state = CachedState::create_transactional(&mut state);
     let block_context = BlockContext::create_for_testing();
-    let fee_token_address = block_context.block_info.fee_token_addresses.eth_fee_token_address;
+    let fee_token_address = block_context.chain_info.fee_token_addresses.eth_fee_token_address;
     let state_changes1 = create_state_changes_for_test(&mut transactional_state, fee_token_address);
     transactional_state.commit();
 

--- a/crates/blockifier/src/test_utils/initial_test_state.rs
+++ b/crates/blockifier/src/test_utils/initial_test_state.rs
@@ -6,7 +6,7 @@ use starknet_api::stark_felt;
 use strum::IntoEnumIterator;
 
 use crate::abi::abi_utils::get_fee_token_var_address;
-use crate::block_context::BlockContext;
+use crate::block_context::ChainInfo;
 use crate::state::cached_state::CachedState;
 use crate::test_utils::contracts::FeatureContract;
 use crate::test_utils::dict_state_reader::DictStateReader;
@@ -14,7 +14,7 @@ use crate::transaction::objects::FeeType;
 
 /// Utility to fund an account.
 pub fn fund_account(
-    block_context: &BlockContext,
+    chain_info: &ChainInfo,
     account_address: ContractAddress,
     initial_balance: u128,
     state: &mut CachedState<DictStateReader>,
@@ -23,7 +23,7 @@ pub fn fund_account(
     let balance_key = get_fee_token_var_address(account_address);
     for fee_type in FeeType::iter() {
         storage_view.insert(
-            (block_context.fee_token_address(&fee_type), balance_key),
+            (chain_info.fee_token_address(&fee_type), balance_key),
             stark_felt!(initial_balance),
         );
     }
@@ -38,7 +38,7 @@ pub fn fund_account(
 /// * "Deploys" the requested number of instances of each input contract.
 /// * Makes each input account contract privileged.
 pub fn test_state(
-    block_context: &BlockContext,
+    chain_info: &ChainInfo,
     initial_balances: u128,
     contract_instances: &[(FeatureContract, u8)],
 ) -> CachedState<DictStateReader> {
@@ -49,9 +49,9 @@ pub fn test_state(
     let erc20 = FeatureContract::ERC20;
     class_hash_to_class.insert(erc20.get_class_hash(), erc20.get_class());
     address_to_class_hash
-        .insert(block_context.fee_token_address(&FeeType::Eth), erc20.get_class_hash());
+        .insert(chain_info.fee_token_address(&FeeType::Eth), erc20.get_class_hash());
     address_to_class_hash
-        .insert(block_context.fee_token_address(&FeeType::Strk), erc20.get_class_hash());
+        .insert(chain_info.fee_token_address(&FeeType::Strk), erc20.get_class_hash());
 
     // Set up the rest of the requested contracts.
     for (contract, n_instances) in contract_instances.iter() {
@@ -77,7 +77,7 @@ pub fn test_state(
                 FeatureContract::AccountWithLongValidate(_)
                 | FeatureContract::AccountWithoutValidations(_)
                 | FeatureContract::FaultyAccount(_) => {
-                    fund_account(block_context, instance_address, initial_balances, &mut state);
+                    fund_account(chain_info, instance_address, initial_balances, &mut state);
                 }
                 _ => (),
             }

--- a/crates/blockifier/src/test_utils/prices.rs
+++ b/crates/blockifier/src/test_utils/prices.rs
@@ -43,8 +43,9 @@ fn fee_transfer_resources(
     fee_type: FeeType,
 ) -> VmExecutionResources {
     let block_context = &BlockContext::create_for_account_testing();
-    let state = &mut test_state(block_context, BALANCE, &[]);
-    let token_address = block_context.fee_token_address(&fee_type);
+    let chain_info = &block_context.chain_info;
+    let state = &mut test_state(chain_info, BALANCE, &[]);
+    let token_address = chain_info.fee_token_address(&fee_type);
 
     // Fund the account so we don't hit an error.
     state

--- a/crates/blockifier/src/test_utils/struct_impls.rs
+++ b/crates/blockifier/src/test_utils/struct_impls.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::abi::constants;
 use crate::abi::constants::{MAX_STEPS_PER_TX, MAX_VALIDATE_STEPS_PER_TX};
-use crate::block_context::{BlockContext, BlockInfo, FeeTokenAddresses, GasPrices};
+use crate::block_context::{BlockContext, BlockInfo, ChainInfo, FeeTokenAddresses, GasPrices};
 use crate::execution::call_info::{CallExecution, CallInfo, Retdata};
 use crate::execution::contract_class::{ContractClassV0, ContractClassV1};
 use crate::execution::entry_point::{
@@ -84,17 +84,24 @@ impl CallEntryPoint {
     }
 }
 
-impl BlockInfo {
+impl ChainInfo {
     pub fn create_for_testing() -> Self {
         Self {
             chain_id: ChainId(CHAIN_ID_NAME.to_string()),
-            block_number: BlockNumber(CURRENT_BLOCK_NUMBER),
-            block_timestamp: BlockTimestamp(CURRENT_BLOCK_TIMESTAMP),
-            sequencer_address: contract_address!(TEST_SEQUENCER_ADDRESS),
             fee_token_addresses: FeeTokenAddresses {
                 eth_fee_token_address: contract_address!(TEST_ERC20_CONTRACT_ADDRESS),
                 strk_fee_token_address: contract_address!(TEST_ERC20_CONTRACT_ADDRESS2),
             },
+        }
+    }
+}
+
+impl BlockInfo {
+    pub fn create_for_testing() -> Self {
+        Self {
+            block_number: BlockNumber(CURRENT_BLOCK_NUMBER),
+            block_timestamp: BlockTimestamp(CURRENT_BLOCK_TIMESTAMP),
+            sequencer_address: contract_address!(TEST_SEQUENCER_ADDRESS),
             vm_resource_fee_cost: Default::default(),
             gas_prices: GasPrices {
                 eth_l1_gas_price: DEFAULT_ETH_L1_GAS_PRICE,
@@ -133,11 +140,17 @@ impl BlockInfo {
 
 impl BlockContext {
     pub fn create_for_testing() -> Self {
-        Self { block_info: BlockInfo::create_for_testing() }
+        Self {
+            block_info: BlockInfo::create_for_testing(),
+            chain_info: ChainInfo::create_for_testing(),
+        }
     }
 
     pub fn create_for_account_testing() -> Self {
-        Self { block_info: BlockInfo::create_for_account_testing() }
+        Self {
+            block_info: BlockInfo::create_for_account_testing(),
+            chain_info: ChainInfo::create_for_testing(),
+        }
     }
 }
 

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -158,7 +158,7 @@ impl AccountTransaction {
         if charge_fee && account_tx_context.enforce_fee()? {
             self.check_fee_bounds(account_tx_context, block_context)?;
 
-            verify_can_pay_committed_bounds(state, account_tx_context, block_context)?;
+            verify_can_pay_committed_bounds(state, account_tx_context, &block_context.chain_info)?;
         }
 
         Ok(())
@@ -299,7 +299,8 @@ impl AccountTransaction {
         let msb_amount = StarkFelt::from(0_u8);
 
         // TODO(Gilad): add test that correct fee address is taken, once we add V3 test support.
-        let storage_address = block_context.fee_token_address(&account_tx_context.fee_type());
+        let storage_address =
+            block_context.chain_info.fee_token_address(&account_tx_context.fee_type());
         let fee_transfer_call = CallEntryPoint {
             class_hash: None,
             code_address: None,

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use blockifier::block_context::{BlockContext, BlockInfo, FeeTokenAddresses};
+use blockifier::block_context::{BlockContext, BlockInfo, ChainInfo, FeeTokenAddresses};
 use blockifier::state::cached_state::GlobalContractCache;
 use pyo3::prelude::*;
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::core::{ChainId, ContractAddress};
 use starknet_api::hash::StarkFelt;
 
-use crate::errors::NativeBlockifierResult;
+use crate::errors::{NativeBlockifierError, NativeBlockifierResult};
 use crate::py_state_diff::{PyBlockInfo, PyStateDiff};
 use crate::py_transaction_execution_info::{PyBouncerInfo, PyTransactionExecutionInfo};
 use crate::py_utils::{int_to_chain_id, py_attr, PyFelt};
@@ -265,6 +265,24 @@ pub struct PyOsConfig {
     pub fee_token_address: PyFelt,
 }
 
+impl TryFrom<PyOsConfig> for ChainInfo {
+    type Error = NativeBlockifierError;
+
+    fn try_from(py_os_config: PyOsConfig) -> Result<Self, Self::Error> {
+        Ok(Self {
+            chain_id: py_os_config.chain_id,
+            fee_token_addresses: FeeTokenAddresses {
+                eth_fee_token_address: ContractAddress::try_from(
+                    py_os_config.deprecated_fee_token_address.0,
+                )?,
+                strk_fee_token_address: ContractAddress::try_from(
+                    py_os_config.fee_token_address.0,
+                )?,
+            },
+        })
+    }
+}
+
 impl Default for PyOsConfig {
     fn default() -> Self {
         Self {
@@ -280,21 +298,11 @@ pub fn into_block_context(
     block_info: PyBlockInfo,
     max_recursion_depth: usize,
 ) -> NativeBlockifierResult<BlockContext> {
-    let starknet_os_config = general_config.starknet_os_config.clone();
     let block_context = BlockContext {
         block_info: BlockInfo {
-            chain_id: starknet_os_config.chain_id,
             block_number: BlockNumber(block_info.block_number),
             block_timestamp: BlockTimestamp(block_info.block_timestamp),
             sequencer_address: ContractAddress::try_from(block_info.sequencer_address.0)?,
-            fee_token_addresses: FeeTokenAddresses {
-                eth_fee_token_address: ContractAddress::try_from(
-                    starknet_os_config.deprecated_fee_token_address.0,
-                )?,
-                strk_fee_token_address: ContractAddress::try_from(
-                    starknet_os_config.fee_token_address.0,
-                )?,
-            },
             vm_resource_fee_cost: general_config.cairo_resource_fee_weights.clone(),
             gas_prices: block_info.gas_prices.into(),
             use_kzg_da: block_info.use_kzg_da,
@@ -302,6 +310,7 @@ pub fn into_block_context(
             validate_max_n_steps: general_config.validate_max_n_steps,
             max_recursion_depth,
         },
+        chain_info: general_config.starknet_os_config.clone().try_into()?,
     };
 
     Ok(block_context)


### PR DESCRIPTION
`BlockInfo` should only contain block-level info, whereas chain-level information should be held at the `BlockContext` level, encapsulated in a dedicated `ChainInfo` struct.

Changes:
Only extract from `BlockInfo` and store in `BlockContext.chain_info: ChainInfo`. All other changes are search-replace + moving the fee_token_address getter into `ChainInfo`.

TODO: extract more stuff from BlockInfo: version-dependant constants should be extracted into a dedicated VersionedConstants, which will be a member of BlockContext

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1344)
<!-- Reviewable:end -->
