### PR TITLE
chore: misspelled word

### DIFF
--- a/crates/blockifier/src/fee/os_resources.rs
+++ b/crates/blockifier/src/fee/os_resources.rs
@@ -104,7 +104,7 @@ fn os_resources() -> serde_json::Value {
                 "n_steps": 44
             },
             // The following is the cost of one Keccak round.
-            // TODO(ilya): Consider moving the resources of a keccak round to a seperate dict.
+            // TODO(ilya): Consider moving the resources of a keccak round to a separate dict.
             "Keccak": {
                 "builtin_instance_counter": {
                     "bitwise_builtin": 6,

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -1110,7 +1110,7 @@ fn test_count_actual_storage_changes(
     assert_eq!(expected_modified_contracts_2, storage_updates_2.modified_contracts);
     assert_eq!(expected_storage_updates_2, storage_updates_2.storage_updates);
 
-    // Transfer transaction: transfer 1 ETH to recepient.
+    // Transfer transaction: transfer 1 ETH to recipient.
     let mut state = CachedState::create_transactional(&mut state);
     let account_tx = account_invoke_tx(InvokeTxArgs {
         nonce: nonce_manager.next(account_address),


### PR DESCRIPTION
- Corrected a spelling error: changed 'seperate' to 'separate' for correctness.
- Fixed a spelling error: changed 'recepient' to 'recipient' for accuracy.
