### PR TITLE
refactor: make StateError::UndeclaredClassHash a one-line error

### DIFF
--- a/crates/blockifier/src/state/errors.rs
+++ b/crates/blockifier/src/state/errors.rs
@@ -18,7 +18,7 @@ pub enum StateError {
     ProgramError(#[from] ProgramError),
     #[error("Requested {0:?} is unavailable for deployment.")]
     UnavailableContractAddress(ContractAddress),
-    #[error("Class with hash {0:#?} is not declared.")]
+    #[error("Class with hash {0} is not declared.")]
     UndeclaredClassHash(ClassHash),
     #[error(transparent)]
     StarknetApiError(#[from] StarknetApiError),


### PR DESCRIPTION
Change previous error which prints out as:
```
Class with hash ClassHash(
    StarkFelt(
        "0x00000000000000000000000000000000000000000000000000000000000004d2",
    ),
) is not declared.
```
into:
```
Class with hash 0x00000000000000000000000000000000000000000000000000000000000004d2 is not declared.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1563)
<!-- Reviewable:end -->
