### PR TITLE
fix(concurrency): remove unneeded validation at the end of test_worker_validate

### DIFF
--- a/crates/blockifier/src/concurrency/worker_logic_test.rs
+++ b/crates/blockifier/src/concurrency/worker_logic_test.rs
@@ -296,9 +296,6 @@ fn test_worker_validate() {
     );
     // Verify status change.
     assert_eq!(*worker_executor.scheduler.get_tx_status(tx_index), TransactionStatus::Executing);
-
-    let next_task2 = worker_executor.validate(tx_index);
-    assert_eq!(next_task2, Task::NoTask);
 }
 use cairo_felt::Felt252;
 use rstest::rstest;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1938)
<!-- Reviewable:end -->
