### PR TITLE
refactor: rename context modules

### DIFF
--- a/crates/blockifier/src/block.rs
+++ b/crates/blockifier/src/block.rs
@@ -1,0 +1,80 @@
+use starknet_api::block::{BlockHash, BlockNumber, BlockTimestamp};
+use starknet_api::core::ContractAddress;
+use starknet_api::hash::StarkFelt;
+use starknet_api::state::StorageKey;
+
+use crate::abi::constants;
+use crate::state::state_api::{State, StateResult};
+use crate::transaction::objects::FeeType;
+
+#[cfg(test)]
+#[path = "block_test.rs"]
+pub mod block_test;
+
+#[derive(Clone, Debug)]
+pub struct BlockInfo {
+    pub block_number: BlockNumber,
+    pub block_timestamp: BlockTimestamp,
+
+    // Fee-related.
+    pub sequencer_address: ContractAddress,
+    pub gas_prices: GasPrices,
+    pub use_kzg_da: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct GasPrices {
+    pub eth_l1_gas_price: u128,       // In wei.
+    pub strk_l1_gas_price: u128,      // In fri.
+    pub eth_l1_data_gas_price: u128,  // In wei.
+    pub strk_l1_data_gas_price: u128, // In fri.
+}
+
+impl GasPrices {
+    pub fn get_gas_price_by_fee_type(&self, fee_type: &FeeType) -> u128 {
+        match fee_type {
+            FeeType::Strk => self.strk_l1_gas_price,
+            FeeType::Eth => self.eth_l1_gas_price,
+        }
+    }
+
+    pub fn get_data_gas_price_by_fee_type(&self, fee_type: &FeeType) -> u128 {
+        match fee_type {
+            FeeType::Strk => self.strk_l1_data_gas_price,
+            FeeType::Eth => self.eth_l1_data_gas_price,
+        }
+    }
+}
+
+// Block pre-processing.
+// Writes the hash of the (current_block_number - N) block under its block number in the dedicated
+// contract state, where N=STORED_BLOCK_HASH_BUFFER.
+pub fn pre_process_block(
+    state: &mut dyn State,
+    old_block_number_and_hash: Option<BlockNumberHashPair>,
+) -> StateResult<()> {
+    if let Some(BlockNumberHashPair { number: block_number, hash: block_hash }) =
+        old_block_number_and_hash
+    {
+        state.set_storage_at(
+            ContractAddress::try_from(StarkFelt::from(constants::BLOCK_HASH_CONTRACT_ADDRESS))
+                .expect("Failed to convert `BLOCK_HASH_CONTRACT_ADDRESS` to ContractAddress."),
+            StorageKey::try_from(StarkFelt::from(block_number.0))
+                .expect("Failed to convert BlockNumber to StorageKey."),
+            block_hash.0,
+        )?;
+    }
+
+    Ok(())
+}
+
+pub struct BlockNumberHashPair {
+    pub number: BlockNumber,
+    pub hash: BlockHash,
+}
+
+impl BlockNumberHashPair {
+    pub fn new(block_number: u64, block_hash: StarkFelt) -> BlockNumberHashPair {
+        BlockNumberHashPair { number: BlockNumber(block_number), hash: BlockHash(block_hash) }
+    }
+}

--- a/crates/blockifier/src/block_execution.rs
+++ b/crates/blockifier/src/block_execution.rs
@@ -10,17 +10,6 @@ use crate::state::state_api::{State, StateResult};
 #[path = "block_execution_test.rs"]
 pub mod test;
 
-pub struct BlockNumberHashPair {
-    pub number: BlockNumber,
-    pub hash: BlockHash,
-}
-
-impl BlockNumberHashPair {
-    pub fn new(block_number: u64, block_hash: StarkFelt) -> BlockNumberHashPair {
-        BlockNumberHashPair { number: BlockNumber(block_number), hash: BlockHash(block_hash) }
-    }
-}
-
 // Block pre-processing.
 // Writes the hash of the (current_block_number - N) block under its block number in the dedicated
 // contract state, where N=STORED_BLOCK_HASH_BUFFER.

--- a/crates/blockifier/src/block_test.rs
+++ b/crates/blockifier/src/block_test.rs
@@ -3,7 +3,7 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 
 use crate::abi::constants;
-use crate::block_execution::{pre_process_block, BlockNumberHashPair};
+use crate::block::{pre_process_block, BlockNumberHashPair};
 use crate::state::state_api::StateReader;
 use crate::test_utils::cached_state::create_test_state;
 

--- a/crates/blockifier/src/context.rs
+++ b/crates/blockifier/src/context.rs
@@ -1,0 +1,65 @@
+use starknet_api::core::{ChainId, ContractAddress};
+
+use crate::block::BlockInfo;
+use crate::transaction::objects::FeeType;
+use crate::versioned_constants::VersionedConstants;
+
+/// Create via [`crate::block::pre_process_block`] to ensure correctness.
+#[derive(Clone, Debug)]
+pub struct BlockContext {
+    pub(crate) block_info: BlockInfo,
+    pub(crate) chain_info: ChainInfo,
+    pub(crate) versioned_constants: VersionedConstants,
+}
+
+impl BlockContext {
+    /// Note: Prefer using the recommended constructor methods as detailed in the struct
+    /// documentation. This method is intended for internal use and will be deprecated in future
+    /// versions.
+    pub fn new_unchecked(
+        block_info: &BlockInfo,
+        chain_info: &ChainInfo,
+        versioned_constants: &VersionedConstants,
+    ) -> Self {
+        BlockContext {
+            block_info: block_info.clone(),
+            chain_info: chain_info.clone(),
+            versioned_constants: versioned_constants.clone(),
+        }
+    }
+
+    pub fn block_info(&self) -> &BlockInfo {
+        &self.block_info
+    }
+
+    pub fn chain_info(&self) -> &ChainInfo {
+        &self.chain_info
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ChainInfo {
+    pub chain_id: ChainId,
+    pub fee_token_addresses: FeeTokenAddresses,
+}
+
+impl ChainInfo {
+    pub fn fee_token_address(&self, fee_type: &FeeType) -> ContractAddress {
+        self.fee_token_addresses.get_by_fee_type(fee_type)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FeeTokenAddresses {
+    pub strk_fee_token_address: ContractAddress,
+    pub eth_fee_token_address: ContractAddress,
+}
+
+impl FeeTokenAddresses {
+    pub fn get_by_fee_type(&self, fee_type: &FeeType) -> ContractAddress {
+        match fee_type {
+            FeeType::Strk => self.strk_fee_token_address,
+            FeeType::Eth => self.eth_fee_token_address,
+        }
+    }
+}

--- a/crates/blockifier/src/execution/contract_address_test.rs
+++ b/crates/blockifier/src/execution/contract_address_test.rs
@@ -6,7 +6,7 @@ use starknet_api::{calldata, stark_felt};
 
 use crate::abi::abi_utils::selector_from_name;
 use crate::abi::constants;
-use crate::block_context::ChainInfo;
+use crate::context::ChainInfo;
 use crate::execution::call_info::{CallExecution, Retdata};
 use crate::execution::entry_point::CallEntryPoint;
 use crate::retdata;

--- a/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
@@ -18,7 +18,7 @@ use starknet_api::{calldata, class_hash, contract_address, patricia_key, stark_f
 use test_case::test_case;
 
 use crate::abi::abi_utils::selector_from_name;
-use crate::block_context::ChainInfo;
+use crate::context::ChainInfo;
 use crate::execution::call_info::{CallExecution, CallInfo, Retdata};
 use crate::execution::common_hints::ExecutionMode;
 use crate::execution::entry_point::{CallEntryPoint, CallType};

--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -12,7 +12,7 @@ use starknet_api::transaction::{Calldata, TransactionVersion};
 
 use crate::abi::abi_utils::selector_from_name;
 use crate::abi::constants;
-use crate::block_context::BlockContext;
+use crate::context::BlockContext;
 use crate::execution::call_info::CallInfo;
 use crate::execution::common_hints::ExecutionMode;
 use crate::execution::deprecated_syscalls::hint_processor::SyscallCounter;

--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -13,7 +13,7 @@ use starknet_api::{calldata, patricia_key, stark_felt};
 
 use crate::abi::abi_utils::{get_storage_var_address, selector_from_name};
 use crate::abi::constants;
-use crate::block_context::ChainInfo;
+use crate::context::ChainInfo;
 use crate::execution::call_info::{CallExecution, CallInfo, Retdata};
 use crate::execution::contract_class::ContractClass;
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/syscalls/syscalls_test.rs
+++ b/crates/blockifier/src/execution/syscalls/syscalls_test.rs
@@ -24,7 +24,7 @@ use test_case::test_case;
 
 use crate::abi::abi_utils::selector_from_name;
 use crate::abi::constants;
-use crate::block_context::ChainInfo;
+use crate::context::ChainInfo;
 use crate::execution::call_info::{
     CallExecution, CallInfo, MessageToL1, OrderedEvent, OrderedL2ToL1Message, Retdata,
 };

--- a/crates/blockifier/src/fee/actual_cost.rs
+++ b/crates/blockifier/src/fee/actual_cost.rs
@@ -2,7 +2,7 @@ use starknet_api::core::ContractAddress;
 use starknet_api::transaction::Fee;
 
 use crate::abi::constants as abi_constants;
-use crate::block_context::BlockContext;
+use crate::context::BlockContext;
 use crate::execution::call_info::CallInfo;
 use crate::execution::entry_point::ExecutionResources;
 use crate::fee::gas_usage::calculate_tx_gas_usage_vector;

--- a/crates/blockifier/src/fee/fee_checks.rs
+++ b/crates/blockifier/src/fee/fee_checks.rs
@@ -2,12 +2,13 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::Fee;
 use thiserror::Error;
 
-use super::gas_usage::compute_discounted_gas_from_gas_vector;
-use crate::block_context::{BlockContext, BlockInfo, ChainInfo};
+use crate::block::BlockInfo;
+use crate::context::{BlockContext, ChainInfo};
 use crate::fee::actual_cost::ActualCost;
 use crate::fee::fee_utils::{
     calculate_tx_gas_vector, get_balance_and_if_covers_fee, get_fee_by_gas_vector,
 };
+use crate::fee::gas_usage::compute_discounted_gas_from_gas_vector;
 use crate::state::state_api::StateReader;
 use crate::transaction::errors::TransactionExecutionError;
 use crate::transaction::objects::{

--- a/crates/blockifier/src/fee/fee_test.rs
+++ b/crates/blockifier/src/fee/fee_test.rs
@@ -9,7 +9,7 @@ use rstest::rstest;
 use starknet_api::transaction::{Fee, TransactionVersion};
 
 use crate::abi::constants;
-use crate::block_context::BlockContext;
+use crate::context::BlockContext;
 use crate::fee::actual_cost::ActualCost;
 use crate::fee::fee_checks::{FeeCheckError, FeeCheckReportFields, PostExecutionReport};
 use crate::fee::fee_utils::calculate_l1_gas_by_vm_usage;

--- a/crates/blockifier/src/fee/fee_utils.rs
+++ b/crates/blockifier/src/fee/fee_utils.rs
@@ -4,7 +4,8 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::Fee;
 
 use crate::abi::constants;
-use crate::block_context::{BlockContext, BlockInfo, ChainInfo};
+use crate::block::BlockInfo;
+use crate::context::{BlockContext, ChainInfo};
 use crate::state::state_api::StateReader;
 use crate::transaction::errors::TransactionFeeError;
 use crate::transaction::objects::{

--- a/crates/blockifier/src/fee/gas_usage.rs
+++ b/crates/blockifier/src/fee/gas_usage.rs
@@ -4,7 +4,8 @@ use starknet_api::transaction::Fee;
 
 use super::fee_utils::{calculate_tx_gas_vector, get_fee_by_gas_vector};
 use crate::abi::constants;
-use crate::block_context::{BlockContext, BlockInfo};
+use crate::block::BlockInfo;
+use crate::context::BlockContext;
 use crate::execution::call_info::{CallInfo, MessageL1CostInfo};
 use crate::fee::eth_gas_constants;
 use crate::fee::os_resources::OS_RESOURCES;

--- a/crates/blockifier/src/lib.rs
+++ b/crates/blockifier/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod abi;
-pub mod block_context;
-pub mod block_execution;
+pub mod block;
+pub mod context;
 pub mod execution;
 pub mod fee;
 pub mod state;

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -7,7 +7,7 @@ use starknet_api::core::PatriciaKey;
 use starknet_api::hash::StarkHash;
 use starknet_api::{class_hash, contract_address, patricia_key, stark_felt};
 
-use crate::block_context::BlockContext;
+use crate::context::BlockContext;
 use crate::state::cached_state::*;
 use crate::test_utils::cached_state::deprecated_create_test_state;
 use crate::test_utils::dict_state_reader::DictStateReader;

--- a/crates/blockifier/src/test_utils/initial_test_state.rs
+++ b/crates/blockifier/src/test_utils/initial_test_state.rs
@@ -6,7 +6,7 @@ use starknet_api::stark_felt;
 use strum::IntoEnumIterator;
 
 use crate::abi::abi_utils::get_fee_token_var_address;
-use crate::block_context::ChainInfo;
+use crate::context::ChainInfo;
 use crate::state::cached_state::CachedState;
 use crate::test_utils::contracts::FeatureContract;
 use crate::test_utils::dict_state_reader::DictStateReader;

--- a/crates/blockifier/src/test_utils/prices.rs
+++ b/crates/blockifier/src/test_utils/prices.rs
@@ -6,7 +6,7 @@ use starknet_api::transaction::Calldata;
 use starknet_api::{calldata, stark_felt};
 
 use crate::abi::abi_utils::{get_fee_token_var_address, selector_from_name};
-use crate::block_context::BlockContext;
+use crate::context::BlockContext;
 use crate::execution::common_hints::ExecutionMode;
 use crate::execution::entry_point::{
     CallEntryPoint, EntryPointExecutionContext, ExecutionResources,

--- a/crates/blockifier/src/test_utils/struct_impls.rs
+++ b/crates/blockifier/src/test_utils/struct_impls.rs
@@ -16,7 +16,8 @@ use super::{
     TEST_ERC20_CONTRACT_ADDRESS, TEST_ERC20_CONTRACT_ADDRESS2, TEST_SEQUENCER_ADDRESS,
 };
 use crate::abi::constants;
-use crate::block_context::{BlockContext, BlockInfo, ChainInfo, FeeTokenAddresses, GasPrices};
+use crate::block::{BlockInfo, GasPrices};
+use crate::context::{BlockContext, ChainInfo, FeeTokenAddresses};
 use crate::execution::call_info::{CallExecution, CallInfo, Retdata};
 use crate::execution::contract_class::{ContractClassV0, ContractClassV1};
 use crate::execution::entry_point::{

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -7,7 +7,7 @@ use starknet_api::transaction::{Calldata, Fee, ResourceBounds, TransactionVersio
 
 use crate::abi::abi_utils::selector_from_name;
 use crate::abi::constants as abi_constants;
-use crate::block_context::BlockContext;
+use crate::context::BlockContext;
 use crate::execution::call_info::{CallInfo, Retdata};
 use crate::execution::contract_class::ContractClass;
 use crate::execution::entry_point::{

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -20,7 +20,7 @@ use crate::abi::abi_utils::{
     get_fee_token_var_address, get_storage_var_address, selector_from_name,
 };
 use crate::abi::constants as abi_constants;
-use crate::block_context::BlockContext;
+use crate::context::BlockContext;
 use crate::execution::contract_class::{ContractClass, ContractClassV1};
 use crate::execution::entry_point::EntryPointExecutionContext;
 use crate::execution::errors::{EntryPointExecutionError, VirtualMachineExecutionError};

--- a/crates/blockifier/src/transaction/execution_flavors_test.rs
+++ b/crates/blockifier/src/transaction/execution_flavors_test.rs
@@ -7,7 +7,7 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::stark_felt;
 use starknet_api::transaction::{Calldata, Fee, TransactionSignature, TransactionVersion};
 
-use crate::block_context::{BlockContext, ChainInfo};
+use crate::context::{BlockContext, ChainInfo};
 use crate::execution::errors::EntryPointExecutionError;
 use crate::execution::execution_utils::{felt_to_stark_felt, stark_felt_to_felt};
 use crate::fee::fee_utils::{calculate_tx_fee, calculate_tx_gas_vector, get_fee_by_gas_vector};

--- a/crates/blockifier/src/transaction/objects.rs
+++ b/crates/blockifier/src/transaction/objects.rs
@@ -11,7 +11,7 @@ use starknet_api::transaction::{
 };
 use strum_macros::EnumIter;
 
-use crate::block_context::BlockContext;
+use crate::context::BlockContext;
 use crate::execution::call_info::CallInfo;
 use crate::execution::execution_utils::{felt_to_stark_felt, stark_felt_to_felt};
 use crate::fee::fee_utils::calculate_tx_fee;

--- a/crates/blockifier/src/transaction/post_execution_test.rs
+++ b/crates/blockifier/src/transaction/post_execution_test.rs
@@ -7,7 +7,7 @@ use starknet_api::transaction::{Calldata, Fee, ResourceBoundsMapping, Transactio
 use starknet_api::{patricia_key, stark_felt};
 use starknet_crypto::FieldElement;
 
-use crate::block_context::{BlockContext, ChainInfo};
+use crate::context::{BlockContext, ChainInfo};
 use crate::fee::fee_checks::FeeCheckError;
 use crate::fee::fee_utils::calculate_tx_gas_vector;
 use crate::invoke_tx_args;

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -13,7 +13,7 @@ use starknet_api::{calldata, class_hash, contract_address, patricia_key, stark_f
 use strum::IntoEnumIterator;
 
 use crate::abi::abi_utils::{get_fee_token_var_address, get_storage_var_address};
-use crate::block_context::{BlockContext, ChainInfo, FeeTokenAddresses};
+use crate::context::{BlockContext, ChainInfo, FeeTokenAddresses};
 use crate::execution::contract_class::{ContractClass, ContractClassV0};
 use crate::state::cached_state::CachedState;
 use crate::state::state_api::State;

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -2,7 +2,7 @@ use starknet_api::core::{calculate_contract_address, ContractAddress};
 use starknet_api::transaction::{Fee, Transaction as StarknetApiTransaction, TransactionHash};
 
 use crate::abi::constants as abi_constants;
-use crate::block_context::BlockContext;
+use crate::context::BlockContext;
 use crate::execution::contract_class::ContractClass;
 use crate::execution::entry_point::{EntryPointExecutionContext, ExecutionResources};
 use crate::fee::actual_cost::ActualCost;

--- a/crates/blockifier/src/transaction/transactions.rs
+++ b/crates/blockifier/src/transaction/transactions.rs
@@ -8,7 +8,7 @@ use starknet_api::transaction::{
 };
 
 use crate::abi::abi_utils::selector_from_name;
-use crate::block_context::BlockContext;
+use crate::context::BlockContext;
 use crate::execution::call_info::CallInfo;
 use crate::execution::contract_class::ContractClass;
 use crate::execution::entry_point::{

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -26,7 +26,7 @@ use crate::abi::abi_utils::{
 };
 use crate::abi::constants as abi_constants;
 use crate::abi::sierra_types::next_storage_key;
-use crate::block_context::{BlockContext, ChainInfo, FeeTokenAddresses};
+use crate::context::{BlockContext, ChainInfo, FeeTokenAddresses};
 use crate::execution::call_info::{
     CallExecution, CallInfo, MessageToL1, OrderedEvent, OrderedL2ToL1Message, Retdata,
 };

--- a/crates/native_blockifier/bench/blockifier_bench.rs
+++ b/crates/native_blockifier/bench/blockifier_bench.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 
 use blockifier::abi::abi_utils::{get_fee_token_var_address, selector_from_name};
-use blockifier::block_context::{BlockContext, ChainInfo};
+use blockifier::context::{BlockContext, ChainInfo};
 use blockifier::execution::contract_class::ContractClassV0;
 use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::State;

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use blockifier::block_context::{BlockContext, BlockInfo, ChainInfo, FeeTokenAddresses, GasPrices};
+use blockifier::block::{BlockInfo, GasPrices};
+use blockifier::context::{BlockContext, ChainInfo, FeeTokenAddresses};
 use blockifier::state::cached_state::{GlobalContractCache, GLOBAL_CONTRACT_CACHE_SIZE_FOR_TEST};
 use blockifier::versioned_constants::VersionedConstants;
 use pyo3::prelude::*;

--- a/crates/native_blockifier/src/transaction_executor.rs
+++ b/crates/native_blockifier/src/transaction_executor.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::vec::IntoIter;
 
-use blockifier::block_context::BlockContext;
-use blockifier::block_execution::{pre_process_block, BlockNumberHashPair};
+use blockifier::block::{pre_process_block, BlockNumberHashPair};
+use blockifier::context::BlockContext;
 use blockifier::execution::call_info::{CallInfo, MessageL1CostInfo};
 use blockifier::execution::entry_point::ExecutionResources;
 use blockifier::fee::actual_cost::ActualCost;
@@ -192,7 +192,7 @@ impl<S: StateReader> TransactionExecutor<S> {
         (PyStateDiff::from(self.state.to_state_diff()), visited_pcs)
     }
 
-    // Block pre-processing; see `block_execution::pre_process_block` documentation.
+    // Block pre-processing; see `block::pre_process_block` documentation.
     pub fn pre_process_block(
         &mut self,
         old_block_number_and_hash: Option<(u64, PyFelt)>,


### PR DESCRIPTION
- Rename block_context.rs -> context.rs. This will hold all context types.
- Rename block_execution.rs -> block.rs and move `BlockInfo` and `GasPrices` there (`GasPrices` is only used inside `BlockInfo`).

No other changes.

Python: https://reviewable.io/reviews/starkware-industries/starkware/33527

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1350)
<!-- Reviewable:end -->
