### PR TITLE
refactor: replaced default_invoke_tx_args with macro that enforces to explicitly define max_fee

### DIFF
--- a/crates/blockifier/src/fee/actual_cost_test.rs
+++ b/crates/blockifier/src/fee/actual_cost_test.rs
@@ -16,7 +16,7 @@ use crate::invoke_tx_args;
 use crate::state::cached_state::StateChangesCount;
 use crate::test_utils::contracts::FeatureContract;
 use crate::test_utils::initial_test_state::test_state;
-use crate::test_utils::{create_calldata, default_invoke_tx_args, CairoVersion, BALANCE, MAX_FEE};
+use crate::test_utils::{create_calldata, create_trivial_calldata, CairoVersion, BALANCE, MAX_FEE};
 use crate::transaction::constants;
 use crate::transaction::objects::{GasVector, HasRelatedFeeType};
 use crate::transaction::test_utils::{account_invoke_tx, calculate_class_info_for_testing};
@@ -306,10 +306,11 @@ fn test_calculate_tx_gas_usage(#[values(false, true)] use_kzg_da: bool) {
     let account_contract_address = account_contract.get_instance_address(0);
     let state = &mut test_state(chain_info, BALANCE, &[(account_contract, 1), (test_contract, 1)]);
 
-    let account_tx = account_invoke_tx(default_invoke_tx_args(
-        account_contract_address,
-        test_contract.get_instance_address(0),
-    ));
+    let account_tx = account_invoke_tx(invoke_tx_args! {
+        sender_address: account_contract_address,
+        calldata: create_trivial_calldata(test_contract.get_instance_address(0)),
+        max_fee: Fee(MAX_FEE),
+    });
     let calldata_length = account_tx.calldata_length();
     let signature_length = account_tx.signature_length();
     let fee_token_address = chain_info.fee_token_address(&account_tx.fee_type());

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -21,8 +21,7 @@ use starknet_api::deprecated_contract_class::{
 use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::{
-    Calldata, ContractAddressSalt, Fee, Resource, ResourceBounds, ResourceBoundsMapping,
-    TransactionSignature,
+    Calldata, ContractAddressSalt, Resource, ResourceBounds, ResourceBoundsMapping,
 };
 use starknet_api::{calldata, contract_address, patricia_key, stark_felt};
 
@@ -30,8 +29,6 @@ use crate::abi::abi_utils::{get_fee_token_var_address, selector_from_name};
 use crate::execution::contract_class::{ContractClass, ContractClassV0};
 use crate::execution::entry_point::{CallEntryPoint, CallType};
 use crate::execution::execution_utils::felt_to_stark_felt;
-use crate::invoke_tx_args;
-use crate::test_utils::invoke::InvokeTxArgs;
 use crate::utils::const_max;
 use crate::versioned_constants::VersionedConstants;
 
@@ -377,22 +374,11 @@ pub fn create_calldata(
     Calldata(calldata.into())
 }
 
-// TODO(Gilad, 30/03/2024): Make this an associated function of InvokeTxArgs.
-pub fn default_invoke_tx_args(
-    account_contract_address: ContractAddress,
-    test_contract_address: ContractAddress,
-) -> InvokeTxArgs {
-    let execute_calldata = create_calldata(
+/// Calldata for a trivial entry point in the test contract.
+pub fn create_trivial_calldata(test_contract_address: ContractAddress) -> Calldata {
+    create_calldata(
         test_contract_address,
         "return_result",
         &[stark_felt!(2_u8)], // Calldata: num.
-    );
-
-    invoke_tx_args! {
-        max_fee: Fee(MAX_FEE),
-        signature: TransactionSignature::default(),
-        nonce: Nonce::default(),
-        sender_address: account_contract_address,
-        calldata: execute_calldata,
-    }
+    )
 }

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -36,8 +36,8 @@ use crate::test_utils::deploy_account::deploy_account_tx;
 use crate::test_utils::initial_test_state::{fund_account, test_state};
 use crate::test_utils::invoke::InvokeTxArgs;
 use crate::test_utils::{
-    create_calldata, CairoVersion, NonceManager, BALANCE, DEFAULT_STRK_L1_GAS_PRICE, MAX_FEE,
-    MAX_L1_GAS_AMOUNT, MAX_L1_GAS_PRICE,
+    create_calldata, create_trivial_calldata, CairoVersion, NonceManager, BALANCE,
+    DEFAULT_STRK_L1_GAS_PRICE, MAX_FEE, MAX_L1_GAS_AMOUNT, MAX_L1_GAS_PRICE,
 };
 use crate::transaction::account_transaction::AccountTransaction;
 use crate::transaction::constants::TRANSFER_ENTRY_POINT_NAME;
@@ -94,11 +94,7 @@ fn test_enforce_fee_false_works(block_context: BlockContext, #[case] version: Tr
             max_fee: Fee(0),
             resource_bounds: l1_resource_bounds(0, DEFAULT_STRK_L1_GAS_PRICE),
             sender_address: account_address,
-            calldata: create_calldata(
-                contract_address,
-                "return_result",
-                &[stark_felt!(2_u8)]  // Calldata: num.
-            ),
+            calldata: create_trivial_calldata(contract_address),
             version,
             nonce: nonce_manager.next(account_address),
         },
@@ -127,11 +123,7 @@ fn test_account_flow_test(
         invoke_tx_args! {
             max_fee,
             sender_address: account_address,
-            calldata: create_calldata(
-                contract_address,
-                "return_result",
-                &[stark_felt!(2_u8)]  // Calldata: num.
-            ),
+            calldata: create_trivial_calldata(contract_address),
             version: tx_version,
             nonce: nonce_manager.next(account_address),
             only_query,
@@ -320,11 +312,7 @@ fn test_max_fee_limit_validate(
     // slightly above them.
     let tx_args = invoke_tx_args! {
         sender_address: grindy_account_address,
-        calldata: create_calldata(
-            contract_address,
-            "return_result",
-            &[stark_felt!(2_u8)], // Calldata: num.
-        ),
+        calldata: create_trivial_calldata(contract_address),
         version,
         nonce: nonce_manager.next(grindy_account_address)
     };

--- a/crates/blockifier/src/transaction/execution_flavors_test.rs
+++ b/crates/blockifier/src/transaction/execution_flavors_test.rs
@@ -18,8 +18,8 @@ use crate::test_utils::contracts::FeatureContract;
 use crate::test_utils::dict_state_reader::DictStateReader;
 use crate::test_utils::initial_test_state::test_state;
 use crate::test_utils::{
-    create_calldata, CairoVersion, NonceManager, BALANCE, MAX_FEE, MAX_L1_GAS_AMOUNT,
-    MAX_L1_GAS_PRICE,
+    create_calldata, create_trivial_calldata, CairoVersion, NonceManager, BALANCE, MAX_FEE,
+    MAX_L1_GAS_AMOUNT, MAX_L1_GAS_PRICE,
 };
 use crate::transaction::errors::{
     TransactionExecutionError, TransactionFeeError, TransactionPreValidationError,
@@ -165,7 +165,7 @@ fn test_simulate_validate_charge_fee_pre_validate(
         max_fee,
         resource_bounds: l1_resource_bounds(MAX_L1_GAS_AMOUNT, MAX_L1_GAS_PRICE),
         sender_address: account_address,
-        calldata: create_calldata(test_contract_address, "return_result", &[stark_felt!(2_u8)]),
+        calldata: create_trivial_calldata(test_contract_address),
         version,
         only_query,
     };

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -55,7 +55,7 @@ use crate::test_utils::initial_test_state::test_state;
 use crate::test_utils::invoke::invoke_tx;
 use crate::test_utils::prices::Prices;
 use crate::test_utils::{
-    create_calldata, default_invoke_tx_args, test_erc20_account_balance_key,
+    create_calldata, create_trivial_calldata, test_erc20_account_balance_key,
     test_erc20_sequencer_balance_key, CairoVersion, NonceManager, SaltManager,
     ACCOUNT_CONTRACT_CAIRO1_PATH, BALANCE, CHAIN_ID_NAME, CURRENT_BLOCK_NUMBER,
     CURRENT_BLOCK_TIMESTAMP, MAX_FEE, MAX_L1_GAS_AMOUNT, MAX_L1_GAS_PRICE,
@@ -337,8 +337,11 @@ fn test_invoke_tx(
     let state = &mut test_state(chain_info, BALANCE, &[(account_contract, 1), (test_contract, 1)]);
     let test_contract_address = test_contract.get_instance_address(0);
     let account_contract_address = account_contract.get_instance_address(0);
-    let invoke_tx =
-        invoke_tx(default_invoke_tx_args(account_contract_address, test_contract_address));
+    let invoke_tx = invoke_tx(invoke_tx_args! {
+        sender_address: account_contract_address,
+        calldata: create_trivial_calldata(test_contract_address),
+        max_fee: Fee(MAX_FEE)
+    });
 
     // Extract invoke transaction fields for testing, as it is consumed when creating an account
     // transaction.
@@ -751,8 +754,10 @@ fn test_max_fee_exceeds_balance(account_cairo_version: CairoVersion) {
         &[(account_contract, 1), (test_contract, 1)],
     );
     let account_contract_address = account_contract.get_instance_address(0);
-    let default_args =
-        default_invoke_tx_args(account_contract_address, test_contract.get_instance_address(0));
+    let default_args = invoke_tx_args! {
+        sender_address: account_contract_address,
+        calldata: create_trivial_calldata(test_contract.get_instance_address(0)
+    )};
 
     let invalid_max_fee = Fee(BALANCE + 1);
     // TODO(Ori, 1/2/2024): Write an indicative expect message explaining why the conversion works.
@@ -813,10 +818,11 @@ fn test_insufficient_resource_bounds(account_cairo_version: CairoVersion) {
         BALANCE,
         &[(account_contract, 1), (test_contract, 1)],
     );
-    let valid_invoke_tx_args = default_invoke_tx_args(
-        account_contract.get_instance_address(0),
-        test_contract.get_instance_address(0),
-    );
+    let valid_invoke_tx_args = invoke_tx_args! {
+        sender_address: account_contract.get_instance_address(0),
+        calldata: create_trivial_calldata(test_contract.get_instance_address(0)),
+        max_fee: Fee(MAX_FEE)
+    };
 
     // The minimal gas estimate does not depend on tx version.
     let tx = &account_invoke_tx(valid_invoke_tx_args.clone());
@@ -901,11 +907,11 @@ fn test_actual_fee_gt_resource_bounds(account_cairo_version: CairoVersion) {
         BALANCE,
         &[(account_contract, 1), (test_contract, 1)],
     );
-    let invoke_tx_args = default_invoke_tx_args(
-        account_contract.get_instance_address(0),
-        test_contract.get_instance_address(0),
-    );
-
+    let invoke_tx_args = invoke_tx_args! {
+        sender_address: account_contract.get_instance_address(0),
+        calldata: create_trivial_calldata(test_contract.get_instance_address(0)),
+        max_fee: Fee(MAX_FEE)
+    };
     let tx = &account_invoke_tx(invoke_tx_args.clone());
     let minimal_l1_gas = estimate_minimal_gas_vector(block_context, tx).unwrap().l1_gas;
     let minimal_fee =
@@ -932,10 +938,11 @@ fn test_invalid_nonce(account_cairo_version: CairoVersion) {
         BALANCE,
         &[(account_contract, 1), (test_contract, 1)],
     );
-    let valid_invoke_tx_args = default_invoke_tx_args(
-        account_contract.get_instance_address(0),
-        test_contract.get_instance_address(0),
-    );
+    let valid_invoke_tx_args = invoke_tx_args! {
+        sender_address: account_contract.get_instance_address(0),
+        calldata: create_trivial_calldata(test_contract.get_instance_address(0)),
+        max_fee: Fee(MAX_FEE)
+    };
     let mut transactional_state = CachedState::create_transactional(state);
 
     // Strict, negative flow: account nonce = 0, incoming tx nonce = 1.
@@ -1477,10 +1484,11 @@ fn test_valid_flag(
         &[(account_contract, 1), (test_contract, 1)],
     );
 
-    let account_tx = account_invoke_tx(default_invoke_tx_args(
-        account_contract.get_instance_address(0),
-        test_contract.get_instance_address(0),
-    ));
+    let account_tx = account_invoke_tx(invoke_tx_args! {
+        sender_address: account_contract.get_instance_address(0),
+        calldata: create_trivial_calldata(test_contract.get_instance_address(0)),
+        max_fee: Fee(MAX_FEE)
+    });
 
     let actual_execution_info = account_tx.execute(state, block_context, true, false).unwrap();
 


### PR DESCRIPTION
refactor: replaced default_invoke_tx_args with macro that enforces to explicitly define max_fee

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1510)
<!-- Reviewable:end -->
