### PR TITLE
Feature: derive Clone for call info related types

### DIFF
--- a/crates/blockifier/src/execution/call_info.rs
+++ b/crates/blockifier/src/execution/call_info.rs
@@ -23,8 +23,7 @@ macro_rules! retdata {
     };
 }
 
-#[cfg_attr(test, derive(Clone))]
-#[derive(Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct OrderedEvent {
     pub order: usize,
     pub event: EventContent,
@@ -53,23 +52,20 @@ impl MessageL1CostInfo {
     }
 }
 
-#[cfg_attr(test, derive(Clone))]
-#[derive(Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct MessageToL1 {
     pub to_address: EthAddress,
     pub payload: L2ToL1Payload,
 }
 
-#[cfg_attr(test, derive(Clone))]
-#[derive(Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct OrderedL2ToL1Message {
     pub order: usize,
     pub message: MessageToL1,
 }
 
 /// Represents the effects of executing a single entry point.
-#[cfg_attr(test, derive(Clone))]
-#[derive(Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct CallExecution {
     pub retdata: Retdata,
     pub events: Vec<OrderedEvent>,
@@ -88,7 +84,7 @@ struct ExecutionResourcesDef {
 }
 
 /// Represents the full effects of executing an entry point, including the inner calls it invoked.
-#[derive(Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct CallInfo {
     pub call: CallEntryPoint,
     pub execution: CallExecution,

--- a/crates/blockifier/src/execution/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/entry_point_execution.rs
@@ -36,6 +36,7 @@ pub struct VmExecutionContext<'a> {
     pub program_extra_data_length: usize,
 }
 
+#[derive(Clone, Debug)]
 pub struct CallResult {
     pub failed: bool,
     pub retdata: Retdata,


### PR DESCRIPTION
Context: Starknet OS port to Rust.

The current port relies on a fork of Blockifier which implements these traits. If this can go upstream this would make our life easier.