### PR TITLE
chore: make FeatureContract::cairo_version public

### DIFF
--- a/crates/blockifier/src/test_utils/contracts.rs
+++ b/crates/blockifier/src/test_utils/contracts.rs
@@ -67,7 +67,7 @@ pub enum FeatureContract {
 }
 
 impl FeatureContract {
-    fn cairo_version(&self) -> CairoVersion {
+    pub fn cairo_version(&self) -> CairoVersion {
         match self {
             Self::AccountWithLongValidate(version)
             | Self::AccountWithoutValidations(version)
@@ -77,55 +77,6 @@ impl FeatureContract {
             Self::SecurityTests | Self::ERC20 => CairoVersion::Cairo0,
             Self::LegacyTestContract => CairoVersion::Cairo1,
         }
-    }
-
-    fn get_cairo_version_bit(&self) -> u32 {
-        match self.cairo_version() {
-            CairoVersion::Cairo0 => 0,
-            CairoVersion::Cairo1 => CAIRO1_BIT,
-        }
-    }
-
-    /// Unique integer representing each unique contract. Used to derive "class hash" and "address".
-    fn get_integer_base(self) -> u32 {
-        self.get_cairo_version_bit()
-            + match self {
-                Self::AccountWithLongValidate(_) => ACCOUNT_LONG_VALIDATE_BASE,
-                Self::AccountWithoutValidations(_) => ACCOUNT_WITHOUT_VALIDATIONS_BASE,
-                Self::Empty(_) => EMPTY_CONTRACT_BASE,
-                Self::ERC20 => ERC20_CONTRACT_BASE,
-                Self::FaultyAccount(_) => FAULTY_ACCOUNT_BASE,
-                Self::LegacyTestContract => LEGACY_CONTRACT_BASE,
-                Self::SecurityTests => SECURITY_TEST_CONTRACT_BASE,
-                Self::TestContract(_) => TEST_CONTRACT_BASE,
-            }
-    }
-
-    fn get_compiled_path(&self) -> String {
-        let cairo_version = self.cairo_version();
-        let contract_name = match self {
-            Self::AccountWithLongValidate(_) => ACCOUNT_LONG_VALIDATE_NAME,
-            Self::AccountWithoutValidations(_) => ACCOUNT_WITHOUT_VALIDATIONS_NAME,
-            Self::Empty(_) => EMPTY_CONTRACT_NAME,
-            Self::FaultyAccount(_) => FAULTY_ACCOUNT_NAME,
-            Self::LegacyTestContract => LEGACY_CONTRACT_NAME,
-            Self::SecurityTests => SECURITY_TEST_CONTRACT_NAME,
-            Self::TestContract(_) => TEST_CONTRACT_NAME,
-            // ERC20 is a special case - not in the feature_contracts directory.
-            Self::ERC20 => return ERC20_CONTRACT_PATH.into(),
-        };
-        format!(
-            "./feature_contracts/cairo{}/compiled/{}{}.json",
-            match cairo_version {
-                CairoVersion::Cairo0 => "0",
-                CairoVersion::Cairo1 => "1",
-            },
-            contract_name,
-            match cairo_version {
-                CairoVersion::Cairo0 => "_compiled",
-                CairoVersion::Cairo1 => ".casm",
-            }
-        )
     }
 
     pub fn set_cairo_version(&mut self, version: CairoVersion) {
@@ -175,5 +126,54 @@ impl FeatureContract {
 
     pub fn get_raw_class(&self) -> String {
         get_raw_contract_class(&self.get_compiled_path())
+    }
+
+    fn get_cairo_version_bit(&self) -> u32 {
+        match self.cairo_version() {
+            CairoVersion::Cairo0 => 0,
+            CairoVersion::Cairo1 => CAIRO1_BIT,
+        }
+    }
+
+    /// Unique integer representing each unique contract. Used to derive "class hash" and "address".
+    fn get_integer_base(self) -> u32 {
+        self.get_cairo_version_bit()
+            + match self {
+                Self::AccountWithLongValidate(_) => ACCOUNT_LONG_VALIDATE_BASE,
+                Self::AccountWithoutValidations(_) => ACCOUNT_WITHOUT_VALIDATIONS_BASE,
+                Self::Empty(_) => EMPTY_CONTRACT_BASE,
+                Self::ERC20 => ERC20_CONTRACT_BASE,
+                Self::FaultyAccount(_) => FAULTY_ACCOUNT_BASE,
+                Self::LegacyTestContract => LEGACY_CONTRACT_BASE,
+                Self::SecurityTests => SECURITY_TEST_CONTRACT_BASE,
+                Self::TestContract(_) => TEST_CONTRACT_BASE,
+            }
+    }
+
+    fn get_compiled_path(&self) -> String {
+        let cairo_version = self.cairo_version();
+        let contract_name = match self {
+            Self::AccountWithLongValidate(_) => ACCOUNT_LONG_VALIDATE_NAME,
+            Self::AccountWithoutValidations(_) => ACCOUNT_WITHOUT_VALIDATIONS_NAME,
+            Self::Empty(_) => EMPTY_CONTRACT_NAME,
+            Self::FaultyAccount(_) => FAULTY_ACCOUNT_NAME,
+            Self::LegacyTestContract => LEGACY_CONTRACT_NAME,
+            Self::SecurityTests => SECURITY_TEST_CONTRACT_NAME,
+            Self::TestContract(_) => TEST_CONTRACT_NAME,
+            // ERC20 is a special case - not in the feature_contracts directory.
+            Self::ERC20 => return ERC20_CONTRACT_PATH.into(),
+        };
+        format!(
+            "./feature_contracts/cairo{}/compiled/{}{}.json",
+            match cairo_version {
+                CairoVersion::Cairo0 => "0",
+                CairoVersion::Cairo1 => "1",
+            },
+            contract_name,
+            match cairo_version {
+                CairoVersion::Cairo0 => "_compiled",
+                CairoVersion::Cairo1 => ".casm",
+            }
+        )
     }
 }


### PR DESCRIPTION
This is useful for tests with parameterized version.

Also moved private functions to appear after public ones, *no logic changes there*.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/blockifier/2002)
<!-- Reviewable:end -->
