### PR TITLE
fix: bug - os kzg resources is not zero in old versions

### DIFF
--- a/crates/blockifier/src/versioned_constants.rs
+++ b/crates/blockifier/src/versioned_constants.rs
@@ -375,6 +375,12 @@ impl OsResources {
     }
 
     fn os_kzg_da_resources(&self, data_segment_length: usize) -> ExecutionResources {
+        // BACKWARD COMPATIBILITY: we set compute_os_kzg_commitment_info to empty in older versions
+        // where this was not yet computed.
+        let empty_resources = ExecutionResources::default();
+        if self.compute_os_kzg_commitment_info == empty_resources {
+            return empty_resources;
+        }
         &(&self.compute_os_kzg_commitment_info * data_segment_length)
             + &poseidon_hash_many_cost(data_segment_length)
     }

--- a/crates/blockifier/src/versioned_constants_test.rs
+++ b/crates/blockifier/src/versioned_constants_test.rs
@@ -27,11 +27,11 @@ fn test_successful_gas_costs_parsing() {
     assert_eq!(versioned_constants.os_constants.gas_costs.step_gas_cost, 2);
     assert_eq!(versioned_constants.os_constants.gas_costs.entry_point_initial_budget, 2 * 3); // step_gas_cost * 3.
 
-    // entry_point_intial_budget * 4 + step_gas_cost * 5.
+    // entry_point_initial_budget * 4 + step_gas_cost * 5.
     assert_eq!(versioned_constants.os_constants.gas_costs.entry_point_gas_cost, 6 * 4 + 2 * 5);
 }
 
-fn get_json_value_without_dafaults() -> serde_json::Value {
+fn get_json_value_without_defaults() -> serde_json::Value {
     let json_data = r#"
     {
         "invoke_tx_max_n_steps": 2,
@@ -77,21 +77,21 @@ fn get_json_value_without_dafaults() -> serde_json::Value {
     // Remove defaults from OsConstants.
     os_constants.as_object_mut().unwrap().remove("validate_rounding_consts");
 
-    let mut json_value_without_defualts: Value = serde_json::from_str(json_data).unwrap();
-    json_value_without_defualts
+    let mut json_value_without_defaults: Value = serde_json::from_str(json_data).unwrap();
+    json_value_without_defaults
         .as_object_mut()
         .unwrap()
         .insert("os_constants".to_string(), os_constants);
 
-    json_value_without_defualts
+    json_value_without_defaults
 }
 
 #[test]
 fn test_default_values() {
-    let json_value_without_defualts = get_json_value_without_dafaults();
+    let json_value_without_defaults = get_json_value_without_defaults();
 
     let versioned_constants: VersionedConstants =
-        serde_json::from_value(json_value_without_defualts).unwrap();
+        serde_json::from_value(json_value_without_defaults).unwrap();
 
     assert_eq!(versioned_constants.get_validate_block_number_rounding(), 1);
     assert_eq!(versioned_constants.get_validate_timestamp_rounding(), 1);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1942)
<!-- Reviewable:end -->
