### PR TITLE
feat: add versioned_constants_13_0.json

### DIFF
--- a/crates/blockifier/resources/versioned_constants_13_0.json
+++ b/crates/blockifier/resources/versioned_constants_13_0.json
@@ -1,0 +1,394 @@
+{
+    "gateway": {
+        "max_calldata_length": 4000,
+        "max_contract_bytecode_size": 61440
+    },
+    "invoke_tx_max_n_steps": 3000000,
+    "max_recursion_depth": 50,
+    "os_constants": {
+        "nop_entry_point_offset": -1,
+        "entry_point_type_external": 0,
+        "entry_point_type_l1_handler": 1,
+        "entry_point_type_constructor": 2,
+        "l1_handler_version": 0,
+        "sierra_array_len_bound": 4294967296,
+        "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+        "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+        "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+        "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+        "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
+        "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+        "default_entry_point_selector": 0,
+        "block_hash_contract_address": 1,
+        "stored_block_hash_buffer": 10,
+        "step_gas_cost": 100,
+        "range_check_gas_cost": 70,
+        "memory_hole_gas_cost": 10,
+        "initial_gas_cost": {
+            "step_gas_cost": 100000000
+        },
+        "entry_point_initial_budget": {
+            "step_gas_cost": 100
+        },
+        "syscall_base_gas_cost": {
+            "step_gas_cost": 100
+        },
+        "entry_point_gas_cost": {
+            "entry_point_initial_budget": 1,
+            "step_gas_cost": 500
+        },
+        "fee_transfer_gas_cost": {
+            "entry_point_gas_cost": 1,
+            "step_gas_cost": 100
+        },
+        "transaction_gas_cost": {
+            "entry_point_gas_cost": 2,
+            "fee_transfer_gas_cost": 1,
+            "step_gas_cost": 100
+        },
+        "call_contract_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 10,
+            "entry_point_gas_cost": 1
+        },
+        "deploy_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 200,
+            "entry_point_gas_cost": 1
+        },
+        "get_block_hash_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "get_execution_info_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 10
+        },
+        "library_call_gas_cost": {
+            "call_contract_gas_cost": 1
+        },
+        "replace_class_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "storage_read_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "storage_write_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "emit_event_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 10
+        },
+        "send_message_to_l1_gas_cost": {
+            "syscall_base_gas_cost": 1,
+            "step_gas_cost": 50
+        },
+        "secp256k1_add_gas_cost": {
+            "step_gas_cost": 406,
+            "range_check_gas_cost": 29
+        },
+        "secp256k1_get_point_from_x_gas_cost": {
+            "step_gas_cost": 391,
+            "range_check_gas_cost": 30,
+            "memory_hole_gas_cost": 20
+        },
+        "secp256k1_get_xy_gas_cost": {
+            "step_gas_cost": 239,
+            "range_check_gas_cost": 11,
+            "memory_hole_gas_cost": 40
+        },
+        "secp256k1_mul_gas_cost": {
+            "step_gas_cost": 76401,
+            "range_check_gas_cost": 7045
+        },
+        "secp256k1_new_gas_cost": {
+            "step_gas_cost": 475,
+            "range_check_gas_cost": 35,
+            "memory_hole_gas_cost": 40
+        },
+        "secp256r1_add_gas_cost": {
+            "step_gas_cost": 589,
+            "range_check_gas_cost": 57
+        },
+        "secp256r1_get_point_from_x_gas_cost": {
+            "step_gas_cost": 510,
+            "range_check_gas_cost": 44,
+            "memory_hole_gas_cost": 20
+        },
+        "secp256r1_get_xy_gas_cost": {
+            "step_gas_cost": 241,
+            "range_check_gas_cost": 11,
+            "memory_hole_gas_cost": 40
+        },
+        "secp256r1_mul_gas_cost": {
+            "step_gas_cost": 125240,
+            "range_check_gas_cost": 13961
+        },
+        "secp256r1_new_gas_cost": {
+            "step_gas_cost": 594,
+            "range_check_gas_cost": 49,
+            "memory_hole_gas_cost": 40
+        },
+        "keccak_gas_cost": {
+            "syscall_base_gas_cost": 1
+        },
+        "keccak_round_cost_gas_cost": 180000,
+        "error_block_number_out_of_range": "Block number out of range",
+        "error_out_of_gas": "Out of gas",
+        "error_invalid_input_len": "Invalid input length",
+        "error_invalid_argument": "Invalid argument",
+        "validated": "VALID",
+        "l1_gas": "L1_GAS",
+        "l2_gas": "L2_GAS",
+        "l1_gas_index": 0,
+        "l2_gas_index": 1
+    },
+    "os_resources": {
+        "execute_syscalls": {
+            "CallContract": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 19
+                },
+                "n_memory_holes": 0,
+                "n_steps": 691
+            },
+            "DelegateCall": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 19
+                },
+                "n_memory_holes": 0,
+                "n_steps": 713
+            },
+            "DelegateL1Handler": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0,
+                "n_steps": 692
+            },
+            "Deploy": {
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 7,
+                    "range_check_builtin": 18
+                },
+                "n_memory_holes": 0,
+                "n_steps": 944
+            },
+            "EmitEvent": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 19
+            },
+            "GetBlockHash": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 2
+                },
+                "n_memory_holes": 0,
+                "n_steps": 74
+            },
+            "GetBlockNumber": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 40
+            },
+            "GetBlockTimestamp": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 38
+            },
+            "GetCallerAddress": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 32
+            },
+            "GetContractAddress": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 36
+            },
+            "GetExecutionInfo": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 29
+            },
+            "GetSequencerAddress": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 34
+            },
+            "GetTxInfo": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 29
+            },
+            "GetTxSignature": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 44
+            },
+            "Keccak": {
+                "builtin_instance_counter": {
+                    "bitwise_builtin": 6,
+                    "keccak_builtin": 1,
+                    "range_check_builtin": 56
+                },
+                "n_memory_holes": 0,
+                "n_steps": 381
+            },
+            "LibraryCall": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 19
+                },
+                "n_memory_holes": 0,
+                "n_steps": 680
+            },
+            "LibraryCallL1Handler": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 15
+                },
+                "n_memory_holes": 0,
+                "n_steps": 659
+            },
+            "ReplaceClass": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 73
+            },
+            "Secp256k1Add": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 29
+                },
+                "n_memory_holes": 0,
+                "n_steps": 406
+            },
+            "Secp256k1GetPointFromX": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 30
+                },
+                "n_memory_holes": 20,
+                "n_steps": 391
+            },
+            "Secp256k1GetXy": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 11
+                },
+                "n_memory_holes": 40,
+                "n_steps": 239
+            },
+            "Secp256k1Mul": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 7045
+                },
+                "n_memory_holes": 0,
+                "n_steps": 76401
+            },
+            "Secp256k1New": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 35
+                },
+                "n_memory_holes": 40,
+                "n_steps": 475
+            },
+            "Secp256r1Add": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 57
+                },
+                "n_memory_holes": 0,
+                "n_steps": 589
+            },
+            "Secp256r1GetPointFromX": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 44
+                },
+                "n_memory_holes": 20,
+                "n_steps": 510
+            },
+            "Secp256r1GetXy": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 11
+                },
+                "n_memory_holes": 40,
+                "n_steps": 241
+            },
+            "Secp256r1Mul": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 13961
+                },
+                "n_memory_holes": 0,
+                "n_steps": 125240
+            },
+            "Secp256r1New": {
+                "builtin_instance_counter": {
+                    "range_check_builtin": 49
+                },
+                "n_memory_holes": 40,
+                "n_steps": 594
+            },
+            "SendMessageToL1": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 84
+            },
+            "StorageRead": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 44
+            },
+            "StorageWrite": {
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+                "n_steps": 46
+            }
+        },
+        "execute_txs_inner": {
+            "Declare": {
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 15,
+                    "range_check_builtin": 63
+                },
+                "n_memory_holes": 0,
+                "n_steps": 2711
+            },
+            "DeployAccount": {
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 23,
+                    "range_check_builtin": 83
+                },
+                "n_memory_holes": 0,
+                "n_steps": 3628
+            },
+            "InvokeFunction": {
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 16,
+                    "range_check_builtin": 80
+                },
+                "n_memory_holes": 0,
+                "n_steps": 3382
+            },
+            "L1Handler": {
+                "builtin_instance_counter": {
+                    "pedersen_builtin": 11,
+                    "range_check_builtin": 17
+                },
+                "n_memory_holes": 0,
+                "n_steps": 1069
+            }
+        }
+    },
+    "validate_max_n_steps": 1000000,
+    "vm_resource_fee_cost": {
+        "bitwise_builtin": 0.32,
+        "ec_op_builtin": 5.12,
+        "ecdsa_builtin": 10.24,
+        "keccak_builtin": 10.24,
+        "n_steps": 0.005,
+        "output_builtin": 0,
+        "pedersen_builtin": 0.16,
+        "poseidon_builtin": 0.16,
+        "range_check_builtin": 0.08
+    }
+}


### PR DESCRIPTION
Changes between this and the current versioned_constants:
- no `event_size_limit`
- invoke_tx_max_n_steps is 3_000_000 instead of 4_000_000
- no `l2_resource_gas_costs`
- multiple value changes in os_resources
- `vm_resource_fee_cost` is X2 for all values.

No other changes (in particular, os constants is indeed _unchanged_)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1520)
<!-- Reviewable:end -->
