### PR TITLE
refactor(concurrency): change worker executor field block context to reference

### DIFF
--- a/crates/blockifier/src/concurrency/worker_logic.rs
+++ b/crates/blockifier/src/concurrency/worker_logic.rs
@@ -48,14 +48,14 @@ pub struct WorkerExecutor<'a, S: StateReader> {
     pub state: ThreadSafeVersionedState<S>,
     pub chunk: &'a [Transaction],
     pub execution_outputs: Box<[Mutex<Option<ExecutionTaskOutput>>]>,
-    pub block_context: BlockContext,
+    pub block_context: &'a BlockContext,
     pub bouncer: Mutex<&'a mut Bouncer>,
 }
 impl<'a, S: StateReader> WorkerExecutor<'a, S> {
     pub fn new(
         state: ThreadSafeVersionedState<S>,
         chunk: &'a [Transaction],
-        block_context: BlockContext,
+        block_context: &'a BlockContext,
         bouncer: Mutex<&'a mut Bouncer>,
     ) -> Self {
         let scheduler = Scheduler::new(chunk.len());
@@ -106,7 +106,7 @@ impl<'a, S: StateReader> WorkerExecutor<'a, S> {
         let charge_fee = true;
 
         let execution_result =
-            tx.execute_raw(&mut transactional_state, &self.block_context, charge_fee, validate);
+            tx.execute_raw(&mut transactional_state, self.block_context, charge_fee, validate);
 
         if execution_result.is_ok() {
             // TODO(Noa, 15/05/2024): use `tx_versioned_state` when we add support to transactional
@@ -283,7 +283,7 @@ impl<'a, S: StateReader> WorkerExecutor<'a, S> {
                 tx_context.fee_token_address(),
                 &mut tx_versioned_state,
                 tx_execution_info.actual_fee,
-                &self.block_context,
+                self.block_context,
                 sequencer_balance_value_low,
                 sequencer_balance_value_high,
             );

--- a/crates/blockifier/src/concurrency/worker_logic_test.rs
+++ b/crates/blockifier/src/concurrency/worker_logic_test.rs
@@ -101,7 +101,7 @@ fn test_worker_execute() {
     let worker_executor = WorkerExecutor::new(
         safe_versioned_state.clone(),
         &txs,
-        block_context,
+        &block_context,
         Mutex::new(&mut bouncer),
     );
 
@@ -266,7 +266,7 @@ fn test_worker_validate() {
     let worker_executor = WorkerExecutor::new(
         safe_versioned_state.clone(),
         &txs,
-        block_context,
+        &block_context,
         Mutex::new(&mut bouncer),
     );
 
@@ -424,7 +424,7 @@ fn test_deploy_before_declare() {
 
     let mut bouncer = Bouncer::new(BouncerConfig::default());
     let worker_executor =
-        WorkerExecutor::new(safe_versioned_state, &txs, block_context, Mutex::new(&mut bouncer));
+        WorkerExecutor::new(safe_versioned_state, &txs, &block_context, Mutex::new(&mut bouncer));
 
     // Creates 2 active tasks.
     worker_executor.scheduler.next_task();
@@ -515,7 +515,7 @@ fn test_worker_commit_phase() {
 
     let mut bouncer = Bouncer::new(BouncerConfig::default());
     let worker_executor =
-        WorkerExecutor::new(safe_versioned_state, &txs, block_context, Mutex::new(&mut bouncer));
+        WorkerExecutor::new(safe_versioned_state, &txs, &block_context, Mutex::new(&mut bouncer));
 
     // Try to commit before any transaction is ready.
     worker_executor.commit_while_possible();


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1958)
<!-- Reviewable:end -->
