### PR TITLE
refactor(concurrency): use test_state instead of test_state_reader in…

### DIFF
--- a/crates/blockifier/src/concurrency/test_utils.rs
+++ b/crates/blockifier/src/concurrency/test_utils.rs
@@ -56,8 +56,8 @@ macro_rules! default_scheduler {
 
 // TODO(meshi, 01/06/2024): Consider making this a macro.
 pub fn safe_versioned_state_for_testing(
-    block_state: DictStateReader,
-) -> ThreadSafeVersionedState<DictStateReader> {
+    block_state: CachedState<DictStateReader>,
+) -> ThreadSafeVersionedState<CachedState<DictStateReader>> {
     ThreadSafeVersionedState::new(VersionedState::new(block_state))
 }
 

--- a/crates/blockifier/src/concurrency/worker_logic_test.rs
+++ b/crates/blockifier/src/concurrency/worker_logic_test.rs
@@ -19,7 +19,7 @@ use crate::state::cached_state::StateMaps;
 use crate::state::state_api::StateReader;
 use crate::test_utils::contracts::FeatureContract;
 use crate::test_utils::declare::declare_tx;
-use crate::test_utils::initial_test_state::test_state_reader;
+use crate::test_utils::initial_test_state::test_state;
 use crate::test_utils::{
     create_calldata, CairoVersion, NonceManager, BALANCE, MAX_FEE, MAX_L1_GAS_AMOUNT,
     MAX_L1_GAS_PRICE, TEST_ERC20_CONTRACT_ADDRESS,
@@ -43,9 +43,8 @@ fn test_worker_execute() {
     let chain_info = &block_context.chain_info;
 
     // Create the state.
-    let state_reader =
-        test_state_reader(chain_info, BALANCE, &[(account_contract, 1), (test_contract, 1)]);
-    let safe_versioned_state = safe_versioned_state_for_testing(state_reader);
+    let state = test_state(chain_info, BALANCE, &[(account_contract, 1), (test_contract, 1)]);
+    let safe_versioned_state = safe_versioned_state_for_testing(state);
 
     // Create transactions.
     let test_contract_address = test_contract.get_instance_address(0);
@@ -216,9 +215,8 @@ fn test_worker_validate() {
     let chain_info = &block_context.chain_info;
 
     // Create the state.
-    let state_reader =
-        test_state_reader(chain_info, BALANCE, &[(account_contract, 1), (test_contract, 1)]);
-    let safe_versioned_state = safe_versioned_state_for_testing(state_reader);
+    let state = test_state(chain_info, BALANCE, &[(account_contract, 1), (test_contract, 1)]);
+    let safe_versioned_state = safe_versioned_state_for_testing(state);
 
     // Create transactions.
     let test_contract_address = test_contract.get_instance_address(0);
@@ -320,11 +318,8 @@ pub fn test_add_fee_to_sequencer_balance(
     let tx_index = 0;
     let block_context = BlockContext::create_for_account_testing_with_concurrency_mode(true);
     let account = FeatureContract::Empty(CairoVersion::Cairo1);
-    let safe_versioned_state = safe_versioned_state_for_testing(test_state_reader(
-        &block_context.chain_info,
-        0,
-        &[(account, 1)],
-    ));
+    let safe_versioned_state =
+        safe_versioned_state_for_testing(test_state(&block_context.chain_info, 0, &[(account, 1)]));
     let mut tx_versioned_state = safe_versioned_state.pin_version(tx_index);
     let (sequencer_balance_key_low, sequencer_balance_key_high) =
         get_sequencer_balance_keys(&block_context);
@@ -371,8 +366,8 @@ fn test_deploy_before_declare() {
     let block_context = BlockContext::create_for_account_testing_with_concurrency_mode(true);
     let chain_info = &block_context.chain_info;
     let account_contract = FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1);
-    let state_reader = test_state_reader(chain_info, BALANCE, &[(account_contract, 2)]);
-    let safe_versioned_state = safe_versioned_state_for_testing(state_reader);
+    let state = test_state(chain_info, BALANCE, &[(account_contract, 2)]);
+    let safe_versioned_state = safe_versioned_state_for_testing(state);
 
     // Create transactions.
     let account_address_0 = account_contract.get_instance_address(0);

--- a/crates/blockifier/src/test_utils/initial_test_state.rs
+++ b/crates/blockifier/src/test_utils/initial_test_state.rs
@@ -37,11 +37,11 @@ pub fn fund_account(
 /// * "Declares" the input list of contracts.
 /// * "Deploys" the requested number of instances of each input contract.
 /// * Makes each input account contract privileged.
-pub fn test_state_reader(
+pub fn test_state(
     chain_info: &ChainInfo,
     initial_balances: u128,
     contract_instances: &[(FeatureContract, u16)],
-) -> DictStateReader {
+) -> CachedState<DictStateReader> {
     let mut class_hash_to_class = HashMap::new();
     let mut address_to_class_hash = HashMap::new();
 
@@ -81,14 +81,5 @@ pub fn test_state_reader(
         }
     }
 
-    state_reader
-}
-
-/// Initializes a state for testing, with the output of test_state_reader as the initial state.
-pub fn test_state(
-    chain_info: &ChainInfo,
-    initial_balances: u128,
-    contract_instances: &[(FeatureContract, u16)],
-) -> CachedState<DictStateReader> {
-    CachedState::from(test_state_reader(chain_info, initial_balances, contract_instances))
+    CachedState::from(state_reader)
 }


### PR DESCRIPTION
… testing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1943)
<!-- Reviewable:end -->
