### PR TITLE
refactor: changed call_infos input type to avoid clone usage

### DIFF
--- a/crates/blockifier/src/blockifier/transaction_executor.rs
+++ b/crates/blockifier/src/blockifier/transaction_executor.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::vec::IntoIter;
 
 use cairo_vm::vm::runners::builtin_runner::HASH_BUILTIN_NAME;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
@@ -100,14 +99,13 @@ impl<S: StateReader> TransactionExecutor<S> {
                 let tx_execution_summary = tx_execution_info.summarize();
 
                 // Count message to L1 resources.
-                let call_infos: IntoIter<&CallInfo> =
+                let call_infos: Vec<&CallInfo> =
                     [&tx_execution_info.validate_call_info, &tx_execution_info.execute_call_info]
                         .iter()
                         .filter_map(|&call_info| call_info.as_ref())
-                        .collect::<Vec<&CallInfo>>()
-                        .into_iter();
+                        .collect::<Vec<&CallInfo>>();
                 let MessageL1CostInfo { l2_to_l1_payload_lengths, message_segment_length } =
-                    MessageL1CostInfo::calculate(call_infos, l1_handler_payload_size)?;
+                    MessageL1CostInfo::calculate(&call_infos, l1_handler_payload_size)?;
 
                 let starknet_gas_usage = get_starknet_gas_usage(
                     message_segment_length,

--- a/crates/blockifier/src/execution/call_info.rs
+++ b/crates/blockifier/src/execution/call_info.rs
@@ -3,6 +3,7 @@ use std::iter::Sum;
 use std::ops::Add;
 
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use starknet_api::core::{ClassHash, ContractAddress, EthAddress, PatriciaKey};
 use starknet_api::hash::{StarkFelt, StarkHash};
@@ -40,14 +41,17 @@ pub struct MessageL1CostInfo {
 }
 
 impl MessageL1CostInfo {
-    pub fn calculate<'a>(
-        call_infos: impl Iterator<Item = &'a CallInfo>,
+    pub fn calculate(
+        call_infos: &[&CallInfo],
         l1_handler_payload_size: Option<usize>,
     ) -> TransactionExecutionResult<Self> {
-        let mut l2_to_l1_payload_lengths = Vec::new();
-        for call_info in call_infos {
-            l2_to_l1_payload_lengths.extend(call_info.get_sorted_l2_to_l1_payload_lengths()?);
-        }
+        let l2_to_l1_payload_lengths: Vec<usize> = call_infos
+            .iter()
+            .map(|call_info| call_info.get_sorted_l2_to_l1_payload_lengths())
+            .try_collect::<Vec<usize>, Vec<Vec<usize>>, TransactionExecutionError>()?
+            .into_iter()
+            .flatten()
+            .collect();
 
         let message_segment_length =
             get_message_segment_length(&l2_to_l1_payload_lengths, l1_handler_payload_size);

--- a/crates/blockifier/src/fee/actual_cost.rs
+++ b/crates/blockifier/src/fee/actual_cost.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use itertools::Itertools;
 use starknet_api::core::ContractAddress;
 use starknet_api::transaction::Fee;
 
@@ -161,13 +162,14 @@ impl<'a> ActualCostBuilder<'a> {
         );
         // TODO(Dafna, 1/6/2024): Compute the DA size and pass it instead of state_changes_count.
         let da_gas = self.starknet_resources.get_state_changes_cost(use_kzg_da);
-        let non_optional_call_infos =
-            self.validate_call_info.into_iter().chain(self.execute_call_info);
+        let non_optional_call_infos: Vec<&'a CallInfo> =
+            self.validate_call_info.into_iter().chain(self.execute_call_info).collect_vec();
+
         // Gas usage for SHARP costs and Starknet L1-L2 messages. Includes gas usage for data
         // availability.
         let gas_usage_vector = Self::calculate_tx_gas_usage_vector(
             &self.tx_context.block_context.versioned_constants,
-            non_optional_call_infos,
+            &non_optional_call_infos,
             &self.starknet_resources,
             self.l1_payload_size,
             use_kzg_da,
@@ -209,12 +211,12 @@ impl<'a> ActualCostBuilder<'a> {
     /// * L2 resources cost, e.g., for storing transaction calldata.
     fn calculate_tx_gas_usage_vector(
         versioned_constants: &VersionedConstants,
-        call_infos: impl Iterator<Item = &'a CallInfo> + Clone,
+        call_infos: &[&CallInfo],
         starknet_resources: &StarknetResources,
         l1_handler_payload_size: Option<usize>,
         use_kzg_da: bool,
     ) -> TransactionExecutionResult<GasVector> {
-        Ok(get_messages_gas_cost(call_infos.clone(), l1_handler_payload_size)?
+        Ok(get_messages_gas_cost(call_infos, l1_handler_payload_size)?
             + starknet_resources.to_gas_vector(versioned_constants, use_kzg_da)
             + get_tx_events_gas_cost(call_infos, versioned_constants))
     }

--- a/crates/blockifier/src/fee/actual_cost_test.rs
+++ b/crates/blockifier/src/fee/actual_cost_test.rs
@@ -29,6 +29,20 @@ fn versioned_constants() -> &'static VersionedConstants {
     VersionedConstants::latest_constants()
 }
 
+fn create_callinfo(l2_to_l1_payload_size: usize) -> CallInfo {
+    let payload_vec = vec![stark_felt!(0_u16); l2_to_l1_payload_size];
+    CallInfo {
+        execution: CallExecution {
+            l2_to_l1_messages: vec![OrderedL2ToL1Message {
+                message: MessageToL1 { payload: L2ToL1Payload(payload_vec), ..Default::default() },
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
 /// This test goes over seven cases. In each case, we calculate the gas usage given the parameters.
 /// We then perform the same calculation manually, each time using only the relevant parameters.
 /// The seven cases are:
@@ -47,7 +61,7 @@ fn test_calculate_tx_gas_usage_basic(#[values(false, true)] use_kzg_da: bool) {
     let versioned_constants = VersionedConstants::default();
     let empty_tx_gas_usage_vector = ActualCostBuilder::calculate_tx_gas_usage_vector(
         &versioned_constants,
-        std::iter::empty(),
+        &Vec::default(),
         &StarknetResources::default(),
         None,
         use_kzg_da,
@@ -71,7 +85,7 @@ fn test_calculate_tx_gas_usage_basic(#[values(false, true)] use_kzg_da: bool) {
             GasVector { l1_gas: code_gas_cost.to_integer(), ..Default::default() };
         let declare_gas_usage_vector = ActualCostBuilder::calculate_tx_gas_usage_vector(
             &versioned_constants,
-            std::iter::empty(),
+            &Vec::default(),
             &declare_tx_starknet_resources,
             None,
             use_kzg_da,
@@ -107,7 +121,7 @@ fn test_calculate_tx_gas_usage_basic(#[values(false, true)] use_kzg_da: bool) {
 
     let deploy_account_gas_usage_vector = ActualCostBuilder::calculate_tx_gas_usage_vector(
         &versioned_constants,
-        std::iter::empty(),
+        &Vec::default(),
         &deploy_tx_starknet_resources,
         None,
         use_kzg_da,
@@ -126,7 +140,7 @@ fn test_calculate_tx_gas_usage_basic(#[values(false, true)] use_kzg_da: bool) {
     );
     let l1_handler_gas_usage_vector = ActualCostBuilder::calculate_tx_gas_usage_vector(
         &versioned_constants,
-        std::iter::empty(),
+        &Vec::default(),
         &l1_handler_tx_starknet_resources,
         Some(l1_handler_payload_size),
         use_kzg_da,
@@ -152,32 +166,20 @@ fn test_calculate_tx_gas_usage_basic(#[values(false, true)] use_kzg_da: bool) {
     assert_eq!(l1_handler_gas_usage_vector, manual_gas_computation);
 
     // Any transaction with L2-to-L1 messages.
-
-    let mut call_infos = Vec::new();
-
-    for i in 0..4 {
-        let payload_vec = vec![stark_felt!(0_u16); i];
-
-        let call_info = CallInfo {
-            execution: CallExecution {
-                l2_to_l1_messages: vec![OrderedL2ToL1Message {
-                    message: MessageToL1 {
-                        payload: L2ToL1Payload(payload_vec),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                }],
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        call_infos.push(call_info);
-    }
+    let call_info_0 = create_callinfo(0);
+    let call_info_1 = create_callinfo(1);
+    let call_info_2 = create_callinfo(2);
+    let call_info_3 = create_callinfo(3);
+    let call_infos: Vec<&CallInfo> = call_info_0
+        .into_iter()
+        .chain(&call_info_1)
+        .chain(&call_info_2)
+        .chain(&call_info_3)
+        .collect();
 
     // l2_to_l1_payload_lengths is [0, 1, 2, 3]
-    let call_infos_iter = call_infos.iter();
-    let l2_to_l1_payload_lengths: Vec<usize> = call_infos_iter
+    let l2_to_l1_payload_lengths: Vec<usize> = call_infos
+        .iter()
         .clone()
         .flat_map(|call_info| call_info.get_sorted_l2_to_l1_payload_lengths().unwrap())
         .collect();
@@ -192,7 +194,7 @@ fn test_calculate_tx_gas_usage_basic(#[values(false, true)] use_kzg_da: bool) {
         StarknetResources::new(0, 0, None, l2_to_l1_state_changes_count);
     let l2_to_l1_messages_gas_usage_vector = ActualCostBuilder::calculate_tx_gas_usage_vector(
         &versioned_constants,
-        call_infos_iter.clone(),
+        &call_infos,
         &l2_to_l1_starknet_resources,
         None,
         use_kzg_da,
@@ -233,7 +235,7 @@ fn test_calculate_tx_gas_usage_basic(#[values(false, true)] use_kzg_da: bool) {
         StarknetResources::new(0, 0, None, storage_writes_state_changes_count);
     let storage_writings_gas_usage_vector = ActualCostBuilder::calculate_tx_gas_usage_vector(
         &versioned_constants,
-        std::iter::empty(),
+        &Vec::default(),
         &storage_writes_starknet_resources,
         None,
         use_kzg_da,
@@ -262,7 +264,7 @@ fn test_calculate_tx_gas_usage_basic(#[values(false, true)] use_kzg_da: bool) {
     );
     let gas_usage_vector = ActualCostBuilder::calculate_tx_gas_usage_vector(
         &versioned_constants,
-        call_infos_iter,
+        &call_infos,
         &combined_cases_starknet_resources,
         Some(l1_handler_payload_size),
         use_kzg_da,
@@ -331,7 +333,7 @@ fn test_calculate_tx_gas_usage(#[values(false, true)] use_kzg_da: bool) {
 
     let gas_vector = ActualCostBuilder::calculate_tx_gas_usage_vector(
         versioned_constants,
-        std::iter::empty(),
+        &Vec::default(),
         &starknet_resources,
         None,
         use_kzg_da,
@@ -382,7 +384,7 @@ fn test_calculate_tx_gas_usage(#[values(false, true)] use_kzg_da: bool) {
         StarknetResources::new(calldata_length, signature_length, None, state_changes_count);
     let gas_vector = ActualCostBuilder::calculate_tx_gas_usage_vector(
         versioned_constants,
-        std::iter::empty(),
+        &Vec::default(),
         &starknet_resources,
         None,
         use_kzg_da,

--- a/crates/blockifier/src/fee/gas_usage.rs
+++ b/crates/blockifier/src/fee/gas_usage.rs
@@ -18,12 +18,13 @@ use crate::versioned_constants::{ResourceCost, VersionedConstants};
 #[path = "gas_usage_test.rs"]
 pub mod test;
 
-pub fn get_tx_events_gas_cost<'a>(
-    call_infos: impl Iterator<Item = &'a CallInfo>,
+pub fn get_tx_events_gas_cost(
+    call_infos: &[&CallInfo],
     versioned_constants: &VersionedConstants,
 ) -> GasVector {
-    let l1_gas = call_infos
-        .map(|call_info| get_events_gas_cost(&call_info.execution.events, versioned_constants))
+    let l1_gas: u128 = call_infos
+        .iter()
+        .map(|call_info| (get_events_gas_cost(&call_info.execution.events, versioned_constants)))
         .sum();
     GasVector::from_l1_gas(l1_gas)
 }
@@ -76,8 +77,8 @@ pub fn get_starknet_gas_usage(
 
 /// Returns an estimation of the gas usage for processing L1<>L2 messages on L1. Accounts for both
 /// Starknet and SHARP contracts.
-pub fn get_messages_gas_cost<'a>(
-    call_infos: impl Iterator<Item = &'a CallInfo>,
+pub fn get_messages_gas_cost(
+    call_infos: &[&CallInfo],
     l1_handler_payload_size: Option<usize>,
 ) -> TransactionExecutionResult<GasVector> {
     let MessageL1CostInfo { l2_to_l1_payload_lengths, message_segment_length } =

--- a/crates/blockifier/src/fee/gas_usage_test.rs
+++ b/crates/blockifier/src/fee/gas_usage_test.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use pretty_assertions::assert_eq;
 use rstest::{fixture, rstest};
 use starknet_api::hash::StarkFelt;
@@ -25,8 +26,8 @@ fn test_get_event_gas_cost(versioned_constants: &VersionedConstants) {
     let call_info_1 = &CallInfo::default();
     let call_info_2 = &CallInfo::default();
     let call_info_3 = &CallInfo::default();
-    let call_infos = call_info_1.into_iter().chain(call_info_2).chain(call_info_3);
-    assert_eq!(GasVector::default(), get_tx_events_gas_cost(call_infos, versioned_constants));
+    let call_infos = call_info_1.into_iter().chain(call_info_2).chain(call_info_3).collect_vec();
+    assert_eq!(GasVector::default(), get_tx_events_gas_cost(&call_infos, versioned_constants));
 
     let create_event = |keys_size: usize, data_size: usize| OrderedEvent {
         order: 0,
@@ -57,12 +58,12 @@ fn test_get_event_gas_cost(versioned_constants: &VersionedConstants) {
         }],
         ..Default::default()
     };
-    let call_infos = call_info_1.into_iter().chain(call_info_2).chain(call_info_3);
+    let call_infos = call_info_1.into_iter().chain(call_info_2).chain(call_info_3).collect_vec();
     let expected = GasVector::from_l1_gas(
         // 4 keys and 6 data words overall.
         (data_word_cost * (event_key_factor * 4_u128 + 6_u128)).to_integer(),
     );
-    let gas_vector = get_tx_events_gas_cost(call_infos, versioned_constants);
+    let gas_vector = get_tx_events_gas_cost(&call_infos, versioned_constants);
     assert_eq!(expected, gas_vector);
     assert_ne!(GasVector::default(), gas_vector)
 }


### PR DESCRIPTION
clone was [here](https://github.com/starkware-libs/blockifier/blob/main/crates/blockifier/src/fee/actual_cost.rs#L217C45-L217C50)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1637)
<!-- Reviewable:end -->
