### PR TITLE
fix: versioned constants validate

### DIFF
--- a/crates/blockifier/src/versioned_constants.rs
+++ b/crates/blockifier/src/versioned_constants.rs
@@ -301,8 +301,8 @@ impl<'de> Deserialize<'de> for OsResources {
 
         // Validations.
 
-        #[cfg(not(any(feature = "testing", test)))]
-        validate(&os_resources);
+        #[cfg(not(test))]
+        os_resources.validate::<D>()?;
 
         Ok(os_resources)
     }
@@ -445,7 +445,7 @@ impl TryFrom<OsConstantsRawJson> for OSConstants {
         let os_constants = OSConstants { gas_costs, validate_rounding_consts };
 
         // Skip validation in testing: to test validation run validate manually.
-        #[cfg(not(any(feature = "testing", test)))]
+        #[cfg(not(test))]
         os_constants.validate()?;
 
         Ok(os_constants)


### PR DESCRIPTION
- validate invocation had a syntax error, which was hidden by the cfg
- remove `testing` from the cfg, since we all compile with `testing` during development, and it's just not what we want.

Python: https://reviewable.io/reviews/starkware-industries/starkware/34038

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1537)
<!-- Reviewable:end -->
