### PR TITLE
fix(concurrency): stop the transaction committer when the scheduler is done

### DIFF
--- a/crates/blockifier/src/concurrency/scheduler.rs
+++ b/crates/blockifier/src/concurrency/scheduler.rs
@@ -22,9 +22,13 @@ impl<'a> TransactionCommitter<'a> {
     /// Tries to commit the next uncommitted transaction in the chunk. Returns the index of the
     /// transaction to commit if successful, or None if the transaction is not yet executed.
     pub fn try_commit(&mut self) -> Option<usize> {
-        if *self.commit_index_guard >= self.scheduler.chunk_size {
+        if self.scheduler.done() {
             return None;
         };
+        assert!(
+            *self.commit_index_guard < self.scheduler.chunk_size,
+            "The commit index must be less than the chunk size, since the scheduler is not done."
+        );
 
         let mut status = self.scheduler.lock_tx_status(*self.commit_index_guard);
         if *status != TransactionStatus::Executed {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1989)
<!-- Reviewable:end -->
