### PR TITLE
fix(native_blockifier): fix build for mac + unused import

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,15 @@
 # Increase Rust stack size.
 # This should be large enough for `MAX_ENTRY_POINT_RECURSION_DEPTH` recursive entry point calls.
 RUST_MIN_STACK = "4194304" #  4 MiB
+
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
It's impossible to build the native blockifier on a mac without those flags.
Import constant only for the necessary feature otherwise compilation fails

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1406)
<!-- Reviewable:end -->
