### PR TITLE
fix(native_blockifier): Remove `PyGasPrices`

### DIFF
--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use blockifier::block_context::{BlockContext, BlockInfo, ChainInfo, FeeTokenAddresses};
+use blockifier::block_context::{BlockContext, BlockInfo, ChainInfo, FeeTokenAddresses, GasPrices};
 use blockifier::state::cached_state::GlobalContractCache;
 use pyo3::prelude::*;
 use starknet_api::block::{BlockNumber, BlockTimestamp};
@@ -304,7 +304,13 @@ pub fn into_block_context(
             block_timestamp: BlockTimestamp(block_info.block_timestamp),
             sequencer_address: ContractAddress::try_from(block_info.sequencer_address.0)?,
             vm_resource_fee_cost: general_config.cairo_resource_fee_weights.clone(),
-            gas_prices: block_info.gas_prices.into(),
+            gas_prices: GasPrices {
+                eth_l1_gas_price: block_info.eth_l1_gas_price,
+                strk_l1_gas_price: block_info.strk_l1_gas_price,
+                eth_l1_data_gas_price: block_info.eth_l1_data_gas_price,
+                strk_l1_data_gas_price: block_info.strk_l1_data_gas_price,
+            },
+
             use_kzg_da: block_info.use_kzg_da,
             invoke_tx_max_n_steps: general_config.invoke_tx_max_n_steps,
             validate_max_n_steps: general_config.validate_max_n_steps,

--- a/crates/native_blockifier/src/py_state_diff.rs
+++ b/crates/native_blockifier/src/py_state_diff.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
-use blockifier::block_context::GasPrices;
 use blockifier::state::cached_state::CommitmentStateDiff;
 use indexmap::IndexMap;
 use pyo3::prelude::*;
@@ -116,29 +115,13 @@ impl From<CommitmentStateDiff> for PyStateDiff {
 }
 
 #[derive(Default, FromPyObject)]
-pub struct PyGasPrices {
+pub struct PyBlockInfo {
+    pub block_number: u64,
+    pub block_timestamp: u64,
     pub eth_l1_gas_price: u128,
     pub strk_l1_gas_price: u128,
     pub eth_l1_data_gas_price: u128,
     pub strk_l1_data_gas_price: u128,
-}
-
-impl From<PyGasPrices> for GasPrices {
-    fn from(py_gas_prices: PyGasPrices) -> Self {
-        Self {
-            eth_l1_gas_price: py_gas_prices.eth_l1_gas_price,
-            strk_l1_gas_price: py_gas_prices.strk_l1_gas_price,
-            eth_l1_data_gas_price: py_gas_prices.eth_l1_data_gas_price,
-            strk_l1_data_gas_price: py_gas_prices.strk_l1_data_gas_price,
-        }
-    }
-}
-
-#[derive(Default, FromPyObject)]
-pub struct PyBlockInfo {
-    pub block_number: u64,
-    pub block_timestamp: u64,
-    pub gas_prices: PyGasPrices,
     pub sequencer_address: PyFelt,
     pub use_kzg_da: bool,
 }


### PR DESCRIPTION
`PyX` types are intended to represent (a subset) of the real structure of object in Python.
Currently Python is broken do to PyBlockInfo's FromPyObject expecting there to be a `PyGasPrices`, which doesn't exist in Ptyhon

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1353)
<!-- Reviewable:end -->
