### PR TITLE
fix(concurrency): fix usage of invoke_tx_args! macro with redundent field name

### DIFF
--- a/crates/blockifier/src/concurrency/worker_logic_test.rs
+++ b/crates/blockifier/src/concurrency/worker_logic_test.rs
@@ -47,7 +47,7 @@ fn trivial_calldata_invoke_tx(
         calldata: create_trivial_calldata(test_contract_address),
         resource_bounds: l1_resource_bounds(MAX_L1_GAS_AMOUNT, MAX_L1_GAS_PRICE),
         version: TransactionVersion::THREE,
-        nonce: nonce,
+        nonce,
     })
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1985)
<!-- Reviewable:end -->
