### PR TITLE
chore: fix docstring of tx_executor execute

### DIFF
--- a/crates/blockifier/src/blockifier/transaction_executor.rs
+++ b/crates/blockifier/src/blockifier/transaction_executor.rs
@@ -77,8 +77,8 @@ impl<S: StateReader> TransactionExecutor<S> {
     }
 
     /// Executes the given transaction on the state maintained by the executor.
-    /// Returns the execution trace, together with the compiled class hashes of executed classes
-    /// (used for counting purposes).
+    /// Returns the execution trace and the resources consumed by the transaction (required for the
+    /// bouncer).
     pub fn execute(
         &mut self,
         tx: Transaction,


### PR DESCRIPTION
The docstring was not updated since is was first created in: #447.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1651)
<!-- Reviewable:end -->
