### PR TITLE
feat: add Cairo constants to `VersionedConstants` - unused

### DIFF
--- a/crates/blockifier/resources/versioned_constants.json
+++ b/crates/blockifier/resources/versioned_constants.json
@@ -1,20 +1,164 @@
 {
-    "gateway": {
-        "max_calldata_length": 4000,
-        "max_contract_bytecode_size": 61440
+  "starknet_os_constants": {
+    "nop_entry_point_offset": -1,
+    "entry_point_type_external": 0,
+    "entry_point_type_l1_handler": 1,
+    "entry_point_type_constructor": 2,
+    "l1_handler_version": 0,
+    "sierra_array_len_bound": 4294967296,
+    "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+    "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+    "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+    "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+    "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
+    "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+    "default_entry_point_selector": 0,
+    "block_hash_contract_address": 1,
+    "stored_block_hash_buffer": 10,
+    "step_gas_cost": 100,
+    "range_check_gas_cost": 70,
+    "memory_hole_gas_cost": 10,
+    "initial_gas_cost": {
+      "step_gas_cost": 100000000
     },
-    "invoke_tx_max_n_steps": 3000000,
-    "max_recursion_depth": 50,
-    "validate_max_n_steps": 1000000,
-    "vm_resource_fee_cost": {
-        "bitwise_builtin": 0.32,
-        "ec_op_builtin": 5.12,
-        "ecdsa_builtin": 10.24,
-        "keccak_builtin": 10.24,
-        "n_steps": 0.005,
-        "output_builtin": 0,
-        "pedersen_builtin": 0.16,
-        "poseidon_builtin": 0.16,
-        "range_check_builtin": 0.08
-    }
+    "entry_point_initial_budget": {
+      "step_gas_cost": 100
+    },
+    "syscall_base_gas_cost": {
+      "step_gas_cost": 100
+    },
+    "entry_point_gas_cost": {
+      "entry_point_initial_budget": 1,
+      "step_gas_cost": 500
+    },
+    "fee_transfer_gas_cost": {
+      "entry_point_gas_cost": 1,
+      "step_gas_cost": 100
+    },
+    "transaction_gas_cost": {
+      "entry_point_gas_cost": 2,
+      "fee_transfer_gas_cost": 1,
+      "step_gas_cost": 100
+    },
+    "call_contract_gas_cost": {
+      "syscall_base_gas_cost": 1,
+      "step_gas_cost": 10,
+      "entry_point_gas_cost": 1
+    },
+    "deploy_gas_cost": {
+      "syscall_base_gas_cost": 1,
+      "step_gas_cost": 200,
+      "entry_point_gas_cost": 1
+    },
+    "get_block_hash_gas_cost": {
+      "syscall_base_gas_cost": 1,
+      "step_gas_cost": 50
+    },
+    "get_execution_info_gas_cost": {
+      "syscall_base_gas_cost": 1,
+      "step_gas_cost": 10
+    },
+    "library_call_gas_cost": {
+      "call_contract_gas_cost": 1
+    },
+    "replace_class_gas_cost": {
+      "syscall_base_gas_cost": 1,
+      "step_gas_cost": 50
+    },
+    "storage_read_gas_cost": {
+      "syscall_base_gas_cost": 1,
+      "step_gas_cost": 50
+    },
+    "storage_write_gas_cost": {
+      "syscall_base_gas_cost": 1,
+      "step_gas_cost": 50
+    },
+    "emit_event_gas_cost": {
+      "syscall_base_gas_cost": 1,
+      "step_gas_cost": 10
+    },
+    "send_message_to_l1_gas_cost": {
+      "syscall_base_gas_cost": 1,
+      "step_gas_cost": 50
+    },
+    "secp256k1_add_gas_cost": {
+      "step_gas_cost": 406,
+      "range_check_gas_cost": 29
+    },
+    "secp256k1_get_point_from_x_gas_cost": {
+      "step_gas_cost": 391,
+      "range_check_gas_cost": 30,
+      "memory_hole_gas_cost": 20
+    },
+    "secp256k1_get_xy_gas_cost": {
+      "step_gas_cost": 239,
+      "range_check_gas_cost": 11,
+      "memory_hole_gas_cost": 40
+    },
+    "secp256k1_mul_gas_cost": {
+      "step_gas_cost": 76501,
+      "range_check_gas_cost": 7045,
+      "memory_hole_gas_cost": 2
+    },
+    "secp256k1_new_gas_cost": {
+      "step_gas_cost": 475,
+      "range_check_gas_cost": 35,
+      "memory_hole_gas_cost": 40
+    },
+    "secp256r1_add_gas_cost": {
+      "step_gas_cost": 589,
+      "range_check_gas_cost": 57
+    },
+    "secp256r1_get_point_from_x_gas_cost": {
+      "step_gas_cost": 510,
+      "range_check_gas_cost": 44,
+      "memory_hole_gas_cost": 20
+    },
+    "secp256r1_get_xy_gas_cost": {
+      "step_gas_cost": 241,
+      "range_check_gas_cost": 11,
+      "memory_hole_gas_cost": 40
+    },
+    "secp256r1_mul_gas_cost": {
+      "step_gas_cost": 125340,
+      "range_check_gas_cost": 13961,
+      "memory_hole_gas_cost": 2
+    },
+    "secp256r1_new_gas_cost": {
+      "step_gas_cost": 594,
+      "range_check_gas_cost": 49,
+      "memory_hole_gas_cost": 40
+    },
+    "keccak_gas_cost": {
+      "syscall_base_gas_cost": 1
+    },
+    "keccak_round_cost_gas_cost": 180000,
+    "error_block_number_out_of_range": "'Block number out of range'",
+    "error_out_of_gas": "'Out of gas'",
+    "error_invalid_input_len": "'Invalid input length'",
+    "error_invalid_argument": "'Invalid argument'",
+    "validated": "'VALID'",
+    "l1_gas": "'L1_GAS'",
+    "l2_gas": "'L2_GAS'",
+    "l1_gas_index": 0,
+    "l2_gas_index": 1
+  },
+  "gateway": {
+    "max_calldata_length": 4000,
+    "max_contract_bytecode_size": 61440
+  },
+  "invoke_tx_max_n_steps": 3000000,
+  "max_recursion_depth": 50,
+  "validate_max_n_steps": 1000000,
+  "vm_resource_fee_cost": {
+    "bitwise_builtin": 0.32,
+    "ec_op_builtin": 5.12,
+    "ecdsa_builtin": 10.24,
+    "keccak_builtin": 10.24,
+    "n_steps": 0.005,
+    "output_builtin": 0,
+    "pedersen_builtin": 0.16,
+    "poseidon_builtin": 0.16,
+    "range_check_builtin": 0.08
+  }
 }

--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -223,7 +223,7 @@ impl EntryPointExecutionContext {
         }
 
         let gas_per_step = versioned_constants
-            .vm_resource_fee_cost
+            .vm_resource_fee_cost()
             .get(constants::N_STEPS_RESOURCE)
             .unwrap_or_else(|| {
                 panic!("{} must appear in `vm_resource_fee_cost`.", constants::N_STEPS_RESOURCE)

--- a/crates/blockifier/src/fee/fee_utils.rs
+++ b/crates/blockifier/src/fee/fee_utils.rs
@@ -43,7 +43,7 @@ pub fn calculate_l1_gas_by_vm_usage(
     versioned_constants: &VersionedConstants,
     vm_resource_usage: &ResourcesMapping,
 ) -> TransactionFeeResult<GasVector> {
-    let vm_resource_fee_costs = &versioned_constants.vm_resource_fee_cost;
+    let vm_resource_fee_costs = versioned_constants.vm_resource_fee_cost();
     let vm_resource_names = HashSet::<&String>::from_iter(vm_resource_usage.0.keys());
     if !vm_resource_names.is_subset(&HashSet::from_iter(vm_resource_fee_costs.keys())) {
         return Err(TransactionFeeError::CairoResourcesNotContainedInFeeCosts);

--- a/crates/blockifier/src/test_utils/struct_impls.rs
+++ b/crates/blockifier/src/test_utils/struct_impls.rs
@@ -1,10 +1,5 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use cairo_vm::vm::runners::builtin_runner::{
-    BITWISE_BUILTIN_NAME, EC_OP_BUILTIN_NAME, HASH_BUILTIN_NAME, OUTPUT_BUILTIN_NAME,
-    POSEIDON_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME, SIGNATURE_BUILTIN_NAME,
-};
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::core::{ChainId, ContractAddress, PatriciaKey};
 use starknet_api::hash::StarkHash;
@@ -15,7 +10,6 @@ use super::{
     DEFAULT_ETH_L1_GAS_PRICE, DEFAULT_STRK_L1_DATA_GAS_PRICE, DEFAULT_STRK_L1_GAS_PRICE,
     TEST_ERC20_CONTRACT_ADDRESS, TEST_ERC20_CONTRACT_ADDRESS2, TEST_SEQUENCER_ADDRESS,
 };
-use crate::abi::constants;
 use crate::block::{BlockInfo, GasPrices};
 use crate::context::{BlockContext, ChainInfo, FeeTokenAddresses, TransactionContext};
 use crate::execution::call_info::{CallExecution, CallInfo, Retdata};
@@ -86,21 +80,6 @@ impl CallEntryPoint {
 impl VersionedConstants {
     pub fn create_for_testing() -> Self {
         Self::latest_constants().clone()
-    }
-
-    pub fn create_for_account_testing() -> Self {
-        let vm_resource_fee_cost = Arc::new(HashMap::from([
-            (constants::N_STEPS_RESOURCE.to_string(), 1_f64),
-            (HASH_BUILTIN_NAME.to_string(), 1_f64),
-            (RANGE_CHECK_BUILTIN_NAME.to_string(), 1_f64),
-            (SIGNATURE_BUILTIN_NAME.to_string(), 1_f64),
-            (BITWISE_BUILTIN_NAME.to_string(), 1_f64),
-            (POSEIDON_BUILTIN_NAME.to_string(), 1_f64),
-            (OUTPUT_BUILTIN_NAME.to_string(), 1_f64),
-            (EC_OP_BUILTIN_NAME.to_string(), 1_f64),
-        ]));
-
-        Self { vm_resource_fee_cost, ..Self::create_for_testing() }
     }
 }
 

--- a/crates/blockifier/src/versioned_constants.rs
+++ b/crates/blockifier/src/versioned_constants.rs
@@ -3,9 +3,15 @@ use std::io;
 use std::path::Path;
 use std::sync::Arc;
 
+use indexmap::{IndexMap, IndexSet};
 use once_cell::sync::Lazy;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use serde_json::{Number, Value};
 use thiserror::Error;
+
+#[cfg(test)]
+#[path = "versioned_constants_test.rs"]
+pub mod test;
 
 const DEFAULT_CONSTANTS_JSON: &str = include_str!("../resources/versioned_constants.json");
 static DEFAULT_CONSTANTS: Lazy<VersionedConstants> = Lazy::new(|| {
@@ -18,15 +24,20 @@ static DEFAULT_CONSTANTS: Lazy<VersionedConstants> = Lazy::new(|| {
 /// automatically ignored during deserialization.
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct VersionedConstants {
-    // Fee related.
-    // TODO: Consider making this a struct, this will require change the way we access these
-    // values.
-    pub vm_resource_fee_cost: Arc<HashMap<String, f64>>,
-
     // Limits.
     pub invoke_tx_max_n_steps: u32,
     pub validate_max_n_steps: u32,
     pub max_recursion_depth: usize,
+
+    // Fee related.
+    // TODO: Consider making this a struct, this will require change the way we access these
+    // values.
+    vm_resource_fee_cost: Arc<HashMap<String, f64>>,
+
+    // Cairo OS constants.
+    // Note: if loaded from a json file, there are some assumptions made on its structure.
+    // See the struct's docstring for more details.
+    starknet_os_constants: Arc<StarknetOSConstants>,
 }
 
 impl VersionedConstants {
@@ -34,6 +45,46 @@ impl VersionedConstants {
     /// To use custom constants, initialize the struct from a file using `try_from`.
     pub fn latest_constants() -> &'static Self {
         &DEFAULT_CONSTANTS
+    }
+
+    pub fn vm_resource_fee_cost(&self) -> &HashMap<String, f64> {
+        &self.vm_resource_fee_cost
+    }
+
+    pub fn gas_cost(&self, name: &str) -> u64 {
+        match self.starknet_os_constants.gas_costs.get(name) {
+            Some(&cost) => cost,
+            None if StarknetOSConstants::ALLOWED_GAS_COST_NAMES.contains(&name) => {
+                panic!(
+                    "{} is present in `StarknetOSConstants::GAS_COSTS` but not in `self`; was \
+                     validation skipped?",
+                    name
+                )
+            }
+            None => {
+                panic!(
+                    "Only gas costs listed in `{0:?}` should be requested, got: {1}",
+                    StarknetOSConstants::ALLOWED_GAS_COST_NAMES,
+                    name,
+                )
+            }
+        }
+    }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn create_for_account_testing() -> Self {
+        let vm_resource_fee_cost = Arc::new(HashMap::from([
+            (crate::abi::constants::N_STEPS_RESOURCE.to_string(), 1_f64),
+            (cairo_vm::vm::runners::builtin_runner::HASH_BUILTIN_NAME.to_string(), 1_f64),
+            (cairo_vm::vm::runners::builtin_runner::RANGE_CHECK_BUILTIN_NAME.to_string(), 1_f64),
+            (cairo_vm::vm::runners::builtin_runner::SIGNATURE_BUILTIN_NAME.to_string(), 1_f64),
+            (cairo_vm::vm::runners::builtin_runner::BITWISE_BUILTIN_NAME.to_string(), 1_f64),
+            (cairo_vm::vm::runners::builtin_runner::POSEIDON_BUILTIN_NAME.to_string(), 1_f64),
+            (cairo_vm::vm::runners::builtin_runner::OUTPUT_BUILTIN_NAME.to_string(), 1_f64),
+            (cairo_vm::vm::runners::builtin_runner::EC_OP_BUILTIN_NAME.to_string(), 1_f64),
+        ]));
+
+        Self { vm_resource_fee_cost, ..Self::create_for_testing() }
     }
 }
 
@@ -45,10 +96,169 @@ impl TryFrom<&Path> for VersionedConstants {
     }
 }
 
+// Below, serde first deserializes the json into a regular IndexMap wrapped by the newtype
+// `StarknetOSConstantsRawJSON`, then calls the `try_from` of the newtype, which handles the
+// conversion into actual values.
+// Assumption: if the json has a value that contains the expression "FOO * 2", then the key `FOO`
+// must appear before this value in the JSON.
+// FIXME: JSON doesn't guarantee order, serde seems to work for this use-case, buit there is no
+// guarantee that it will stay that way. Seriously consider switching to serde_yaml/other format.
+// FIXME FOLLOWUP: if we switch from JSON, we can switch to strongly typed fields, instead of an
+// internal indexmap: using strongly typed fields breaks the order under serialization, making
+// testing very difficult.
+// TODO: consider encoding the * and + operations inside the json file, instead of hardcoded below
+// in the `try_from`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(try_from = "OsConstantsRawJSON")]
+pub struct StarknetOSConstants {
+    gas_costs: IndexMap<String, u64>,
+}
+
+impl StarknetOSConstants {
+    // List of all gas cost constants that *must* be present in the JSON file, all other consts are
+    // ignored. See documentation in core/os/constants.cairo.
+    const ALLOWED_GAS_COST_NAMES: [&'static str; 31] = [
+        "step_gas_cost",
+        "range_check_gas_cost",
+        "memory_hole_gas_cost",
+        "initial_gas_cost",
+        "entry_point_initial_budget",
+        "syscall_base_gas_cost",
+        "entry_point_gas_cost",
+        "fee_transfer_gas_cost",
+        "transaction_gas_cost",
+        "call_contract_gas_cost",
+        "deploy_gas_cost",
+        "get_block_hash_gas_cost",
+        "get_execution_info_gas_cost",
+        "library_call_gas_cost",
+        "replace_class_gas_cost",
+        "storage_read_gas_cost",
+        "storage_write_gas_cost",
+        "emit_event_gas_cost",
+        "send_message_to_l1_gas_cost",
+        "secp256k1_add_gas_cost",
+        "secp256k1_get_point_from_x_gas_cost",
+        "secp256k1_get_xy_gas_cost",
+        "secp256k1_mul_gas_cost",
+        "secp256k1_new_gas_cost",
+        "secp256r1_add_gas_cost",
+        "secp256r1_get_point_from_x_gas_cost",
+        "secp256r1_get_xy_gas_cost",
+        "secp256r1_mul_gas_cost",
+        "secp256r1_new_gas_cost",
+        "keccak_gas_cost",
+        "keccak_round_cost_gas_cost",
+    ];
+
+    pub fn validate(&self) -> Result<(), OsConstantsSerdeError> {
+        // Check that all the allowed gas consts set is contained inside the parsed consts,
+        // that is, all consts in the list appeared as keys in the json file.
+        for key in Self::ALLOWED_GAS_COST_NAMES {
+            if !self.gas_costs.contains_key(key) {
+                return Err(OsConstantsSerdeError::ValidationError(format!(
+                    "Starknet os constants is missing the following key: {}",
+                    key
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl TryFrom<OsConstantsRawJSON> for StarknetOSConstants {
+    type Error = OsConstantsSerdeError;
+
+    fn try_from(raw_json_data: OsConstantsRawJSON) -> Result<Self, Self::Error> {
+        let mut gas_costs = IndexMap::new();
+
+        let gas_cost_whitelist: IndexSet<_> =
+            Self::ALLOWED_GAS_COST_NAMES.iter().copied().collect();
+        for (key, value) in raw_json_data.raw_json_file_as_dict {
+            if !gas_cost_whitelist.contains(key.as_str()) {
+                // Ignore non-whitelist consts.
+                continue;
+            }
+
+            match value {
+                Value::Number(n) => {
+                    let value = n.as_u64().ok_or_else(|| OsConstantsSerdeError::OutOfRange {
+                        key: key.clone(),
+                        value: n,
+                    })?;
+                    gas_costs.insert(key, value);
+                }
+                Value::Object(obj) => {
+                    // Converts:
+                    // `k_1: {k_2: factor_1, k_3: factor_2}`
+                    // into:
+                    // k_1 = k_2 * factor_1 + k_3 * factor_2
+                    // Assumption: k_2 and k_3 appeared before k_1 in the JSON.
+                    let sum = obj.into_iter().try_fold(0, |acc, (inner_key, factor)| {
+                        let factor = factor.as_u64().ok_or_else(|| {
+                            OsConstantsSerdeError::OutOfRangeFactor {
+                                key: key.clone(),
+                                value: factor,
+                            }
+                        })?;
+                        let inner_key_value = *gas_costs.get(&inner_key).ok_or_else(|| {
+                            OsConstantsSerdeError::KeyNotFound { key: key.clone(), inner_key }
+                        })?;
+
+                        Ok(acc + inner_key_value * factor)
+                    })?;
+                    gas_costs.insert(key, sum);
+                }
+                Value::String(_) => {
+                    // String consts are all non-whitelisted, ignore them.
+                    continue;
+                }
+                _ => return Err(OsConstantsSerdeError::UnhandledValueType(value)),
+            }
+        }
+
+        let os_constants = StarknetOSConstants { gas_costs };
+
+        // Skip validation in testing: to test validation run validate manually.
+        #[cfg(not(any(feature = "testing", test)))]
+        os_constants.validate()?;
+
+        Ok(os_constants)
+    }
+}
+
+// Intermediate representation of the JSON file in order to make the deserialization easier, using a
+// regular the try_from.
+#[derive(Debug, Deserialize)]
+struct OsConstantsRawJSON {
+    #[serde(flatten)]
+    raw_json_file_as_dict: IndexMap<String, Value>,
+}
+
 #[derive(Debug, Error)]
 pub enum VersionedConstantsError {
     #[error(transparent)]
     IoError(#[from] io::Error),
     #[error("JSON file cannot be serialized into VersionedConstants: {0}")]
     ParseError(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum OsConstantsSerdeError {
+    #[error("Value cannot be cast into u64: {0}")]
+    InvalidFactorFormat(Value),
+    #[error("Unknown key '{inner_key}' used to create value for '{key}'")]
+    KeyNotFound { key: String, inner_key: String },
+    #[error("Value {value} for key '{key}' is out of range and cannot be cast into u64")]
+    OutOfRange { key: String, value: Number },
+    #[error(
+        "Value {value} used to create value for key '{key}' is out of range and cannot be cast \
+         into u64"
+    )]
+    OutOfRangeFactor { key: String, value: Value },
+    #[error("Unhandled value type: {0}")]
+    UnhandledValueType(Value),
+    #[error("Validation failed: {0}")]
+    ValidationError(String),
 }

--- a/crates/blockifier/src/versioned_constants_test.rs
+++ b/crates/blockifier/src/versioned_constants_test.rs
@@ -1,0 +1,104 @@
+use pretty_assertions::assert_eq;
+
+use super::*;
+
+// TODO: Test Starknet OS validation.
+
+#[test]
+fn test_successful_parsing() {
+    let json_data = r#"
+    {
+        "step_gas_cost": 2,
+        "entry_point_initial_budget": {
+            "step_gas_cost": 3
+        },
+        "entry_point_gas_cost": {
+            "entry_point_initial_budget": 4,
+            "step_gas_cost": 5
+        },
+        "ignore the gas string": "GAS!",
+        "I look like a gas cost but my name is all wrong": 0
+    }"#;
+    let starknet_os_constants: Arc<StarknetOSConstants> = serde_json::from_str(json_data).unwrap();
+    let versioned_constants = VersionedConstants { starknet_os_constants, ..Default::default() };
+
+    assert_eq!(versioned_constants.gas_cost("step_gas_cost"), 2);
+    assert_eq!(versioned_constants.gas_cost("entry_point_initial_budget"), 2 * 3); // step_gas_cost * 3.
+
+    // entry_point_intial_budget * 4 + step_gas_cost * 5.
+    assert_eq!(versioned_constants.gas_cost("entry_point_gas_cost"), 6 * 4 + 2 * 5);
+
+    // Only the 3 values asserted against should be present, the rest are ignored.
+    assert_eq!(versioned_constants.starknet_os_constants.gas_costs.len(), 3);
+}
+
+#[test]
+fn test_string_inside_composed_field() {
+    let json_data = r#"
+    {
+        "step_gas_cost": 2,
+        "entry_point_initial_budget": {
+            "step_gas_cost": "meow"
+        }
+    }"#;
+
+    check_constants_serde_error(
+        json_data,
+        "Value \"meow\" used to create value for key 'entry_point_initial_budget' is out of range \
+         and cannot be cast into u64",
+    );
+}
+
+fn check_constants_serde_error(json_data: &str, expected_error_message: &str) {
+    let error = serde_json::from_str::<StarknetOSConstants>(json_data).unwrap_err();
+    assert_eq!(error.to_string(), expected_error_message);
+}
+
+#[test]
+fn test_missing_key() {
+    let json_data = r#"
+    {
+        "entry_point_initial_budget": {
+            "TEN LI GAZ!": 2
+        }
+    }"#;
+    check_constants_serde_error(
+        json_data,
+        "Unknown key 'TEN LI GAZ!' used to create value for 'entry_point_initial_budget'",
+    );
+}
+
+#[test]
+fn test_unhandled_value_type() {
+    let json_data = r#"
+    {
+        "step_gas_cost": []
+    }"#;
+    check_constants_serde_error(json_data, "Unhandled value type: []");
+}
+
+#[test]
+fn test_invalid_number() {
+    check_constants_serde_error(
+        r#"{"step_gas_cost": 42.5}"#,
+        "Value 42.5 for key 'step_gas_cost' is out of range and cannot be cast into u64",
+    );
+
+    check_constants_serde_error(
+        r#"{"step_gas_cost": -2}"#,
+        "Value -2 for key 'step_gas_cost' is out of range and cannot be cast into u64",
+    );
+
+    let json_data = r#"
+    {
+        "step_gas_cost": 2,
+        "entry_point_initial_budget": {
+            "step_gas_cost": 42.5
+        }
+    }"#;
+    check_constants_serde_error(
+        json_data,
+        "Value 42.5 used to create value for key 'entry_point_initial_budget' is out of range and \
+         cannot be cast into u64",
+    );
+}

--- a/crates/native_blockifier/src/py_utils.rs
+++ b/crates/native_blockifier/src/py_utils.rs
@@ -104,9 +104,8 @@ pub fn versioned_constants_with_overrides(
     validate_max_n_steps: u32,
     max_recursion_depth: usize,
 ) -> VersionedConstants {
-    VersionedConstants {
-        validate_max_n_steps,
-        max_recursion_depth,
-        ..VersionedConstants::latest_constants().clone()
-    }
+    let mut versioned_constants = VersionedConstants::latest_constants().clone();
+    versioned_constants.max_recursion_depth = max_recursion_depth;
+    versioned_constants.validate_max_n_steps = validate_max_n_steps;
+    versioned_constants
 }


### PR DESCRIPTION
Currently not using them, just adding the deserialization logic and tests.
In upcoming commits this will replace `constants.rs`.

The idea is that values inside `cairo_constants` that are json objects,
that is, have the form:
```json
{
  A: x,
  B: y,
  C: z,
  ...
}
```
should be parsed as x*A + y*B + z*C + ..., where {x,y,z} must be
integers (otherwise an error is thrown), and where {A,B,C} must
correspond to keys that have already been parsed in the json.

Note: JSON standard doesn't enforce order on the keys, but our
implementation does; we should consider using a format that ensures
order, rather than relying on serde's implementation and `IndexMap`.

For reference, here's the way it looks in the cairo constants flie: https://github.com/starkware-industries/starkware/blob/daaa8ef1e466a1905f88749bb0dde2142e1bc9d7/src/starkware/starknet/core/os/constants.cairo#L1.

FYI @Yael-Starkware

Python: https://reviewable.io/reviews/starkware-industries/starkware/33612

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1379)
<!-- Reviewable:end -->
