### PR TITLE
refactor(concurrency): use ` ThreadSafeVersionedState ` in tests and define appropriate methods

### DIFF
--- a/crates/blockifier/src/concurrency/test_utils.rs
+++ b/crates/blockifier/src/concurrency/test_utils.rs
@@ -1,6 +1,4 @@
-use std::sync::{Arc, Mutex};
-
-use crate::concurrency::versioned_state_proxy::VersionedState;
+use crate::concurrency::versioned_state_proxy::{ThreadSafeVersionedState, VersionedState};
 use crate::test_utils::dict_state_reader::DictStateReader;
 
 #[macro_export]
@@ -32,10 +30,8 @@ macro_rules! default_scheduler {
 }
 
 // TODO(meshi, 01/06/2024): Consider making this a macro.
-// TODO: Use `ThreadSafeVersionedState` as a return value, need to change the inner field to public,
-// or add new method that gets `StateReader`.
-pub fn versioned_state_for_testing(
+pub fn safe_versioned_state_for_testing(
     block_state: DictStateReader,
-) -> Arc<Mutex<VersionedState<DictStateReader>>> {
-    Arc::new(Mutex::new(VersionedState::new(block_state)))
+) -> ThreadSafeVersionedState<DictStateReader> {
+    ThreadSafeVersionedState::new(VersionedState::new(block_state))
 }

--- a/crates/blockifier/src/concurrency/versioned_state_proxy.rs
+++ b/crates/blockifier/src/concurrency/versioned_state_proxy.rs
@@ -145,8 +145,16 @@ pub struct ThreadSafeVersionedState<S: StateReader>(Arc<Mutex<VersionedState<S>>
 pub type LockedVersionedState<'a, S> = MutexGuard<'a, VersionedState<S>>;
 
 impl<S: StateReader> ThreadSafeVersionedState<S> {
+    pub fn new(versioned_state: VersionedState<S>) -> Self {
+        ThreadSafeVersionedState(Arc::new(Mutex::new(versioned_state)))
+    }
+
     pub fn pin_version(&self, tx_index: TxIndex) -> VersionedStateProxy<S> {
         VersionedStateProxy { tx_index, state: self.0.clone() }
+    }
+
+    pub fn state(&self) -> LockedVersionedState<'_, S> {
+        self.0.lock().expect("Failed to acquire state lock.")
     }
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1857)
<!-- Reviewable:end -->
