### PR TITLE
fix: remove workspace.lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,13 +56,3 @@ strum_macros = "0.24.3"
 tempfile = "3.7.0"
 test-case = "2.2.2"
 thiserror = "1.0.37"
-
-[workspace.lints.rust]
-future-incompatible = "deny"
-nonstandard-style = "deny"
-rust-2018-idioms = "deny"
-unused = "deny"
-warnings = "deny"
-
-[workspace.lints.clippy]
-as_conversions = "deny"

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -6,8 +6,15 @@ repository.workspace = true
 license-file.workspace = true
 description = "The transaction-executing component in the Starknet sequencer."
 
-[lints]
-workspace = true
+[lints.rust]
+future-incompatible = "deny"
+nonstandard-style = "deny"
+rust-2018-idioms = "deny"
+unused = "deny"
+warnings = "deny"
+
+[lints.clippy]
+as_conversions = "deny"
 
 [features]
 concurrency = []

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -13,8 +13,20 @@ description = "A Bridge between the Rust blockifier crate and Python."
 extension-module = ["pyo3/extension-module"]
 testing = []
 
-[lints]
-workspace = true
+# Move to workspace and inherit from [workspace.lints] once we start using rust_rules >= 0.41.0.
+# (bug: https://github.com/bazelbuild/rules_rust/issues/2536, fixed in: https://github.com/bazelbuild/rules_rust/pull/2551 which was included in 0.41.0).
+[lints.rust]
+future-incompatible = "deny"
+nonstandard-style = "deny"
+rust-2018-idioms = "deny"
+unused = "deny"
+warnings = "deny"
+
+# Move to workspace and inherit from [workspace.lints] once we start using rust_rules >= 0.41.0.
+# (bug: https://github.com/bazelbuild/rules_rust/issues/2536, fixed in: https://github.com/bazelbuild/rules_rust/pull/2551 which was included in 0.41.0).
+[lints.clippy]
+as_conversions = "deny"
+
 
 [lib]
 name = "native_blockifier"


### PR DESCRIPTION
In main repo we needed to bump rust_rules to a higher version in order to support stable rust 1.74, which `clap = 4.5.7` started requiring implicitely:
https://github.com/clap-rs/clap/commit/4b45d361b1b96eb1f37b7d1db2684203ca828a94.

This rust_rules version has a bug with workspace.lints support, which is fixed in later versions.

Note: I didn't put the docstring in blockifier/Cargo.toml because we don't want to mention bazel there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/1995)
<!-- Reviewable:end -->
