### PR TITLE
feat: add more constants to`VersionedConstants`

### DIFF
--- a/crates/blockifier/resources/versioned_constants.json
+++ b/crates/blockifier/resources/versioned_constants.json
@@ -1,17 +1,20 @@
 {
-    "vm_resource_fee_cost": {
-
-        "bitwise_builtin":0.32,
-        "ec_op_builtin":5.12,
-        "ecdsa_builtin":10.24,
-        "keccak_builtin":10.24,
-        "n_steps": 0.005,
-        "output_builtin": 0,
-        "pedersen_builtin": 0.16,
-        "poseidon_builtin":0.16,
-        "range_check_builtin":0.08
+    "gateway": {
+        "max_calldata_length": 4000,
+        "max_contract_bytecode_size": 61440
     },
     "invoke_tx_max_n_steps": 3000000,
     "max_recursion_depth": 50,
-    "validate_max_n_steps": 1000000
+    "validate_max_n_steps": 1000000,
+    "vm_resource_fee_cost": {
+        "bitwise_builtin": 0.32,
+        "ec_op_builtin": 5.12,
+        "ecdsa_builtin": 10.24,
+        "keccak_builtin": 10.24,
+        "n_steps": 0.005,
+        "output_builtin": 0,
+        "pedersen_builtin": 0.16,
+        "poseidon_builtin": 0.16,
+        "range_check_builtin": 0.08
+    }
 }

--- a/crates/blockifier/src/versioned_constants.rs
+++ b/crates/blockifier/src/versioned_constants.rs
@@ -13,6 +13,9 @@ static DEFAULT_CONSTANTS: Lazy<VersionedConstants> = Lazy::new(|| {
         .expect("Versioned constants JSON file is malformed")
 });
 
+/// Contains constants for the Blockifier that may vary between versions.
+/// Additional constants in the JSON file, not used by Blockifier but included for transparency, are
+/// automatically ignored during deserialization.
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct VersionedConstants {
     // Fee related.

--- a/crates/native_blockifier/src/py_block_executor.rs
+++ b/crates/native_blockifier/src/py_block_executor.rs
@@ -35,9 +35,10 @@ pub struct PyBlockExecutor {
 #[pymethods]
 impl PyBlockExecutor {
     #[new]
-    #[pyo3(signature = (general_config, max_recursion_depth, global_contract_cache_size, target_storage_config))]
+    #[pyo3(signature = (general_config, validate_max_n_steps, max_recursion_depth, global_contract_cache_size, target_storage_config))]
     pub fn create(
         general_config: PyGeneralConfig,
+        validate_max_n_steps: u32,
         max_recursion_depth: usize,
         global_contract_cache_size: usize,
         target_storage_config: StorageConfig,
@@ -45,7 +46,8 @@ impl PyBlockExecutor {
         log::debug!("Initializing Block Executor...");
         let storage =
             PapyrusStorage::new(target_storage_config).expect("Failed to initialize storage");
-        let versioned_constants = versioned_constants_with_overrides(max_recursion_depth);
+        let versioned_constants =
+            versioned_constants_with_overrides(validate_max_n_steps, max_recursion_depth);
         log::debug!("Initialized Block Executor.");
 
         Self {

--- a/crates/native_blockifier/src/py_utils.rs
+++ b/crates/native_blockifier/src/py_utils.rs
@@ -100,6 +100,13 @@ where
     Ok(obj.getattr(attr)?.extract()?)
 }
 
-pub fn versioned_constants_with_overrides(max_recursion_depth: usize) -> VersionedConstants {
-    VersionedConstants { max_recursion_depth, ..VersionedConstants::latest_constants().clone() }
+pub fn versioned_constants_with_overrides(
+    validate_max_n_steps: u32,
+    max_recursion_depth: usize,
+) -> VersionedConstants {
+    VersionedConstants {
+        validate_max_n_steps,
+        max_recursion_depth,
+        ..VersionedConstants::latest_constants().clone()
+    }
 }

--- a/crates/native_blockifier/src/py_validator.rs
+++ b/crates/native_blockifier/src/py_validator.rs
@@ -31,21 +31,22 @@ pub struct PyValidator {
 #[pymethods]
 impl PyValidator {
     #[new]
-    #[pyo3(signature = (general_config, state_reader_proxy, next_block_info, max_recursion_depth, global_contract_cache_size, max_nonce_for_validation_skip))]
+    #[pyo3(signature = (general_config, state_reader_proxy, next_block_info, validate_max_n_steps, max_recursion_depth, global_contract_cache_size, max_nonce_for_validation_skip))]
     pub fn create(
         general_config: PyGeneralConfig,
         state_reader_proxy: &PyAny,
         next_block_info: PyBlockInfo,
+        validate_max_n_steps: u32,
         max_recursion_depth: usize,
         global_contract_cache_size: usize,
         max_nonce_for_validation_skip: PyFelt,
     ) -> NativeBlockifierResult<Self> {
-        let versioned_constants = versioned_constants_with_overrides(max_recursion_depth);
+        let versioned_constants =
+            versioned_constants_with_overrides(validate_max_n_steps, max_recursion_depth);
 
         let tx_executor = TransactionExecutor::new(
             PyStateReader::new(state_reader_proxy),
             &general_config,
-            // TODO(Gilad): add max_validate_n_steps override argument and override here.
             &versioned_constants,
             next_block_info,
             GlobalContractCache::new(global_contract_cache_size),


### PR DESCRIPTION
- Add gateway constants, these are only for transparency, and aren't used directly by the Blockifier whatsoever.
- Pass `validate_max_n_steps` into the blockifier via native_blockifier, to override versioned constants defaults.

Python: https://reviewable.io/reviews/starkware-industries/starkware/33582

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1369)
<!-- Reviewable:end -->
